### PR TITLE
cleanup floating point exception management

### DIFF
--- a/src/jointcal.cc
+++ b/src/jointcal.cc
@@ -7,10 +7,6 @@
 
 #include <stdlib.h> /* for getenv */
 
-#define _GNU_SOURCE 1
-#define __USE_GNU
-#include <fenv.h> 
-
 //#include "boost/scoped_array.hpp"
 //#include "boost/shared_array.hpp"
 //#include "boost/multi_index_container.hpp"
@@ -47,16 +43,6 @@ namespace jointcal {
         }
         std::cout << sourceFluxField << std::endl;
     }
-    
-    static void __attribute__ ((constructor))
-trapfpe ()
-{
-  /* Enable some exceptions.  At startup all exceptions are masked. */
-
-  if (getenv("DUMP_CORE_ON_FPE"))
-    feenableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW|FE_UNDERFLOW);
-//    feenableexcept (FE_ALL_EXCEPT);
-} 
     
     Jointcal::Jointcal(
         std::vector<lsst::afw::table::SortedCatalogT< lsst::afw::table::SourceRecord> > const sourceList,

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -30,7 +30,6 @@ static void __attribute__ ((constructor)) trapfpe ()
 }
 #endif
 
-
 namespace jointcal = lsst::jointcal;
 namespace afwImg = lsst::afw::image;
 

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -16,20 +16,20 @@
 
 #include <stdlib.h> /* for getenv */
 
+// NOTE: turn this flag on to raise exceptions on floating point errors.
+// NOTE: this only works on GNU/Linux (fenableexcept is not C++ standard).
+// #define DUMP_CORE_ON_FPE
+#ifdef DUMP_CORE_ON_FPE
 #define _GNU_SOURCE 1
 #define __USE_GNU
 #include <fenv.h>
-
-
-static void __attribute__ ((constructor))
-trapfpe ()
+static void __attribute__ ((constructor)) trapfpe ()
 {
-  /* Enable some exceptions.  At startup all exceptions are masked.  */
-  
-  if (getenv("DUMP_CORE_ON_FPE"))
-    feenableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
+   // Enable some exceptions.  At startup all exceptions are masked.
+  feenableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
 }
- 
+#endif
+
 
 namespace jointcal = lsst::jointcal; 
 namespace afwImg = lsst::afw::image;


### PR DESCRIPTION
Cleanup floating point exception management, but keep it as GNU only. May be useful for future debugging, but the "portable" version of fenv.h that I proposed in RFC-158 was not as portable as I'd hoped.