### PR TITLE
jointcal running on test data (DM-5297)

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -35,6 +35,9 @@ class Associations {
   FittedStarList fittedStarList; //  the std::list of stars that are going to be fitted
 
 
+  // TODO: NOTE: these only exist because those lists can't be swig'd because
+  // swig doesn't like boost::intrusive_ptr (which the lists contain).
+  // Once DM-4043 is solved, delete these.
   size_t refStarListSize()
   { return refStarList.size(); }
   size_t photRefStarListSize()

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -34,6 +34,14 @@ class Associations {
   RefStarList photRefStarList; // the (e.g) Landolt stars
   FittedStarList fittedStarList; //  the std::list of stars that are going to be fitted
 
+
+  size_t refStarListSize()
+  { return refStarList.size(); }
+  size_t photRefStarListSize()
+  { return photRefStarList.size(); }
+  size_t fittedStarListSize()
+  { return fittedStarList.size(); }
+
     // fit cuts and stuff:
   Point commonTangentPoint;
 

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -76,13 +76,13 @@ public:
 
   //! Collect stars form an external reference catalog (USNO-A by default) that match the FittedStarList. Optionally project these RefStar s on the tangent plane defined by the CommonTangentPoint().
   void CollectRefStars(const bool ProjectOnTP=true);
-  
+
   //! Collect stars from an external reference catalog using the LSST stack mechanism
   void CollectLSSTRefStars(lsst::afw::table::SortedCatalogT< lsst::afw::table::SimpleRecord > &Ref, std::string filter);
 
 
 
-    
+
 #ifdef STORAGE
   //! This is Monte-Carlo stuff -- to remove this from associations
   //! the Association class should provide us w/ iterators and acceptors
@@ -111,21 +111,21 @@ public:
 			   const double &MatchCutArcSec);
 #endif
   //    void SetRefPhotFactor(int chip, double photfact);
-  
+
   //! apply cuts (mainly number of measurements) on potential FittedStars
   void SelectFittedStars();
-  
+
   const CcdImageList& TheCcdImageList() const {return ccdImageList;}
-  
+
   unsigned int NShoots() const { return nshoots_; }
 
   //! Number of different bands in the input image list. Not implemented so far
   unsigned NBands() const {return 1;}
-  
+
   // Return the bounding box in (ra, dec) coordinates containing the whole catalog
   const lsst::afw::geom::Box2D GetRaDecBBox();
 
-  
+
 private:
   void AssociateRefStars(const double &MatchCutInArcSec, const Gtransfo *T);
   unsigned int nshoots_;

--- a/include/lsst/jointcal/AstromFit.h
+++ b/include/lsst/jointcal/AstromFit.h
@@ -77,12 +77,12 @@ class AstromFit {
   unsigned int _nParTot;
   unsigned _nMeasuredStars;
   double _posError;  // constant term on error on position (in pixel unit)
-  
+
  public :
 
   //! this is the only constructor
   AstromFit (Associations &A, DistortionModel *D, double PosError);
-  
+
   //! Does a 1 step minimization, assuming a linear model.
   /*! It calls AssignIndices, LSDerivatives, solves the linear system
     and calls OffsetParams. No line search. Relies on sparse linear
@@ -176,7 +176,7 @@ class AstromFit {
   template <class Accum>
     void AccumulateStatRefStars(Accum &Accu) const;
 
-  
+
   //! only for outlier removal
   void GetMeasuredStarIndices(const MeasuredStar &Ms,
 			      std::vector<unsigned> &Indices) const;

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -33,7 +33,7 @@ class CcdImage : public RefCount
   Frame imageFrame; // in pixels
   // wholeCatalog is just store the catalog of selected sources
   //  lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> wholeCatalog;
-  
+
   MeasuredStarList wholeCatalog; // the catalog of measured objets
   MeasuredStarList catalogForFit;
 
@@ -48,16 +48,16 @@ class CcdImage : public RefCount
   CountedRef<Gtransfo> TP2CTP; // reverse one
   CountedRef<Gtransfo> pix2CommonTangentPlane;// pixels -> CTP
   CountedRef<Gtransfo> pix2TP;
-  
+
   CountedRef<Gtransfo> sky2TP;
-  
+
   std::string riName;
   std::string riDir;
   std::string instrument;
   int chip; // CCD number
   ShootIdType shoot; // Same value for all CcdImages from the same exposure
   unsigned bandRank; // some incremental band indicator.
-  
+
 
   double expTime; // seconds
   double airMass; // airmass value.
@@ -75,7 +75,7 @@ class CcdImage : public RefCount
   std::string dateObs;
   // refraction
   double sineta,coseta,tgz,hourAngle;  // eta : parallactic angle, z: zenithal angle (X = 1/cos(z))
-  
+
   std::string band;
   std::string flatName;
   //  std::string flat; // full flat name
@@ -86,7 +86,7 @@ class CcdImage : public RefCount
   int    bandIndex;
   int    index;
   int    expindex;
-  
+
   Point  commonTangentPoint;
 
   void LoadCatalog(const lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> &Cat, const std::string &fluxField);
@@ -99,7 +99,7 @@ class CcdImage : public RefCount
     const int &visit, const int &ccd, const std::string &ccdImage, const std::string &fluxField );
 
 
-    
+
 #ifdef TO_BE_FIXED
   //!
   CcdImage(const ReducedImage &Ri, const Point &CommonTangentPoint, const CatalogLoader * LoadIt);
@@ -107,7 +107,7 @@ class CcdImage : public RefCount
 
   //!
   std::string Name() const { return riName;}
-  
+
   //!
   std::string Dir() const { return riDir; }
 
@@ -127,11 +127,11 @@ class CcdImage : public RefCount
   //!
   const Gtransfo* CommonTangentPlane2TP() const
   { return CTP2TP.get();}
-  
+
   //!
   const Gtransfo* TP2CommonTangentPlane() const
   { return TP2CTP.get();}
-  
+
   //!
   const Gtransfo* Pix2TangentPlane() const
   { return pix2TP.get();}
@@ -139,7 +139,7 @@ class CcdImage : public RefCount
   //!
   const Gtransfo* Sky2TP() const
   { return sky2TP.get();}
-  
+
   //! returns chip ID
   int Chip() const { return chip;}
 
@@ -151,29 +151,29 @@ class CcdImage : public RefCount
 
   //! returns seeing
   //  double Seeing() const { return seeing;}
-  
+
   //! returns gfseeing
   //  double GFSeeing() const { return gfseeing;}
-  
+
   //! returns sigma back
   //  double SigmaBack() const { return sigmaback;}
-  
+
   //! returns shoot ID
   ShootIdType Shoot() const { return shoot;}
-  
+
   //! Exposure time (s)
   double ExpTime() const { return expTime;}
-  
+
   //!  Airmass
   double AirMass() const {return airMass;}
-  
+
   //! Date Obs
   std::string DateObs() const { return dateObs; }
 
   //! Julian Date
   double JD() const { return jd; }
 
-  
+
   //!Elixir ZP (applies to fluxes in ADU/sec at airmass 1).
   double ElixirZP() const { return elixirZP;}
 
@@ -182,10 +182,10 @@ class CcdImage : public RefCount
 
   //!zp from the psf zp file, returns 0 if not present
   double PSFZP() const { return psfzp;}
-  
+
   //! absorption term
   double PhotK() const { return photk; }
-  
+
   //! original ZP
   double PhotC() const { return photc; }
 
@@ -206,58 +206,58 @@ class CcdImage : public RefCount
 
   //!conversion from ADU to ADU/sec at airmass=1
   double FluxCoeff() const { return fluxCoeff;}
-  
+
   //! return the CcdImage band name
   std::string Band() const { return band;}
-  
+
   //! return the CcdImage band index. This is a static index that mostly turns a letter (e.g. 'g') into a number (e.g. 2). Different from BandRank()
   int BandIndex() const { return bandIndex; }
-  
+
   //! Flat used to flatfield
   std::string FlatName() const { return flatName;}
 
   //! Full path of the scatter corrections
   std::string CFHTScatter() const { return cfhtscatter; }
-  
+
   //! SNLS grid
   std::string SNLSGrid() const { return snlsgrid; }
-  
+
   //! correction map to convert from one set of fluxes to another
   std::string FlatCVMap() const { return flatcvmap; }
-  
+
   //void SetPix2TangentPlane(const Gtransfo *);
-  
+
   //! the wcs read in the header. NOT updated when fitting.
   const Gtransfo *ReadWCS() const {return readWcs.get();}
-  
+
   //! the inverse of the one above.
   const Gtransfo *InverseReadWCS() const {return inverseReadWcs.get();}
-  
+
   //! Frame in pixels
   const Frame& ImageFrame() const { return imageFrame;}
-  
+
   //! Frame on sky
   //Frame RaDecFrame() const;
-  
+
   //! Fitted Ccd object (contain the refscale parameters)
   //  void             SetFittedCcd(FittedCcd* ccd) { if(ccd) fittedccd=ccd; }
   //  FittedCcd*       GetFittedCcd() { return fittedccd; }
   //  FittedCcd const* GetFittedCcd() const { return fittedccd; }
-  
+
   //! returns wether "this" overlaps with Other.
   //  bool Overlaps(const CcdImage &Other) const;
-  
+
   //! CcdImage index
   int     Index() const { return index; }
   void    SetIndex(int idx) { index = idx; }
-  
+
   //! Exposure Index
   int     ExpIndex() const { return expindex; }
   void    SetExpIndex(int idx) { expindex = idx; }
-  
+
   //! Common Tangent Point
   Point const&       CommonTangentPoint() const { return commonTangentPoint; }
-  
+
  private:
   CcdImage(const CcdImage &); // forbid copies
 
@@ -273,16 +273,16 @@ class CcdImage : public RefCount
 class CcdImageList : public std::list<boost::shared_ptr<CcdImage> >
 {
   public:
-  
+
   //!
   //std::list<std::string> DateObs() const;
-  
+
   //!
   //std::list<std::string> Bands() const;
-  
+
   //!
   //double       MeanAirmass() const;
-  
+
   //!
   template<class Accept> CcdImageList SubList(const Accept &OP) const
     {
@@ -291,7 +291,7 @@ class CcdImageList : public std::list<boost::shared_ptr<CcdImage> >
 	if (OP(**i)) out.push_back(*i);
       return out;
     }
-  
+
   // find the matching image. Chip==-1 means any chip
 //  double AirMass(const int Shoot, const int Chip = -1) const;
 };

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -270,7 +270,7 @@ class CcdImage : public RefCount
 
 //! a  list of CcdImage. Usually produced by Associations
 //class CcdImageList : public std::list<CountedRef<CcdImage> >
-class CcdImageList : public std::list<boost::shared_ptr<CcdImage> >
+class CcdImageList : public std::list<std::shared_ptr<CcdImage> >
 {
   public:
 

--- a/include/lsst/jointcal/ConstrainedPolyModel.h
+++ b/include/lsst/jointcal/ConstrainedPolyModel.h
@@ -70,7 +70,7 @@ public :
 
   //! Access to array of shoots involved in the solution.
   std::vector<ShootIdType> GetShoots() const;
-   
+
   /*! the mapping of sky coordinates (i.e. the coordinate system
   in which fitted stars are reported) onto the Tangent plane
   (into which the pixel coordinates are transformed) */
@@ -86,7 +86,7 @@ public :
   poloka-core */
   //  bool WriteChipArrangement(const std::string &FileName) const;
 
- 
+
 };
 
 }} // end of namespaces

--- a/include/lsst/jointcal/FastFinder.h
+++ b/include/lsst/jointcal/FastFinder.h
@@ -11,7 +11,7 @@ namespace jointcal {
 /*! \file
     \brief Fast locator in starlists.
 */
- 
+
 /*!  This is an auxillary class for matching objects from
   starlists. It allows to locate rapidly the closest objects from a
   given position. The very simple strategy is to sort objects

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -32,7 +32,7 @@ struct PmBlock
 
   PmBlock() : pmx(0), pmy(0), epmx(0), epmy(0), epmxy(0), color(0), mightMove(false) {};
 
-  
+
 
 };
 
@@ -53,7 +53,7 @@ class FittedStar : public BaseStar, public PmBlock {
   unsigned indexInMatrix;
   int measurementCount;
   const RefStar *refStar;
-  
+
   double flux2;
   double fluxErr;
   double fluxErr2;
@@ -65,19 +65,19 @@ class FittedStar : public BaseStar, public PmBlock {
     flux2(-1),
     fluxErr(-1),
     fluxErr2(-1) {}
-  
+
   FittedStar(const BaseStar &B) :
     BaseStar(B), mag(-1), emag(-1), col(0.), gen(-1), wmag(0),
     indexInMatrix(0), measurementCount(0), refStar(NULL),
     flux2(-1),
     fluxErr(-1),
     fluxErr2(-1) {}
-    
+
   //  FittedStar(const FittedStar& F)
   //    : BaseStar(F), mag(F.mag), emag(F.emag), col(F.col), gen(F.gen), wmag(F.wmag),
   //      index(F.index), measurementCount(F.measurementCount), refStar(F.refStar),
   //      flux2(F.flux2), fluxErr(F.fluxErr), fluxErr2(F.fluxErr2) {}
-    
+
   //!
   FittedStar(const MeasuredStar &M);
 
@@ -90,7 +90,7 @@ class FittedStar : public BaseStar, public PmBlock {
     refStar = NULL;
     wmag = 0;
   }
-  
+
 
   //!
   void dump(std::ostream & stream = std::cout) const
@@ -133,18 +133,18 @@ class FittedStar : public BaseStar, public PmBlock {
 
   //!
   const RefStar *GetRefStar() const { return refStar;};
-  
+
   //! getters
   double         Flux() const { return flux; }
   double&        Flux() { return flux; }
   double         FluxErr() const { return fluxErr; }
   double&        FluxErr() { return fluxErr; }
-  
+
   double         Flux2() const { return flux2; }
   double&        Flux2() { return flux2; }
   double         FluxErr2() const { return fluxErr2; }
   double&        FluxErr2() { return fluxErr2; }
-  
+
   //! write stuff
   std::string       WriteHeader_(std::ostream& pr=std::cout, const char* i=NULL) const;
   virtual void      writen(std::ostream& s) const;
@@ -160,7 +160,7 @@ static BaseStar*  read(std::istream& s, const char* format);
 //! A list of FittedStar s. Such a list is typically constructed by Associations
 class FittedStarList : public  StarList<FittedStar>
 {
- 
+
   public :
 
   bool  inTangentPlaneCoordinates;
@@ -183,7 +183,7 @@ class FittedStarList : public  StarList<FittedStar>
 
 
 };
- 
+
 typedef FittedStarList::const_iterator FittedStarCIterator;
 typedef FittedStarList::iterator FittedStarIterator;
 typedef CountedRef<FittedStar> FittedStarRef;

--- a/include/lsst/jointcal/Frame.h
+++ b/include/lsst/jointcal/Frame.h
@@ -22,15 +22,15 @@ class Frame {
 public:
   //! coordinate of boundary.
   double xMin,xMax,yMin,yMax;
-  
+
   //! Default constructor
   Frame();
-    
+
   //! this one is dangerous: you may swap the 2 middle arguments.
   //! Prefer next one
   Frame(const double &xMin, const double &yMin,
 	const double &xMax, const double &yMax);
-  
+
   //! typical use: Frame(Point(xmin,ymin),Point(xmax,ymax))
   Frame(const Point &LowerLeft, const Point &UpperRight);
 
@@ -45,56 +45,56 @@ public:
 
   //! size along y axis
   double Height() const {return yMax-yMin;}
-  
+
   //! Center  of the frame
   Point Center() const {return Point((xMax+xMin)*0.5,(yMax+yMin)*0.5);}
-  
+
   //! intersection of Frame's.
   Frame operator*(const Frame &Right) const;  /* intersection : a = b n c */
-  
+
   //! intersection of Frame's
   Frame& operator*=( const Frame &Right);     /* intersection : a = a n b */
-  
+
   //! union of Frames
   Frame operator+(const Frame &Right) const;  /* union : a = b u c */
 
   //! union of Frames
   Frame& operator+=( const Frame &Right);     /* intersection : a = a u b */
-  
+
   //! shrinks the frame (if MarginSize>0), enlarges it (if MarginSize<0).
   void CutMargin(const double MarginSize);
-  
+
   //! shrinks the frame (if MarginSize>0), enlarges it (if MarginSize<0).
   void CutMargin(const double MarginX, const double MarginY);
-  
+
   //! necessary for comparisons (!= is defined from this one implicitely)
   bool operator ==(const Frame &Right) const;
-  
+
   //! comparison
   bool operator !=(const Frame &Right) const {return !(*this == Right);}
 
   //! rescale it. The center does not move.
   Frame Rescale(const double Factor) const;
-  
+
   // the area.
   double Area() const;
-  
+
   //! inside?
   bool InFrame(const double &x, const double &y) const;
-  
+
   //! same as above
   bool InFrame(const Point &pt) const
   {return InFrame(pt.x,pt.y);}
-  
+
   //! distance to closest boundary.
   double MinDistToEdges(const Point &P) const;
-  
+
   void dump(std::ostream & stream = std::cout) const;
-  
+
   //! allows \verbatim std::cout << frame; \endverbatim.
   friend std::ostream & operator<<(std::ostream &stream, const Frame &Right)
           { Right.dump(stream); return stream;};
-  
+
 private:
   void order();
 };

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -43,11 +43,11 @@ class GtransfoLin;
 
 class Gtransfo: public RefCount{
 public:
-  
+
   //!
   virtual void  apply(const double Xin, const double Yin,
 		      double &Xout, double &Yout) const = 0 ;
-  
+
   //! applies the tranfo to Pin and writes into Pout. Is indeed virtual.
   void apply(const Point &Pin, Point &Pout) const
       {apply(Pin.x, Pin.y, Pout.x, Pout.y);}
@@ -132,7 +132,7 @@ public:
   void Write(const std::string &FileName) const;
 
   virtual void Write(std::ostream &stream) const;
-  
+
   virtual ~Gtransfo() {};
 
 
@@ -207,7 +207,7 @@ class GtransfoPoly : public Gtransfo
 {
 public :
   using Gtransfo::apply; // to unhide Gtransfo::apply(const Point &)
-	
+
 private:
   unsigned deg; // the degree
   unsigned nterms; // number of parameters per coordinate
@@ -329,7 +329,7 @@ GtransfoLin NormalizeCoordinatesTransfo(const Frame & F);
 /*=============================================================*/
 //! implements the linear transformations (6 real coefficients).
 class GtransfoLin : public GtransfoPoly {
-  
+
  public:
   using GtransfoPoly::apply; // to unhide Gtransfo::apply(const Point &)
 
@@ -342,35 +342,35 @@ class GtransfoLin : public GtransfoPoly {
 
   //!  enables to combine linear tranformations: T1=T2*T3 is legal.
   GtransfoLin  operator*(const  GtransfoLin &T2) const;
-  
+
   //! returns the inverse: T1 = T2.invert();
   GtransfoLin  invert() const;
-  
-  
+
+
   // useful?    double Jacobian(const double x, const double y) const { return Determinant();}
-  
+
   //!
   void Derivative(const Point &Where, GtransfoLin &Derivative,
 		  const double Step = 0.01) const;
   //!
   GtransfoLin LinearApproximation(const Point &Where,
 				  const double step = 0.01) const;
-  
-  
+
+
   //  void dump(std::ostream &stream = std::cout) const;
-  
+
   // double fit(const StarMatchList &List);
-    
+
   //! the constructor that enables to set all parameters independently. Not very useful.
   GtransfoLin(const double ox, const double oy , const double aa11,
 	      const double aa12, const double aa21, const double aa22);
-  
+
   //! Handy converter:
   GtransfoLin(const GtransfoIdentity &T) : GtransfoPoly(1)
   { if (&T) {} /* avoid a warning */};
-  
+
   Gtransfo* Clone() const { return new GtransfoLin(*this);}
-  
+
   Gtransfo* InverseTransfo(const double Precision,
 			   const Frame& Region) const;
 
@@ -384,7 +384,7 @@ class GtransfoLin : public GtransfoPoly {
 
 protected :
 
-  
+
   double& a11() { return Coeff(1,0,0);}
   double& a12() { return Coeff(0,1,0);}
   double& a21() { return Coeff(1,0,1);}
@@ -399,7 +399,7 @@ protected :
 
 private:
   void SetDegree(const unsigned Deg); // to hide GtransfoPoly::SetDegree
-  
+
 };
 
 
@@ -421,10 +421,10 @@ public:
 /*=============================================================*/
 //! just here to provide a specialized constructor, and fit.
 class GtransfoLinRot : public GtransfoLin {
-  
+
 public:
   using Gtransfo::apply; // to unhide apply(const Point&)
- 
+
     GtransfoLinRot() : GtransfoLin() {};
     GtransfoLinRot(const double AngleRad, const Point *Center=NULL,
 		   const double ScaleFactor=1.0);
@@ -438,7 +438,7 @@ public:
 
 //! just here to provide specialized constructors. GtransfoLin fit routine.
 class GtransfoLinScale :  public GtransfoLin {
-  
+
  public:
   using Gtransfo::apply; // to unhide apply(const Point&)
     //!
@@ -482,7 +482,7 @@ public :
 
   //! the "correction"
   const GtransfoPoly* Corr() const {return corr;}
-  
+
   //!Assign the correction polynomial (what it means is left to derived classes)
   void SetCorrections(const GtransfoPoly *Corrections);
 
@@ -504,7 +504,7 @@ class TanRaDec2Pix; // the inverse of TanPix2RaDec.
 
 //! the transformation that handles pix to sideral transfos (Gnomonic, possibly with polynomial distortions).
 class TanPix2RaDec : public BaseTanWcs {
-  
+
 public:
 
   using Gtransfo::apply; // to unhide apply(const Point&)
@@ -538,9 +538,9 @@ public:
   Gtransfo* InverseTransfo(const double Precision,
 			   const Frame& Region) const;
 
-    
+
   Gtransfo *Clone() const;
-  
+
   void dump(std::ostream &stream) const;
 
   //! Not implemented yet, because we do it otherwise.
@@ -573,9 +573,9 @@ public:
   Gtransfo* InverseTransfo(const double Precision,
 			   const Frame& Region) const;
 
-    
+
   Gtransfo *Clone() const;
-  
+
   void dump(std::ostream &stream) const;
 
   //! Not implemented yet, because we do it otherwise.
@@ -604,7 +604,7 @@ class TanRaDec2Pix : public Gtransfo
 
     //! assume degrees everywhere.
     TanRaDec2Pix(const GtransfoLin &Tan2Pix, const Point &TangentPoint);
-    
+
     //!
     TanRaDec2Pix();
 
@@ -655,7 +655,7 @@ typedef void (GtransfoFun)(const double, const double,
 class UserTransfo : public Gtransfo
 {
   private :
-  
+
   GtransfoFun *userFun;
   const void *userData;
 

--- a/include/lsst/jointcal/Histo2d.h
+++ b/include/lsst/jointcal/Histo2d.h
@@ -7,7 +7,7 @@ namespace jointcal {
 
 
 class Histo2d {
- 
+
  private:
   float *data;
   int nx,ny;

--- a/include/lsst/jointcal/Histo4d.h
+++ b/include/lsst/jointcal/Histo4d.h
@@ -15,7 +15,7 @@ class SparseHisto4d {
   double minVal[4],maxVal[4];
   double scale[4];
   bool sorted;
-  
+
  public:
   SparseHisto4d() {}
   // obvious meanings. NEntries is used as the size of the primary allocation.

--- a/include/lsst/jointcal/Jointcal.h
+++ b/include/lsst/jointcal/Jointcal.h
@@ -16,7 +16,7 @@
 
 namespace lsst {
 namespace jointcal {
-    
+
     struct JointcalControl {
         LSST_CONTROL_FIELD(sourceFluxField, std::string, "name of flux field in source catalog");
 
@@ -25,15 +25,15 @@ namespace jointcal {
         {
             validate();
         }
-        
+
         void validate() const;
 
         ~JointcalControl() {};
     };
-    
+
 class Jointcal {
 public:
-    
+
     Jointcal (
         std::vector<lsst::afw::table::SortedCatalogT< lsst::afw::table::SourceRecord> > const sourceList,
         std::vector<PTR(lsst::daf::base::PropertySet)> const metaList,
@@ -46,9 +46,9 @@ public:
         std::vector<std::string> const cameraList,
         PTR(lsst::jointcal::JointcalControl) const control
     );
-    
+
 private:
-    
+
     std::vector<lsst::afw::table::SortedCatalogT< lsst::afw::table::SourceRecord> > _sourceList;
     std::vector <boost::shared_ptr<lsst::daf::base::PropertySet> > _metaList;
     std::vector<PTR(lsst::afw::image::TanWcs)> _wcsList;
@@ -59,7 +59,7 @@ private:
     std::vector<int> const _ccdList;
     std::vector<std::string> const _cameraList;
 };
-    
+
 }} // end of namespaces
 
 #endif

--- a/include/lsst/jointcal/Jointcal.h
+++ b/include/lsst/jointcal/Jointcal.h
@@ -50,7 +50,7 @@ public:
 private:
 
     std::vector<lsst::afw::table::SortedCatalogT< lsst::afw::table::SourceRecord> > _sourceList;
-    std::vector <boost::shared_ptr<lsst::daf::base::PropertySet> > _metaList;
+    std::vector <std::shared_ptr<lsst::daf::base::PropertySet> > _metaList;
     std::vector<PTR(lsst::afw::image::TanWcs)> _wcsList;
     std::vector<lsst::afw::geom::Box2I> _bboxList;
     std::vector<std::string> _filterList;

--- a/include/lsst/jointcal/Mapping.h
+++ b/include/lsst/jointcal/Mapping.h
@@ -19,7 +19,7 @@ class Mapping
 {
 
     public :
-	
+
     //! Mumber of parameters in total
     virtual unsigned Npar() const = 0;
 
@@ -48,7 +48,7 @@ class Mapping
 
     //!
     virtual ~Mapping() {};
-    
+
 };
 
 // typedef std::list<CountedRef<Mapping> > MappingList;

--- a/include/lsst/jointcal/MeasuredStar.h
+++ b/include/lsst/jointcal/MeasuredStar.h
@@ -26,33 +26,33 @@ class MeasuredStar : public BaseStar
   double eflux;
   double aperrad;
   double chi2;
-  
-  
+
+
   const CcdImage *ccdImage;
   std::vector<double> usrVals;
-  
+
   private :
 
     CountedRef<const FittedStar> fittedStar;
     bool   valid;
 
 
-  
+
   public :
-    
+
     //!
   MeasuredStar()
     : BaseStar(),
       mag(0.), wmag(0.), eflux(0.), aperrad(0.),
       ccdImage(0),
       valid(true) {}
-  
+
   MeasuredStar(const BaseStar &B, const FittedStar *F = NULL) :
     BaseStar(B),
     mag(0.), wmag(0.), eflux(0.), aperrad(0.),
     ccdImage(0),
     valid(true)
-    
+
   {
     //    InitialStarRef = &B;
   }
@@ -67,7 +67,7 @@ class MeasuredStar : public BaseStar
 
   double Mag() const { return mag;}
   double AperRad() const { return aperrad; }
-  
+
   //! the inverse of the mag variance
   double MagWeight() const { return (flux*flux/(eflux*eflux));}
 
@@ -76,12 +76,12 @@ class MeasuredStar : public BaseStar
   const CcdImage &GetCcdImage()  const { return *ccdImage;};
 
   void SetCcdImage(const CcdImage *C) { ccdImage = C;};
-  
+
   //! Fits may use that to discard outliers
   bool  IsValid() const { return valid; }
   //! Fits may use that to discard outliers
   void  SetValid(bool v) { valid=v; }
-  
+
   // No longer decrement counter of associated fitted star in destructor (P. El-Hage le 10/04/2012)
   // ~MeasuredStar() { if (fittedStar) fittedStar->MeasurementCount()--;}
 
@@ -106,7 +106,7 @@ class MeasuredStarList : public StarList<MeasuredStar> {
 
   public :
     MeasuredStarList() {};
-  
+
 
   void SetZeroPoint(const double &ZP);
 
@@ -150,7 +150,7 @@ public:
 
   static CatalogLoader * DefaultCatalogLoader;
   static CatalogLoader * getDefaultCatalogLoader();
-   
+
 protected:
   CatalogLoader(){}
 };
@@ -176,4 +176,4 @@ void SelectFluxForFitCatalog(std::string const& filename);
 }}  // end of namespaces
 
 #endif /* MEASUREDSTAR__H */
-    
+

--- a/include/lsst/jointcal/PhotomFit.h
+++ b/include/lsst/jointcal/PhotomFit.h
@@ -18,7 +18,7 @@ namespace jointcal {
 class Associations;
 
 /*! Some comments.
-  
+
 
 */
 
@@ -37,12 +37,12 @@ class PhotomFit {
   int _LastNTrip; // last triplet count, used to speed up allocation
 
 
-  
+
  public :
 
   //! this is the only constructor
   PhotomFit (Associations &A, PhotomModel *M, double PosError);
-  
+
   //! Does a 1 step minimization, assuming a linear model.
   /*! It calls AssignIndices, LSDerivatives, solves the linear system
     and calls OffsetParams. No line search. Relies on sparse linear

--- a/include/lsst/jointcal/RefStar.h
+++ b/include/lsst/jointcal/RefStar.h
@@ -37,17 +37,17 @@ private :
 
   //!
   double Dec() const {return raDec.y;}
-  
+
   //! reference flux
   double Flux(int band) const;
-  
+
   //! assign the reference fluxes
   void   AssignRefFluxes(std::vector<double> const& refflux);
-  
+
   //! star index
   unsigned int &  Index() { return index; }
   unsigned int    Index() const { return index; }
-  
+
 };
 
 
@@ -55,7 +55,7 @@ private :
 
 /****** RefStarList ***********/
 
-  
+
 class Frame;
 
   //typedef StarList<RefStar> RefStarList;
@@ -65,7 +65,7 @@ class RefStarList : public StarList<RefStar> { };
 typedef RefStarList::const_iterator RefStarCIterator;
 typedef RefStarList::iterator RefStarIterator;
 typedef CountedRef<RefStar> RefStarRef;
- 
+
 
 BaseStarList& Ref2Base(RefStarList &This);
 BaseStarList* Ref2Base(RefStarList *This);

--- a/include/lsst/jointcal/SimplePolyMapping.h
+++ b/include/lsst/jointcal/SimplePolyMapping.h
@@ -110,7 +110,7 @@ class SimpleGtransfoMapping : public Mapping
 
   //!
   void  SetIndex(unsigned I) {index=I;}
-  
+
   virtual void ComputeTransformAndDerivatives(const FatPoint &Where,
 					      FatPoint &OutPos,
 					      Eigen::MatrixX2d &H) const
@@ -132,7 +132,7 @@ class SimplePolyMapping : public SimpleGtransfoMapping
   We need both the transform and its derivative. */
   GtransfoLin _centerAndScale;
   Eigen::Matrix2d preDer;
-  
+
   /* Where we store the combination. We use a pointer for
   constness. Could not get it to work with smart pointers.
   */

--- a/include/lsst/jointcal/SimplePolyModel.h
+++ b/include/lsst/jointcal/SimplePolyModel.h
@@ -52,7 +52,7 @@ public :
 
   // dispaches the offsets after a fit step into the actual locations of parameters
   void OffsetParams(const Eigen::VectorXd &Delta);
-  
+
   /*! the mapping of sky coordinates (i.e. the coordinate system
   in which fitted stars are reported) onto the Tangent plane
   (into which the pixel coordinates are transformed) */

--- a/include/lsst/jointcal/SipToGtransfo.h
+++ b/include/lsst/jointcal/SipToGtransfo.h
@@ -19,7 +19,7 @@ TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image::TanWcs> 
    GtransfoToTanWcs(const lsst::jointcal::TanSipPix2RaDec WcsTransfo,
 		    const lsst::jointcal::Frame &CcdFrame,
 		    const bool NoLowOrderSipTerms=false);
-    
+
 }} // end of namespaces
 
 #endif /* SIPTOGTRANSFO__H */

--- a/include/lsst/jointcal/SipToGtransfo.h
+++ b/include/lsst/jointcal/SipToGtransfo.h
@@ -12,7 +12,7 @@ namespace jointcal {
   class Frame;
 
   //! Transform an afw TanWcs into a Gtransfo
-TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image::TanWcs>  wcs);
+TanSipPix2RaDec ConvertTanWcs(const std::shared_ptr<lsst::afw::image::TanWcs>  wcs);
 
 //! Transform the other way around
  PTR(lsst::afw::image::TanWcs)

--- a/include/lsst/jointcal/StarList.h
+++ b/include/lsst/jointcal/StarList.h
@@ -91,7 +91,7 @@ public:
 /* destructor */
   virtual ~StarList() {};
 
-  
+
   //! invokes dump(stream) for all Stars in the std::list.
  void dump(std::ostream &stream = std::cout ) const {
     for (auto p = this->begin();

--- a/include/lsst/jointcal/StarMatch.h
+++ b/include/lsst/jointcal/StarMatch.h
@@ -34,11 +34,11 @@ namespace jointcal {
 
 //! A hanger for star associations
 class StarMatch {
-  
+
   friend class StarMatchList;
 
 public: /* if one sets that private, then fitting routines will be a nightmare. we could set all the Transfo classes friend... */
-  
+
   FatPoint point1, point2; //!< 2 points
   CountedRef<const BaseStar> s1, s2; //!< the Star pointers (the pointer is in fact generic, pointed data is never used).
   double distance;
@@ -50,7 +50,7 @@ public :
     (which are there for user convenience). */
   StarMatch(const FatPoint &p1, const FatPoint &p2, const BaseStar *S1, const BaseStar *S2) :
     point1(p1), point2(p2), s1(S1), s2(S2), distance(0.) {};
-  
+
   // the next one would require that StarMatch knows BaseStar which is not mandatory for StarMatch to work
   // StarMatch(BaseStar *S1, BaseStar *S2) : point1(*S1), point2(*S2), s1(S1), s2(S2) {};
 
@@ -73,10 +73,10 @@ public :
   friend bool DecreasingDistances(const StarMatch &one, const StarMatch &two);
   friend bool DecPhoRatio(const StarMatch &S1, const StarMatch &S2);
 #endif
-  
+
   /* comparison that ensures that after a sort, duplicates are next one another */
   explicit StarMatch() {};
-  
+
 #ifndef SWIG
   friend std::ostream& operator << (std::ostream &stream, const StarMatch &Match);
 #endif
@@ -86,7 +86,7 @@ public :
 
  private:
   //  bool operator <  (const StarMatch & other) const { return (s1 > other.s1) ? s1 > other.s1 : s2 > other.s2;}
- 
+
   /* for unique to remove duplicates */
   bool operator == (const StarMatch &other) const { return (s1 == other.s1 && s2 == other.s2); };
   bool operator != (const StarMatch &other) const { return (s1 != other.s1 || s2 != other.s2); };
@@ -95,7 +95,7 @@ public :
   friend bool SameS1(const StarMatch &one, const StarMatch &two);
   friend bool CompareS2(const StarMatch &one, const StarMatch &two);
   friend bool SameS2(const StarMatch &one, const StarMatch &two);
-  
+
   //! enables \verbatim std::cout << mystarMatch << std::endl; \endverbatim
 
   //  ClassDef(StarMatch,1);
@@ -213,7 +213,7 @@ class StarMatchList : public std::list<StarMatch> {
   //! returns the order of the used transfo
   int TransfoOrder() const {return order;}
 
-  
+
   //! swaps elements 1 and 2 of each starmatch in std::list.
     void Swap () ;
 
@@ -224,8 +224,8 @@ class StarMatchList : public std::list<StarMatch> {
      The distance is computed using Transfo. Which = 1 (2) removes ambiguities
      on the first (second) term of the match. Which=3 does both.*/
   unsigned RemoveAmbiguities(const Gtransfo &Transfo, const int Which=3);
-  
-  
+
+
   //! sets a transfo between the 2 std::lists and deletes the previous or default one.  No fit.
   void SetTransfo(const Gtransfo *Transfo) { transfo = Transfo->Clone();}
   //!
@@ -252,7 +252,7 @@ class StarMatchList : public std::list<StarMatch> {
   void DumpTransfo(std::ostream &stream = std::cout) const;
 
   ~StarMatchList() {/* should delete the transfo.... or use counted refs*/ };
-  
+
   //!: without descriptor for l2tup
   void write_wnoheader(std::ostream & pr=std::cout, const Gtransfo *T=NULL ) const ;
 

--- a/include/lsst/jointcal/Tripletlist.h
+++ b/include/lsst/jointcal/Tripletlist.h
@@ -18,7 +18,7 @@ class TripletList : public std::vector<Trip>
   unsigned nextFreeIndex;
  public :
   TripletList(int Count) {nextFreeIndex = 0; reserve(Count);};
-    
+
   void AddTriplet(const unsigned i, const unsigned j, double val)
   {
     push_back(Trip(i,j,val));

--- a/include/lsst/jointcal/TwoTransfoMapping.h
+++ b/include/lsst/jointcal/TwoTransfoMapping.h
@@ -23,11 +23,11 @@ class TwoTransfoMapping: public Mapping
   };
 
   std::unique_ptr<tmpVars> tmp;
-  
+
   // forbid copies
   TwoTransfoMapping(const TwoTransfoMapping&);
   void operator= (const TwoTransfoMapping&);
-  
+
 
 
  public :

--- a/include/lsst/jointcal/portable_endian.h
+++ b/include/lsst/jointcal/portable_endian.h
@@ -1,0 +1,118 @@
+// "License": Public Domain
+// I, Mathias Panzenböck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+// In case there are jurisdictions that don't support putting things in the public domain you can also consider it to
+// be "dual licensed" under the BSD, MIT and Apache licenses, if you want to. This code is trivial anyway. Consider it
+// an example on how to get the endian conversion functions on different platforms.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#	include <endian.h>
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#	include <sys/endian.h>
+
+#	define be16toh(x) betoh16(x)
+#	define le16toh(x) letoh16(x)
+
+#	define be32toh(x) betoh32(x)
+#	define le32toh(x) letoh32(x)
+
+#	define be64toh(x) betoh64(x)
+#	define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#	include <winsock2.h>
+#	include <sys/param.h>
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#	error platform not supported
+
+#endif
+
+#endif

--- a/include/lsst/jointcal/test.h
+++ b/include/lsst/jointcal/test.h
@@ -13,13 +13,13 @@
 
 namespace lsst {
 namespace jointcal {
-    
+
     void test(
         lsst::afw::table::SourceCatalog const &sourceCat,
         lsst::daf::base::PropertySet const &metaData
     );
-    
-    
+
+
 }} // end of namespaces
 
 #endif

--- a/include/lsst/jointcal/test2.h
+++ b/include/lsst/jointcal/test2.h
@@ -14,13 +14,13 @@
 
 namespace lsst {
 namespace jointcal {
-    
+
 class test2 {
 public:
-    
+
     test2 (
     );
-    
+
     void addSourceTable (
         lsst::afw::table::SourceCatalog const &sourceCat,
         lsst::daf::base::PropertySet const &metaData
@@ -28,16 +28,16 @@ public:
     );
 
     void addMetaList(std::vector<PTR(lsst::daf::base::PropertySet)>);
-    
+
 private:
-    
+
     typedef std::tuple<lsst::afw::table::SourceCatalog,
             lsst::daf::base::PropertySet> sourceTuple;
 //    std::vector <lsst::afw::table::SourceCatalog> _sources;
 //    std::vector <lsst::daf::base::PropertySet> _sources;
     std::vector <boost::shared_ptr<lsst::daf::base::PropertySet> > _sources;
 };
-    
+
 }} // end of namespaces
 
 #endif

--- a/include/lsst/jointcal/test2.h
+++ b/include/lsst/jointcal/test2.h
@@ -35,7 +35,7 @@ private:
             lsst::daf::base::PropertySet> sourceTuple;
 //    std::vector <lsst::afw::table::SourceCatalog> _sources;
 //    std::vector <lsst::daf::base::PropertySet> _sources;
-    std::vector <boost::shared_ptr<lsst::daf::base::PropertySet> > _sources;
+    std::vector <std::shared_ptr<lsst::daf::base::PropertySet> > _sources;
 };
 
 }} // end of namespaces

--- a/python/lsst/jointcal/dataIds.py
+++ b/python/lsst/jointcal/dataIds.py
@@ -60,8 +60,8 @@ class PerTractCcdDataIdContainer(CoaddDataIdContainer):
             raise RuntimeError("Must call setDatasetType first")
         skymap = None
         log = None
-        visitTract = {} # Set of tracts for each visit
-        visitRefs = {} # List of data references for each visit
+        visitTract = {}  # Set of tracts for each visit
+        visitRefs = {}  # List of data references for each visit
         for dataId in self.idList:
             if "tract" not in dataId:
                 # Discover which tracts the data overlaps
@@ -90,7 +90,7 @@ class PerTractCcdDataIdContainer(CoaddDataIdContainer):
                     # Going with just the nearest tract.  Since we're throwing all tracts for the visit
                     # together, this shouldn't be a problem unless the tracts are much smaller than a CCD.
                     tract = skymap.findTract(wcs.pixelToSky(box.getCenter()))
-                    print("tract = ",tract)
+                    print("tract = ", tract)
                     if overlapsTract(tract, wcs, box):
                         if visit not in visitTract:
                             visitTract[visit] = set()
@@ -137,4 +137,4 @@ def overlapsTract(tract, imageWcs, imageBox):
     imagePoly = convexHull([coord.getVector() for coord in imageCorners])
     if imagePoly is None:
         return False
-    return tractPoly.intersects(imagePoly) # "intersects" also covers "contains" or "is contained by"
+    return tractPoly.intersects(imagePoly)  # "intersects" also covers "contains" or "is contained by"

--- a/python/lsst/jointcal/jointcalCoadd.py
+++ b/python/lsst/jointcal/jointcalCoadd.py
@@ -6,6 +6,7 @@ from lsst.pipe.tasks.makeCoaddTempExp import MakeCoaddTempExpTask
 from lsst.pipe.base import Struct
 import lsst.afw.image as afwImage
 
+
 class JointcalCoaddTask(MakeCoaddTempExpTask):
     def getCalExp(self, dataRef, bgSubtracted):
         """!Return one "calexp" calibrated exposure
@@ -31,14 +32,14 @@ class JointcalCoaddTask(MakeCoaddTempExpTask):
         self.log.info("doApplyUberCal is set - Using jointcal updated calibrations")
         self.applyjointcalResults(dataRef, calexp=exposure)
         return exposure
-    
+
     def applyjointcalResults(self, dataRef, calexp=None):
         """Deprecated function to apply the results to an exposure
         Deprecated, because the mosaic results can be applied to more than
         one kind of target, so it's worth changing the name to be specific.
         """
         return self.applyjointcalResultsExposure(dataRef, calexp).exposure
-        
+
     def applyjointcalResultsExposure(self, dataRef, calexp=None):
         """Update an Exposure with the Wcs, from meas_jointcal
         (Calib and flux sacling will be also used later).
@@ -48,8 +49,8 @@ class JointcalCoaddTask(MakeCoaddTempExpTask):
         if calexp is None:
             calexp = dataRef.get("calexp", immediate=True)
 
-        wcsCont = dataRef.get("wcs",  immediate=True)
+        wcsCont = dataRef.get("wcs", immediate=True)
         wcs = afwImage.TanWcs.cast(wcsCont.getWcs())
         calexp.setWcs(wcs)
-        
+
         return Struct(exposure=calexp)

--- a/python/lsst/jointcal/jointcalLib.i
+++ b/python/lsst/jointcal/jointcalLib.i
@@ -12,7 +12,6 @@ Python interface to lsst::jointcal classes
 %{
 #include <exception>
 #include <list>
-#include <boost/shared_ptr.hpp>
 #include "lsst/afw/table.h"
 #include "lsst/afw/detection.h"
 #include "lsst/pex/logging.h"
@@ -23,6 +22,10 @@ Python interface to lsst::jointcal classes
 #include "lsst/daf/base/PropertySet.h"
 #include "lsst/jointcal/test.h"
 #include "lsst/jointcal/test2.h"
+#include "lsst/jointcal/BaseStar.h"
+#include "lsst/jointcal/StarList.h"
+#include "lsst/jointcal/FittedStar.h"
+#include "lsst/jointcal/RefStar.h"
 #include "lsst/jointcal/Jointcal.h"
 #include "lsst/jointcal/CcdImage.h"
 #include "lsst/jointcal/AstromFit.h"
@@ -51,9 +54,9 @@ Python interface to lsst::jointcal classes
 %shared_ptr(lsst::jointcal::JointcalControl);
 
 %template(SourceList) std::vector<lsst::afw::table::SortedCatalogT< lsst::afw::table::SourceRecord> >;
-%template(WcsList) std::vector<boost::shared_ptr<lsst::afw::image::TanWcs> >;
-%template(PropertySetList) std::vector<boost::shared_ptr<lsst::daf::base::PropertySet> >;
-%template(CalibList) std::vector<boost::shared_ptr< lsst::afw::image::Calib > >;
+%template(WcsList) std::vector<std::shared_ptr<lsst::afw::image::TanWcs> >;
+%template(PropertySetList) std::vector<std::shared_ptr<lsst::daf::base::PropertySet> >;
+%template(CalibList) std::vector<std::shared_ptr< lsst::afw::image::Calib > >;
 %template(BboxList) std::vector<lsst::afw::geom::Box2I>;
 %template(StringList) std::vector<std::string>;
 %template(IntList) std::vector<int>;
@@ -69,16 +72,16 @@ class CcdImage;
 class CcdImageList;
 class MeasuredStar;
 class FittedStarList;
+class RefStarList;
 class MeasuredStarList;
+class BaseStar;
+class RefStar;
+class StarList;
+class FittedStar;
+class Point;
 }}
 %include "lsst/jointcal/Chi2.h"
 %include "lsst/jointcal/AstromFit.h"
-namespace lsst {
-namespace jointcal {
-class RefStarList;
-class FittedStarList;
-class Point;
-}}
 %include "lsst/jointcal/Associations.h"
 namespace lsst {
 namespace jointcal {
@@ -101,9 +104,21 @@ namespace jointcal {
 }}
 
 %shared_ptr(lsst::jointcal::CcdImage);
-%template(CcdImageRef) boost::shared_ptr<lsst::jointcal::CcdImage>;
-%template(CcdImageRefList) std::list<boost::shared_ptr<lsst::jointcal::CcdImage> >;
-%template(TanSipPix2RaDecRef) boost::shared_ptr<lsst::jointcal::TanSipPix2RaDec>;
+// TODO: NOTE: this may not be needed? Unclear.
+// %template(CcdImageRef) std::shared_ptr<lsst::jointcal::CcdImage>;
+%template(CcdImageRefList) std::list<std::shared_ptr<lsst::jointcal::CcdImage> >;
+%template(TanSipPix2RaDecRef) std::shared_ptr<lsst::jointcal::TanSipPix2RaDec>;
+
+// %shared_ptr(lsst::jointcal::BaseStar);
+// %shared_ptr(lsst::jointcal::RefStar);
+// %shared_ptr(lsst::jointcal::FittedStar);
+// %template(RefStarRef) std::shared_ptr<lsst::jointcal::RefStar>;
+// %intrusive_ptr(lsst::jointcal::RefStar);
+// %template(StarListOfRefStar) std::list<std::intrusive_ptr<lsst::jointcal::RefStar> >;
+%include "lsst/jointcal/StarList.h"
+// %template(StarListMonkey) lsst::jointcal::StarList<lsst::jointcal::RefStar>;
+// typedef StarList std::list<lsst::jointcal::CountedRef>;
+// %template(RefStarRefList) std::list<lsst::jointcal::RefStar>;
 
 %shared_ptr(lsst::jointcal::TanSipPix2RaDec);
 %include "lsst/jointcal/Point.h"
@@ -111,6 +126,9 @@ namespace jointcal {
 %include "lsst/jointcal/Gtransfo.h"
 
 %include "lsst/jointcal/CcdImage.h"
+%include "lsst/jointcal/BaseStar.h"
+%include "lsst/jointcal/FittedStar.h"
+%include "lsst/jointcal/RefStar.h"
 %include "lsst/jointcal/SimplePolyModel.h"
 %include "lsst/jointcal/ConstrainedPolyModel.h"
 

--- a/python/lsst/jointcal/jointcalLib.i
+++ b/python/lsst/jointcal/jointcalLib.i
@@ -109,6 +109,8 @@ namespace jointcal {
 %template(CcdImageRefList) std::list<std::shared_ptr<lsst::jointcal::CcdImage> >;
 %template(TanSipPix2RaDecRef) std::shared_ptr<lsst::jointcal::TanSipPix2RaDec>;
 
+// TODO: SWIG doesn't like boost::intrusive_ptr so we can't wrap these.
+// Once DM-4043 is solved, we should clean this up to better wrap the lists.
 // %shared_ptr(lsst::jointcal::BaseStar);
 // %shared_ptr(lsst::jointcal::RefStar);
 // %shared_ptr(lsst::jointcal::FittedStar);

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -72,7 +72,7 @@ bool Associations::AddImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::S
 	std::cout << "setting commonTangentPoint" << commonTangentPoint << std::endl;
     }
 
-  boost::shared_ptr<CcdImage> ccdImage(new CcdImage(Ri, commonTangentPoint, wcs, meta, bbox, filter, calib, visit, ccd, camera, control->sourceFluxField));
+  std::shared_ptr<CcdImage> ccdImage(new CcdImage(Ri, commonTangentPoint, wcs, meta, bbox, filter, calib, visit, ccd, camera, control->sourceFluxField));
 //  CcdImage *ccdImage = new CcdImage(Ri, commonTangentPoint, wcs, meta, bbox, filter, calib, visit, ccd, camera, control->sourceFluxField);
   ccdImageList.push_back(ccdImage);
   std::cout << " we have " << ccdImage->WholeCatalog().size()

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -31,7 +31,7 @@ static double sqr(const double &x) {return x*x;}
 
 namespace lsst {
 namespace jointcal {
-    
+
 // Source selection is performed in the python, so Associations' constructor is just initializing couple of variables
 Associations::Associations()
   : nshoots_(0), nb_photref_associations(0)
@@ -60,7 +60,7 @@ bool Associations::AddImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::S
 {
 
 //  std::cout << " considering image " << ri.Name() << std::endl;
-  
+
   /* if commonTangentPoint was never initialized
      take the one from this image */
   if (commonTangentPoint.x  == 0. && commonTangentPoint.y == 0.)
@@ -71,7 +71,7 @@ bool Associations::AddImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::S
 	commonTangentPoint = Point(crval1, crval2);
 	std::cout << "setting commonTangentPoint" << commonTangentPoint << std::endl;
     }
-    
+
   boost::shared_ptr<CcdImage> ccdImage(new CcdImage(Ri, commonTangentPoint, wcs, meta, bbox, filter, calib, visit, ccd, camera, control->sourceFluxField));
 //  CcdImage *ccdImage = new CcdImage(Ri, commonTangentPoint, wcs, meta, bbox, filter, calib, visit, ccd, camera, control->sourceFluxField);
   ccdImageList.push_back(ccdImage);
@@ -107,14 +107,14 @@ void Associations::AssociateCatalogs(const double MatchCutInArcSec,
   for (CcdImageIterator i=ccdImageList.begin(); i != ccdImageList.end(); ++i)
     {
       CcdImage &ccdImage = **i;
-      
+
       const Gtransfo *toCommonTangentPlane =
 	ccdImage.Pix2CommonTangentPlane();
 
       /* clear the catalog to fit and copy the whole catalog into it.
 	 this enables to reassociate from scratch after a fit
       */
-      
+
       ccdImage.CatalogForFit().clear();
       ccdImage.WholeCatalog().CopyTo(ccdImage.CatalogForFit());
       MeasuredStarList &catalog = ccdImage.CatalogForFit();
@@ -131,7 +131,7 @@ void Associations::AssociateCatalogs(const double MatchCutInArcSec,
 	 actual copy, which we don't want here: we want the pointers in
 	 the StarMatch to refer to fittedStarList elements. */
       FittedStarList toMatch;
-      
+
       for (FittedStarCIterator i=fittedStarList.begin();
 	   i!= fittedStarList.end(); ++i)
 	{
@@ -167,7 +167,7 @@ void Associations::AssociateCatalogs(const double MatchCutInArcSec,
 	  FittedStar &fs = const_cast<FittedStar &>(fs_const);
 	  ms.SetFittedStar(&fs);
 	  matchedCount++;
-	  
+
 	  //	  if(  fs->Distance(toCommonTangentPlane->apply(*ms)) > 1.5/3600. )
 	  //	    cout << " OUTLIER: " << ccdImage.Shoot() << "p" << ccdImage.Chip()
 	  //		 << ms->x << "," << ms->y
@@ -201,7 +201,7 @@ void Associations::AssociateCatalogs(const double MatchCutInArcSec,
       std::cout << " unmatched objects :" << unMatchedCount << std::endl;
       std::cout << " ************" << std::endl;
     } // end of loop on CcdImage's
-    
+
   AssignMags();
 }
 void Associations::CollectRefStars(const bool ProjectOnTP)
@@ -209,7 +209,7 @@ void Associations::CollectRefStars(const bool ProjectOnTP)
 
   // compute the frame on the CTP that contains all input images
   Frame tangentPlaneFrame;
-  
+
   for (CcdImageIterator i=ccdImageList.begin(); i!= ccdImageList.end(); ++i)
     {
       CcdImage &ccdImage = **i;
@@ -227,7 +227,7 @@ void Associations::CollectRefStars(const bool ProjectOnTP)
   GtransfoLin identity;
   TanPix2RaDec CTP2RaDec(identity, commonTangentPoint);
   Frame raDecFrame = ApplyTransfo(tangentPlaneFrame,CTP2RaDec,LargeFrame);
-  
+
   std::cout << "raDecFrame : " << raDecFrame << std::endl;
 
   // collect in USNO catalog
@@ -247,7 +247,7 @@ void Associations::CollectRefStars(const bool ProjectOnTP)
     }
   // project on CTP (i.e. RaDec2CTP), in degrees
   TanRaDec2Pix RaDec2CTP(identity, commonTangentPoint);
-  
+
   if (ProjectOnTP)
     {
       refStarList.ApplyTransfo(RaDec2CTP); // also transforms errors in FatPoint
@@ -266,13 +266,13 @@ void Associations::CollectLSSTRefStars(lsst::afw::table::SortedCatalogT< lsst::a
     {
       throw(LSST_EXCEPT(pex::exceptions::InvalidParameterError, " Reference catalog is empty : stop here "));
     }
-    
+
 //  auto coordKey = Ref.getSchema().find<lsst::afw::coord::Coord>("coord").key;
 // Same syntax as the following line but with auto :  auto coordKey = afwTable::CoordKey(Ref.getSchema()["coord"]);
   afw::table::CoordKey coordKey = Ref.getSchema()["coord"];
   auto fluxKey = Ref.getSchema().find<double>(filter + "_flux").key;
 //  auto fluxSigmaKey = Ref.getSchema().find<double>(filter + "_fluxSigma").key;
-    
+
   for (auto i = Ref.begin(); i != Ref.end(); i++)
     {
 	lsst::afw::coord::Coord coord = i->get(coordKey);
@@ -293,11 +293,11 @@ void Associations::CollectLSSTRefStars(lsst::afw::table::SortedCatalogT< lsst::a
 	RefStar *r = new RefStar(s, s);
 	refStarList.push_back(r);
     }
-      
+
   // project on CTP (i.e. RaDec2CTP), in degrees
   GtransfoLin identity;
   TanRaDec2Pix RaDec2CTP(identity, commonTangentPoint);
-  
+
   AssociateRefStars(usnoMatchCut, &RaDec2CTP);
 }
 
@@ -305,7 +305,7 @@ const lsst::afw::geom::Box2D Associations::GetRaDecBBox()
 {
   // compute the frame on the CTP that contains all input images
   Frame tangentPlaneFrame;
-  
+
   for (CcdImageIterator i=ccdImageList.begin(); i!= ccdImageList.end(); ++i)
     {
       CcdImage &ccdImage = **i;
@@ -318,13 +318,13 @@ const lsst::afw::geom::Box2D Associations::GetRaDecBBox()
   GtransfoLin identity;
   TanPix2RaDec CTP2RaDec(identity, commonTangentPoint);
   Frame raDecFrame = ApplyTransfo(tangentPlaneFrame,CTP2RaDec,LargeFrame);
-  
+
   lsst::afw::geom::Point<double> min(raDecFrame.xMin, raDecFrame.yMin);
   lsst::afw::geom::Point<double> max(raDecFrame.xMax, raDecFrame.yMax);
   lsst::afw::geom::Box2D box(min, max);
-  
+
   return box;
-  
+
 }
 
 void Associations::AssociateRefStars(const double &MatchCutInArcSec,
@@ -350,7 +350,7 @@ void Associations::AssociateRefStars(const double &MatchCutInArcSec,
 					   Fitted2Base(fittedStarList),
 					   T,
 					   MatchCutInArcSec/3600.);
-  
+
   if (cleanMatches)
     {
       std::cout << " number of matches before removing ambiguities "
@@ -392,11 +392,11 @@ void Associations::SelectFittedStars()
       for (MeasuredStarIterator mi = catalog.begin(); mi != catalog.end(); )
 	{
 	  MeasuredStar &mstar = **mi;
-	  
+
 	  const FittedStar *fstar = mstar.GetFittedStar();
 	  if (!fstar) {++mi;continue;}
 	  int nmes = fstar->MeasurementCount(); // DEBUG
-	  
+
 	  /*  keep FittedStar's which either have a minimum number of
 	      measurements, or are matched to a RefStar (i.e. USNO)
 	  */
@@ -428,7 +428,7 @@ void Associations::SelectFittedStars()
 
   // just for printouts:
   // fittedStarList.sort(&DecreasingMeasurementCount);
-    
+
   std::cout
     << " number of possible fitted star after cutting on # of measurements "
     << fittedStarList.size() << std::endl;
@@ -476,23 +476,23 @@ void Associations::CollectMCStars(int realization)
   cout << "[Associations::CollectMCStars]" << endl;
   CcdImageIterator I;
   StarMatchIterator smI;
-  
+
   for(I=ccdImageList.begin();I!=ccdImageList.end();I++)
     {
       CcdImage& ccdImage = **I;
       string dbimdir = ccdImage.Dir();
       string mctruth = dbimdir + "/mc/mctruth.list";
-      
+
       if(realization >= 0)
 	{
 	  stringstream sstrm;
 	  sstrm << dbimdir << "/mc/mctruth_" << realization << ".list";
 	  mctruth = sstrm.str();
 	}
-      
+
       GtransfoIdentity gti;
       MeasuredStarList& catalog = ccdImage.CatalogForFit();
-      
+
       //      BaseStarWithErrorList mctruthlist(mctruth);
       DicStarList mctruthlist(mctruth);
       StarMatchList* smList = ListMatchCollect(Measured2Base(catalog),
@@ -558,53 +558,53 @@ void Associations::CollectPhotometricRefStars(string const& catalogname)
 {
   cout << "[Associations::CollectPhotometricRefStars()] ... ";
   photRefStarList.clear();
-  
+
   DicStarList dsl(catalogname);
   DicStarIterator I;
-  
+
   double rflux;
   vector<double> refflux;
   refflux.resize(10);
-  
+
   for(I=dsl.begin();I!=dsl.end();I++)
     {
       DicStar& ds = **I;
-      
+
       // I am here (debugging the star positions)
       //       cout << "[DEBUG] x,y="
       // 	   << ds.x << " " << ds.y
       // 	   << endl;
-      
+
       refflux[0] = getflux(ds, "mu");
       refflux[1] = getflux(ds, "mg");
       refflux[2] = getflux(ds, "mr");
       refflux[3] = getflux(ds, "mi");
       refflux[4] = getflux(ds, "mz");
-      
+
       refflux[5] = getflux(ds, "U");
       refflux[6] = getflux(ds, "B");
       refflux[7] = getflux(ds, "V");
       refflux[8] = getflux(ds, "R");
       refflux[9] = getflux(ds, "I");
-      
+
       RefStar* rs = new RefStar(ds, ds);
       rs->AssignRefFluxes(refflux);
-      
+
       unsigned int index = (unsigned int)ds.getval("index");
       rs->Index() = index;
-      
+
       photRefStarList.push_back(rs);
     }
-  
+
   cout << photRefStarList.size() << " stars read" << endl;
-  
+
   // Now, If I understand well, all the FittedStar coordinates
   // are in CTP coordinates ==> we have to transform our
   // (RA,DEC) coordinates into CTP coords...
   GtransfoLin identity;
   TanRaDec2Pix RaDec2CTP(identity, commonTangentPoint);
   photRefStarList.ApplyTransfo(RaDec2CTP);
-  
+
   cout << "[DEBUG DEBUB DEBUG]" << endl;
   RaDec2CTP.dump(cout);
   cout << "[DEBUG DEBUB DEBUG]" << endl;
@@ -616,7 +616,7 @@ void Associations::AssociatePhotometricRefStars(double MatchCutInArcSec)
   cout << "[Associations::AssociatePhotometricRefStars]" << endl;
   cout << "[DEBUG]  -> nb fs=" << fittedStarList.size()
        << " nb refstars="  << photRefStarList.size() << endl;
-  
+
   // clear previous associations
   RefStarIterator I;
   for(I=photRefStarList.begin();I!=photRefStarList.end();I++)
@@ -624,13 +624,13 @@ void Associations::AssociatePhotometricRefStars(double MatchCutInArcSec)
       (*I)->SetFittedStar( *(FittedStar*)NULL ); // mais c'est horrible (!)
       //      cout << " XTP,YTP=" << (*I)->x << " " << (*I)->y << endl;
     }
-  
+
   GtransfoIdentity gtransfoIdentity;
   StarMatchList* smList = ListMatchCollect(Ref2Base(photRefStarList),
 					   Fitted2Base(fittedStarList),
 					   &gtransfoIdentity,
 					   MatchCutInArcSec/3600.);
-  
+
   if(Preferences().cleanMatches)
     {
       cout << "  (*) removing ambiguities: "
@@ -638,7 +638,7 @@ void Associations::AssociatePhotometricRefStars(double MatchCutInArcSec)
       smList->RemoveAmbiguities(gtransfoIdentity);
       cout << " --> "  << smList->size() << endl;
     }
-  
+
   // associate the RefStars and the fitted stars ...
   StarMatchIterator smI;
   for(smI=smList->begin(); smI!=smList->end(); smI++)
@@ -650,17 +650,17 @@ void Associations::AssociatePhotometricRefStars(double MatchCutInArcSec)
       FittedStar* fs = dynamic_cast<FittedStar*>(bs);
       fs->SetRefStar(*rs);
     }
-  
+
   cout << "  (*) done. Associated " << smList->size() << " STANDARD stars "
        << "among a list of " << photRefStarList.size() << " objects."
        << endl;
-  
+
   nb_photref_associations = smList->size();
-  
+
   delete smList;
 }
 
-	  
+
 
 //void Associations::SetRefPhotFactor(int chip, double photfact)
 //{
@@ -721,14 +721,14 @@ void Associations::CollectMCStars(int realization)
 {
   CcdImageIterator I;
   StarMatchIterator smI;
-  
+
   for(I=ccdImageList.begin();I!=ccdImageList.end();I++)
     {
       CcdImage& ccdImage = **I;
       string dbimdir = ccdImage.Dir();
       string mcstars = dbimdir + "/mc/mcstars.list";
       string mctruth = dbimdir + "/mc/mctruth.list";
-      
+
       if(realization >= 0)
 	{
 	  stringstream sstrm;
@@ -738,10 +738,10 @@ void Associations::CollectMCStars(int realization)
 	  sstrm << dbimdir << "/mc/mctruth_" << realization << ".list";
 	  mctruth = sstrm.str();
 	}
-      
+
       GtransfoIdentity gti;
       MeasuredStarList& catalog = ccdImage.CatalogForFit();
-      
+
       BaseStarWithErrorList mcstarlist(mcstars);
       StarMatchList *smList = ListMatchCollect(Measured2Base(catalog),
 					       BaseStarWithError2Base(mcstarlist),
@@ -759,7 +759,7 @@ void Associations::CollectMCStars(int realization)
       else
 	cout << "[Associations::CollectMCStars] Unable to match MCStars w/ catalog !" << endl;
       delete smList;
-      
+
       BaseStarWithErrorList mctruthlist(mctruth);
       //      DictStarList mctruthlist(mctruth);
       smList = ListMatchCollect(Measured2Base(catalog),
@@ -787,7 +787,7 @@ void Associations::CollectMCStars(int realization)
       //	       << ms.GetMCMeas() << " "
       //	       << ms.GetMCTruth() << endl;
       //	}
-      
+
     }
 }
 #endif /* STORAGE */

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -112,14 +112,14 @@ static void readusno(const std::string &filebase,double minra,double maxra,
   unsigned int  raword,decword,magword;
   unsigned int minraword,maxraword,mindecword,maxdecword;
   double mag;
-  
+
   std::string catname = std::string(filebase) + ".cat";
   std::string accname = std::string(filebase) + ".acc";
 
 
 
   /* Read the accelerator */
-  
+
   if (!(ifp=fopen(accname.c_str(),"r"))) {
     std::cerr << "readusno error: Couldn't open " << accname << std::endl;
     return;
@@ -217,7 +217,7 @@ while (raword<minraword && !feof(ifp)) read_a_star(ifp, raword, decword, magword
         }
     }
 }
-  
+
  fclose(ifp);
 }
 
@@ -231,7 +231,7 @@ while (raword<minraword && !feof(ifp)) read_a_star(ifp, raword, decword, magword
     is mainly used to
     isolate the brightest objects). Sexagesimal coordinates are accepted.
 */
-  
+
 static void read_ascii_astrom_file(const std::string &FileName,
 				  double MinRa,  double MaxRa,
 				  double MinDec, double MaxDec,
@@ -277,12 +277,12 @@ static void actual_usno_read(const std::string &usnodir,
 			     BaseStarList &ApmList)
 {
   int cat0,cat1;
-  
+
   std::cout << " reading usno in window (" << minra << ','
 	    << maxra << ") (" << mindec << ',' << maxdec << ")" << std::endl;
 
   /* Read parameters */
-  
+
 #ifdef DEBUG_READ
   fprintf(stderr,"Going to read USNO from directory %s\n",usnodir.c_str());
   fprintf(stderr,"minra=%lf, maxra=%lf\n",minra,maxra);

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -2,9 +2,9 @@
 #include <iostream>
 #include <fstream>
 #include <stdio.h>
-// #include <endian.h>
 #include <string.h>
 
+#include "lsst/jointcal/portable_endian.h"
 #include "lsst/jointcal/BaseStar.h"
 #include "lsst/jointcal/AstroUtils.h"
 #include "lsst/jointcal/Frame.h"
@@ -72,8 +72,8 @@ static double sq(const double &x) { return x*x;}
 
 static inline void intswap(unsigned int &a_word)
 {
-  // int tmp = be32toh(a_word);
-  // a_word = tmp;
+  int tmp = be32toh(a_word);
+  a_word = tmp;
 }
 
 

--- a/src/AstromFit.cc
+++ b/src/AstromFit.cc
@@ -22,12 +22,12 @@ class CholmodSupernodalLLT2 : public Eigen::CholmodBase<_MatrixType, _UpLo, Chol
 {
   typedef Eigen::CholmodBase<_MatrixType, _UpLo, CholmodSupernodalLLT2> Base;
     using Base::m_cholmod;
-    
+
   public:
-    
+
     typedef _MatrixType MatrixType;
     typedef typename MatrixType::Index Index;
-    
+
     CholmodSupernodalLLT2() : Base() { init(); }
   //! The factorization happens in the constructor.
     CholmodSupernodalLLT2(const MatrixType& matrix) : Base()
@@ -51,7 +51,7 @@ class CholmodSupernodalLLT2 : public Eigen::CholmodBase<_MatrixType, _UpLo, Chol
 						  Base::m_cholmodFactor->n,
 						  NULL, -1, NULL, true, true,
 						  &this->cholmod());
-    
+
     int ret = cholmod_updown(UpOrDown, &C_cs_perm, Base::m_cholmodFactor, &this->cholmod());
     cholmod_free_sparse(C_cs_perm,  &this->cholmod());
     return ret;
@@ -81,13 +81,13 @@ class CholmodSimplicialLDLT2 : public Eigen::CholmodBase<_MatrixType, _UpLo, Cho
 {
   typedef Eigen::CholmodBase<_MatrixType, _UpLo, CholmodSimplicialLDLT2> Base;
     using Base::m_cholmod;
-    
+
   public:
-    
+
     typedef _MatrixType MatrixType;
     typedef typename MatrixType::Index Index;
     typedef typename MatrixType::RealScalar RealScalar;
-    
+
     CholmodSimplicialLDLT2() : Base() { init(); }
 
     CholmodSimplicialLDLT2(const MatrixType& matrix) : Base()
@@ -103,7 +103,7 @@ class CholmodSimplicialLDLT2 : public Eigen::CholmodBase<_MatrixType, _UpLo, Cho
       const Index size = Base::m_cholmodFactor->n;
       EIGEN_UNUSED_VARIABLE(size);
       eigen_assert(size==H.rows());
-      
+
       cholmod_sparse C_cs = viewAsCholmod(H);
       /* We have to apply the magic permutation to the update matrix,
 	 read page 117 of Cholmod UserGuide.pdf */
@@ -310,7 +310,7 @@ void AstromFit::LSDerivatives1(const CcdImage &Ccd,
       // PA - seems correct !
       alpha(1,1) = 1./sqrt(det*transW(0,0));
       alpha(0,1) = 0;
-      
+
       const FittedStar *fs = ms.GetFittedStar();
 
       Point fittedStarInTP = TransformFittedStar(*fs, sky2TP,
@@ -688,7 +688,7 @@ unsigned AstromFit::RemoveOutliers(const double &NSigCut,
   RemoveRefOutliers(FSOutliers);
   return n;
 }
-  
+
 
 
 //! Find Measurements and references contributing more than a cut, computed as <chi2>+NSigCut+rms(chi2). The outliers are NOT removed, and no refit is done.
@@ -770,7 +770,7 @@ unsigned AstromFit::FindOutliers(const double &NSigCut,
       bool drop_it = true;
       for (auto i=indices.cbegin(); i!= indices.end(); ++i)
 	if (affectedParams(*i) !=0) drop_it = false;
-      
+
       if (drop_it) // store the outlier in one of the lists:
 	{
 	  if (ms) // measurement term
@@ -786,7 +786,7 @@ unsigned AstromFit::FindOutliers(const double &NSigCut,
   cout << "INFO : FindOutliers : found "
        << MSOutliers.size() << " meas outliers and "
        << FSOutliers.size ()<< " ref outliers " << endl;
-  
+
   return nOutliers;
 }
 
@@ -801,7 +801,7 @@ void AstromFit::RemoveMeasOutliers(MeasuredStarList &Outliers)
       fs->MeasurementCount()--; // could be put in SetValid
     }
 }
-  
+
 
 void AstromFit::RemoveRefOutliers(FittedStarList &Outliers)
 {
@@ -882,7 +882,7 @@ void AstromFit::AssignIndices(const std::string &WhatToFit)
 }
 
 
-      
+
 void AstromFit::OffsetParams(const Eigen::VectorXd& Delta)
 {
   if (Delta.size() != _nParTot)
@@ -950,7 +950,7 @@ static void write_vect_in_fits(const Eigen::VectorXd &V, const string &FitsName)
 unsigned AstromFit::Minimize(const std::string &WhatToFit, const double NSigRejCut)
 {
   AssignIndices(WhatToFit);
-  
+
   // return code can take 3 values :
   // 0 : fit has converged - no more outliers
   // 1 : still some ouliers but chi2 increases
@@ -1161,7 +1161,7 @@ void AstromFit::MakeMeasResTuple(const std::string &TupleName) const
 	  mapping->TransformPosAndErrors(inPos, tpPos);
 	  const Gtransfo* sky2TP = _distortionModel->Sky2TP(im);
 	  const FittedStar *fs = ms.GetFittedStar();
-	  
+
 	  Point fittedStarInTP = TransformFittedStar(*fs, sky2TP,
 						     refractionVector,
 						     _refracCoefficient[iband],

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -41,6 +41,8 @@ static double sq(const double &x) { return x*x;}
 
 void CcdImage::LoadCatalog(const lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> &Cat,const std::string &fluxField)
 {
+  // TODO: these should use slots, e.g. "slot_Centroid_x", or better:
+  // self.config.centroidName + "_x" in python.
   auto xKey = Cat.getSchema().find<double>("base_SdssCentroid_x").key;
   auto yKey = Cat.getSchema().find<double>("base_SdssCentroid_y").key;
   auto xsKey = Cat.getSchema().find<float>("base_SdssCentroid_xSigma").key;
@@ -195,8 +197,18 @@ CcdImage::CcdImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceReco
         ra = lsst::afw::geom::degToRad(RaStringToDeg(meta->get<std::string>("RA2000")));
         dec = lsst::afw::geom::degToRad(DecStringToDeg(meta->get<std::string>("DEC2000")));
     }
+    // TODO: Massive hack to get my test data to run.
+    // TODO: this all needs to go away once DM-5501 is dealt with.
+    else if (camera == "monkeySim") {
+        airMass = meta->get<double>("AIRMASS");
+        jd = meta->get<double>("MJD");  // Julian date
+        expTime = meta->get<double>("EXPTIME");
+        lst_obs = lsst::afw::geom::degToRad(meta->get<double>("LST"));
+        ra = lsst::afw::geom::degToRad(meta->get<double>("RA2000"));
+        dec = lsst::afw::geom::degToRad(meta->get<double>("DEC2000"));
+    }
     else {
-        throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,"CcdImage, unsupported camera "+camera);
+        throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,"jointcal::CcdImage does not understand your camera "+camera);
     }
     hourAngle = (lst_obs-ra);
     if  (hourAngle>M_PI) hourAngle -= 2*M_PI;

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -250,7 +250,7 @@ PTR(TanSipPix2RaDec) ConstrainedPolyModel::ProduceSipWcs(const CcdImage &Ccd) co
   // wcsPix2TP = cdStuff*sip , so
   GtransfoPoly sip = GtransfoPoly(cdStuff.invert())*wcsPix2Tp;
   Point tangentPoint( proj->TangentPoint());
-  return boost::shared_ptr<TanSipPix2RaDec>(new TanSipPix2RaDec(cdStuff, tangentPoint, &sip));
+  return std::shared_ptr<TanSipPix2RaDec>(new TanSipPix2RaDec(cdStuff, tangentPoint, &sip));
 }
 
 

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -72,13 +72,13 @@ ConstrainedPolyModel::ConstrainedPolyModel(const CcdImageList &L,
       if ((chipp == _chipMap.end()) && shoot == refShoot )
 	{
 	  const Frame &frame = im.ImageFrame();
-	  
+
 	  _tpFrame += ApplyTransfo(frame, *im.Pix2CommonTangentPlane(), LargeFrame);
 	  GtransfoPoly pol(im.Pix2TangentPlane(),
 			   frame,
 			   degree);
 	  GtransfoLin shiftAndNormalize = NormalizeCoordinatesTransfo(frame);
-	  
+
 	  _chipMap[chip] = std::unique_ptr<SimplePolyMapping>(new SimplePolyMapping(shiftAndNormalize, pol*shiftAndNormalize.invert()));
 	}
     }
@@ -99,7 +99,7 @@ reference exposure, expect troubles" << std::endl;
 										     GtransfoPoly(degree)));
 	}
       _mappings[&im] = std::unique_ptr<TwoTransfoMapping>(new TwoTransfoMapping(_chipMap[chip].get(), _shootMap[shoot].get()));
-    
+
     }
   cout << "INFO: ConstrainedPolyModel : we have " << _chipMap.size() << " chip mappings " << endl;
   cout << "INFO: and " << _shootMap.size() << " shoot mappings " << endl;
@@ -199,7 +199,7 @@ void ConstrainedPolyModel::FreezeErrorScales()
   for (auto i = _chipMap.begin(); i!=_chipMap.end(); ++i)
     i->second->FreezeErrorScales();
 }
-  
+
 
 const Gtransfo& ConstrainedPolyModel::GetChipTransfo(const unsigned Chip) const
 {
@@ -233,17 +233,17 @@ PTR(TanSipPix2RaDec) ConstrainedPolyModel::ProduceSipWcs(const CcdImage &Ccd) co
   mappingMapType::const_iterator i = _mappings.find(&Ccd);
   if  (i==_mappings.end()) return NULL;
   const TwoTransfoMapping *m = i->second.get();
-  
+
   const GtransfoPoly &t1=dynamic_cast<const GtransfoPoly&>(m->T1());
   const GtransfoPoly &t2=dynamic_cast<const GtransfoPoly&>(m->T2());
   const TanRaDec2Pix *proj=dynamic_cast<const TanRaDec2Pix*>(Sky2TP(Ccd));
   if (!(&t1)  || !(&t2) || !proj) return NULL;
-  
+
   GtransfoPoly pix2Tp = t2*t1;
 
   const GtransfoLin &projLinPart = proj->LinPart(); // should be the identity, but who knows? So, let us incorporate it into the pix2TP part.
   GtransfoPoly wcsPix2Tp = GtransfoPoly(projLinPart.invert())*pix2Tp;
-  
+
   // compute a decent approximation, if higher order corrections get ignored
   GtransfoLin cdStuff = wcsPix2Tp.LinearApproximation(Ccd.ImageFrame().Center());
 

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -31,7 +31,7 @@ FastFinder::FastFinder(const BaseStarList &List, const unsigned NXslice) : basel
 
   // the x size of each slice:
   xstep = (xmax-xmin)/nslice;
-  
+
 
   // fill the index array with the first star beyond the slice limit.
   index[0] = 0; // first
@@ -117,7 +117,7 @@ const BaseStar *FastFinder::SecondClosest(const Point &Where,
   return pbest2;
 }
 
-     
+
 
 /* It is by no means clear the the 2 following routines are actually needed.
    It is nor clear to me (P.A) why they are different... but they really are.

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -70,7 +70,7 @@ FittedStarList::FittedStarList(const std::string &FileName)
 }
 
 #endif /* DO_WE_NEED_IT */
-  
+
 
 
 
@@ -78,17 +78,17 @@ BaseStarList& Fitted2Base(FittedStarList &This)
 {
   return (BaseStarList&) This;
 }
- 
+
 BaseStarList* Fitted2Base(FittedStarList *This)
 {
   return (BaseStarList*) This;
 }
- 
+
 const BaseStarList& Fitted2Base(const FittedStarList &This)
 {
   return (const BaseStarList &) This;
 }
- 
+
 const BaseStarList* Fitted2Base(const FittedStarList *This)
 {
   return (BaseStarList*) This;
@@ -112,7 +112,7 @@ void FittedStarList::WriteTuple(const std::string &FileName,
 
 
 /****************/
- 
+
 FittedStarTuple::FittedStarTuple(const std::string &FileName)
   : stream(FileName.c_str())
 {
@@ -122,7 +122,7 @@ FittedStarTuple::FittedStarTuple(const std::string &FileName)
 	 << "# nm : number of measurements" << std::endl
 	 << "# end " << std::endl;
     ;
-  
+
 }
 
 
@@ -152,7 +152,7 @@ std::string FittedStar::WriteHeader_(std::ostream& pr, const char* i) const
 {
  std::string format = BaseStar::WriteHeader_(pr, i);
   if(i==NULL) i = "";
-  
+
   pr << "# mag"   << i << " : fitted magnitude" << std::endl;
   pr << "# emag"  << i << " : error on the fitted magnitude" << std::endl;
   pr << "# col"   << i << " : star color" << std::endl;
@@ -163,7 +163,7 @@ std::string FittedStar::WriteHeader_(std::ostream& pr, const char* i) const
   pr << "# flux2" << i << " : flux in some other band ()" << std::endl;
   pr << "# fluxErr" << i << " : flux error" << std::endl;
   pr << "# fluxErr2" << i << " : flux2 error" << std::endl;
-  
+
   format += "FittedStar 1";
   return format;
 }
@@ -174,7 +174,7 @@ std::string FittedStar::WriteHeader_(std::ostream& pr, const char* i) const
 {
   s.setf(std::ios::scientific);
   s << std::setprecision(12);
-  
+
   BaseStar::writen(s);
   s << mag     << " "
     << emag    << " "

--- a/src/Gtransfo.cc
+++ b/src/Gtransfo.cc
@@ -34,7 +34,7 @@ bool IsIntegerShift(const Gtransfo *a_transfo)
 
   double dx = shift->Coeff(0,0,0);
   double dy = shift->Coeff(0,0,1);
-  
+
   static Point dumb(4000,4000);
   if (fabs(dx - int(floor(dx+0.5))) < eps &&
       fabs(dy - int(floor(dy+0.5))) < eps &&
@@ -133,7 +133,7 @@ void Gtransfo::TransformErrors(const Point &Where,
   /*      (a11 a12)          (vxx  vxy)
      M =  (       )  and V = (        )
           (a21 a22)          (xvy  vyy)
-     
+
      Vxx = Vin[0], vyy = Vin[1], Vxy = Vin[2];
      we want to compute M*V*tp(M)
      A lin alg light package would be perfect...
@@ -142,7 +142,7 @@ void Gtransfo::TransformErrors(const Point &Where,
   int yy = 1;
   int xy = 2;
   // M*V :
-  
+
   double b11 = a11 * VIn[xx] + a12 * VIn[xy];
   double b22 = a21 * VIn[xy] + a22 * VIn[yy];
   double b12 = a11 * VIn[xy] + a12 * VIn[yy];
@@ -214,7 +214,7 @@ void Gtransfo::ParamDerivatives(const Point &Where,
   if ((Where.x || Dx ) || Dy) {} // compilation warning killer
   throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, "Gtransfo::ParamDerivatives() should never be called ");
 }
-  
+
 
 ostream & operator << (ostream &stream, const Gtransfo & T)
            {T.dump(stream); return stream;}
@@ -247,7 +247,7 @@ private:
   Gtransfo *direct;
   Gtransfo *roughInverse;
   double precision2;
-  
+
 
 public:
   GtransfoInverse(const Gtransfo* Direct,
@@ -850,7 +850,7 @@ typedef struct
   const char *name;
   const unsigned char px,py,whichCoord;
 } CoeffTagStruct;
-  
+
 static const CoeffTagStruct CoeffTags[] =
   {
     {"dx",   0,0,0},
@@ -924,7 +924,7 @@ static string monomial_string(const unsigned powx, const unsigned powy)
   if (powy>1) ss<<"^"<<powy;
   return ss.str();
 }
-  
+
 void  GtransfoPoly::dump(ostream &S) const
 {
   for (unsigned ic=0; ic<2; ++ic)
@@ -987,7 +987,7 @@ static GtransfoLin shift_and_normalize(const StarMatchList &List)
 }
 
 static double sq(const double &x) { return x*x;}
-  
+
 double GtransfoPoly::do_the_fit(const StarMatchList &List,
 				const Gtransfo &ShiftToCenter,
 				const bool UseErrors)
@@ -1048,7 +1048,7 @@ double GtransfoPoly::do_the_fit(const StarMatchList &List,
       cout << "GtransfoPoly::fit : could not factorize " << endl;
       return -1;
     }
-  
+
   Eigen::VectorXd sol = factor.solve(B);
   for (unsigned k=0; k< 2*nterms; ++k) coeffs[k] += sol(k);
   if (List.size() == nterms) return 0;
@@ -1069,7 +1069,7 @@ double  GtransfoPoly::fit(const StarMatchList &List)
   do_the_fit(List, conditionner, false); // get a rough solution
   do_the_fit(List, conditionner, true); // weight with it
   double chi2 = do_the_fit(List, conditionner, true); // once more
-  
+
   (*this) = (*this)*conditionner;
   if (List.size() == nterms) return 0;
   return chi2;
@@ -1122,7 +1122,7 @@ public :
       for (unsigned py=0; py<=deg-px; ++py)
 	Coeff(px,py) = P.Coeff(px,py,WhichCoord);
   }
-	
+
 
   long double Coeff(const unsigned powx, const unsigned powy) const
   {
@@ -1177,7 +1177,7 @@ static PolyXY Product(const PolyXY &P1, const PolyXY &P2)
   return result;
 }
 
-	
+
 /* Powers[k](x,y) = P(x,y)**k, 0 <= k <= MaxP */
 static void ComputePowers(const PolyXY &P, const unsigned MaxP, vector<PolyXY> &Powers)
 {
@@ -1483,7 +1483,7 @@ GtransfoLinRot::GtransfoLinRot(const double AngleRad, const Point *Center,
   a11() = a22() = c;
   a21() = s;
   a12() = -s;
-  
+
   // we want that the center does not move : T+M*C = C ==> T = C - M*C
   Point a_point(0.,0.);
   if (Center) a_point = *Center;
@@ -1845,7 +1845,7 @@ TanRaDec2Pix::TanRaDec2Pix() : linTan2Pix()
   cos0 = 1;
   sin0 = 0;
 }
-  
+
 
 
 Point TanRaDec2Pix::TangentPoint() const
@@ -1883,7 +1883,7 @@ void TanRaDec2Pix::TransformPosAndErrors(const FatPoint &In,
   if (ra-ra0 < -M_PI ) ra += (2.* M_PI);
   // Code inspired from worldpos.c in wcssubs (ancestor of the wcslib)
   // The same code is copied in ::apply()
-  
+
   double coss = cos(dec);
   double sins = sin(dec);
   double sinda = sin(ra-ra0);
@@ -1899,7 +1899,7 @@ void TanRaDec2Pix::TransformPosAndErrors(const FatPoint &In,
   double a12 = -sinda*sin0/deno;
   double a21 = coss*sinda*sins/deno;
   double a22 = cosda/deno;
-  
+
   FatPoint tmp;
   tmp.vx = a11*(a11*In.vx + 2*a12*In.vxy) + a12*a12*In.vy;
   tmp.vy = a21*a21*In.vx + a22*a22*In.vy + 2.*a21*a22*In.vxy;
@@ -1908,7 +1908,7 @@ void TanRaDec2Pix::TransformPosAndErrors(const FatPoint &In,
   // l and m are now coordinates in the tangent plane, in radians.
   tmp.x = rad2deg(l);
   tmp.y = rad2deg(m);
-  
+
   linTan2Pix.TransformPosAndErrors(tmp, Out);
 }
 

--- a/src/Histo2d.cc
+++ b/src/Histo2d.cc
@@ -48,7 +48,7 @@ bool Histo2d::indices(const double &X, const double &Y, int &ix, int &iy) const
   iy = (int) floor((Y - miny)*scaley);
   return (iy >=0 && iy < ny);
 }
-  
+
 void Histo2d::Fill(float X, float Y, float Weight)
 {
   int ix, iy;

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -35,7 +35,7 @@ SparseHisto4d::SparseHisto4d(const int N1, double Min1, double Max1,
   maxVal[1] = Max2;
   maxVal[2] = Max3;
   maxVal[3] = Max4;
-  
+
   for (int i =0; i < 4; ++i)
     scale[i] = n[i]/(maxVal[i]-minVal[i]);
   data = new int[nEntries];

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -202,7 +202,7 @@ static void dump_input_list(const BaseStarList &L, const int NStars,
   list.ApplyTransfo(Tin);
   list.write(FileName);
 }
-  
+
 
 
 
@@ -277,7 +277,7 @@ for (int i = 0; i<Conditions.MaxTrialCount; ++i)
   Histo2d historank(Conditions.NStarsL1, 0., Conditions.NStarsL1,
                     Conditions.NStarsL2, 0., Conditions.NStarsL2);
   /* reloop on segment pairs to select the ones in this specific bin */
-  
+
   for (segi1 = sList1.begin(); segi1 != sList1.end(); ++segi1)
     {
     seg1 = &(*segi1);
@@ -433,7 +433,7 @@ SolList Solutions;
      histo.BinLimits(pars,1, minAngle, maxAngle);
 
      StarMatchList *a_list = new StarMatchList;
-     
+
      for (segi1 = sList1.begin(); segi1 != sList1.end(); ++segi1)
        {
 	 seg1 = &(*segi1);
@@ -462,7 +462,7 @@ SolList Solutions;
        }
 
      // a basic check for sanity of the algorithm :
-     
+
      if (int(a_list->size() ) != maxContent+1 )
        {
 	 std::cerr << " There is an internal inconsistency in ListMatchupRotShift " << std::endl
@@ -558,7 +558,7 @@ GtransfoLin *ListMatchupShift(const BaseStarList &L1, const BaseStarList &L2, co
   if (ncomb > 10000) nx = 100; else nx = (int) sqrt(ncomb);
 
   Histo2d histo(nx, -MaxShift, MaxShift, nx, -MaxShift, MaxShift);
-  
+
   BaseStarCIterator s1,s2;
   double x1,y1;
   for (s1 = L1.begin(); s1 != L1.end(); ++s1)
@@ -593,7 +593,7 @@ GtransfoLin *ListMatchupShift(const BaseStarList &L1, const BaseStarList &L2, co
 
   Histo2d histo(nx, -MaxShift, MaxShift, nx, -MaxShift, MaxShift);
   double binSize = 2*MaxShift/nx;
-  
+
   BaseStarCIterator s1;
   FastFinder finder(L2);
   double x1,y1;
@@ -870,7 +870,7 @@ Gtransfo* ListMatchRefine(const BaseStarList& List1, const BaseStarList& List2, 
       delete brightMatch;
       brightMatch = ListMatchCollect(L1, L2, curTransfo, brightDist);
     } while (brightMatch->size() > nstarmin && transDiff > 0.05 && ++iter < 5);
-    
+
     double prevChi2 = curChi2;
     curChi2 = ComputeChi2(*brightMatch, *curTransfo) / brightMatch->size();
 

--- a/src/MeasuredStar.cc
+++ b/src/MeasuredStar.cc
@@ -57,7 +57,7 @@ MeasuredStar::MeasuredStar( const SEStar &S) :
     }
   mag = -1;
   //  InitialStarRef = &S;
-  
+
   // Some (temporary) User values
   usrVals.push_back(S.Mxx());
   usrVals.push_back(S.Myy());
@@ -98,7 +98,7 @@ const BaseStarList* Measured2Base(const MeasuredStarList *This)
   //  string format = BaseStar::WriteHeader_(pr,i);
   std::string format = BaseStar::WriteHeader_(pr,i);
   if(i==NULL) i = "";
-  
+
   pr << "# eflux" << i << " : " << std::endl
      << "# mag" << i << " : " << std::endl
      << "# wmag" << i << " : " << std::endl
@@ -107,7 +107,7 @@ const BaseStarList* Measured2Base(const MeasuredStarList *This)
      << "# airmass"<<i<<" :  "<<std::endl
      << "# band"<<i<< " : ugriz=01234 " << std::endl
      << "# valid" << i << " : 0=outlier 1=ok ?" << std::endl;
-  
+
   format += " MeasuredStar 1 ";
   //  if(i && InitialStarRef)
   //    {
@@ -149,16 +149,16 @@ void MeasuredStar::writen(std::ostream& s) const
   //      bandNumber["i"]=3;
   //      bandNumber["z"]=4;
   //    }
-  
+
   BaseStar::writen(s);
 
   s << eflux << ' '
     << (std::isnan(mag)? -1 : mag) << ' '
     << wmag << ' ';
-  
+
   if(ccdImage)
     std::cout << "ccdImage ! " << ccdImage << std::endl;
-  
+
   if(ccdImage)
     s << ccdImage->Chip() << ' '
       << ccdImage->Shoot() << ' '
@@ -169,7 +169,7 @@ void MeasuredStar::writen(std::ostream& s) const
       << 0 << ' '
       << 0 << ' '
       << -1 << ' ';
-  
+
   s << valid << ' ';
 
 }
@@ -198,7 +198,7 @@ void  MeasuredStarList::SetCcdImage(const CcdImage *C)
   for (MeasuredStarIterator i= begin(); i != end(); ++i)
       (*i)->SetCcdImage(C);
 }
-  
+
 
 
 

--- a/src/PhotomFit.cc
+++ b/src/PhotomFit.cc
@@ -111,7 +111,7 @@ void PhotomFit::LSDerivatives(const CcdImage &Ccd,
       const FittedStar *fs = ms.GetFittedStar();
 
       double res = ms.flux - pf * fs->flux;
-            
+
       if (_fittingModel)
 	{
 	  _photomModel->GetIndicesAndDerivatives(ms,
@@ -163,7 +163,7 @@ void PhotomFit::AccumulateStat(ListType &L, Accum &Accu) const
 #ifdef FUTURE
 	  TweakPhotomMeasurementErrors(inPos, ms, _posError);
 #endif
-	  
+
 	  double pf = _photomModel->PhotomFactor(Ccd, ms);
 	  const FittedStar *fs = ms.GetFittedStar();
 	  double res = ms.flux - pf * fs->flux;
@@ -293,7 +293,7 @@ void PhotomFit::FindOutliers(const double &NSigCut,
 	 this one contrains was already discarded. If yes, we keep this one */
       for (auto i=indices.cbegin(); i!= indices.end(); ++i)
 	if (affectedParams(*i) !=0) drop_it = false;
-      
+
       if (drop_it)
 	{
 	  for (auto i=indices.cbegin(); i!= indices.end(); ++i)
@@ -357,7 +357,7 @@ unsigned PhotomFit::RemoveOutliers(const double &NSigCut)
 	 this one contrains was already discarded. If yes, we keep this one */
       for (auto i=indices.cbegin(); i!= indices.end(); ++i)
 	if (affectedParams(*i) !=0) drop_it = false;
-      
+
       if (drop_it)
 	{
 	  FittedStar *fs = i->ms->GetFittedStar();
@@ -366,7 +366,7 @@ unsigned PhotomFit::RemoveOutliers(const double &NSigCut)
 	  /* By making sure that we do not remove all MeasuredStars
 	     pointing to a FittedStar in a single go,
 	     fs->MeasurementCount() should never go to 0.
-	     
+
 	     It seems plausible that the adopted mechanism prevents as
 	     well to end up with under-constrained transfos. */
 	  for (auto i=indices.cbegin(); i!= indices.cend(); ++i)

--- a/src/Projectionhandler.cc
+++ b/src/Projectionhandler.cc
@@ -19,7 +19,7 @@ OneTPPerShoot::OneTPPerShoot(const CcdImageList &L)
       if (tMap.find(im.Shoot()) == tMap.end())
 	tMap[im.Shoot()] = im.Sky2TP()->Clone();
     }
-    
+
 }
 
 const Gtransfo* OneTPPerShoot::Sky2TP(const CcdImage &C) const

--- a/src/RefStar.cc
+++ b/src/RefStar.cc
@@ -12,7 +12,7 @@ namespace jointcal {
 RefStar::RefStar(const BaseStar &B, const Point &RaDec)
   : BaseStar(B), index(0)
 {
-    
+
   fittedStar = (FittedStar*) NULL;
   raDec = RaDec;
 }
@@ -48,22 +48,22 @@ BaseStarList& Ref2Base(RefStarList &This)
 {
   return (BaseStarList&) This;
 }
-  
+
 BaseStarList* Ref2Base(RefStarList *This)
 {
   return (BaseStarList*) This;
 }
-  
+
 const BaseStarList& Ref2Base(const RefStarList &This)
 {
   return (const BaseStarList &) This;
 }
-  
+
 const BaseStarList* Ref2Base(const RefStarList *This)
 {
   return (BaseStarList*) This;
 }
-  
+
 
 
 /********* RefStarStuple *************/
@@ -83,7 +83,7 @@ RefStarTuple::RefStarTuple(const std::string &FileName)
 	 << "# nm : number of measurements" << std::endl
 	 << "# end " << std::endl;
     ;
-  
+
 }
 
 void RefStarTuple::AddEntry(const RefStar &R, const FittedStar &F)

--- a/src/SimplePhotomModel.cc
+++ b/src/SimplePhotomModel.cc
@@ -66,7 +66,7 @@ unsigned SimplePhotomModel::AssignIndices(const std::string &WhatToFit,  unsigne
    const PhotomStuff &pf = find(C);
    return pf.factor;
  }
-     
+
  void SimplePhotomModel::GetIndicesAndDerivatives(const MeasuredStar &M,
 						  const CcdImage &Ccd,
 						  std::vector<unsigned> &Indices,

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -140,7 +140,7 @@ PTR(TanSipPix2RaDec) SimplePolyModel::ProduceSipWcs(const CcdImage &Ccd) const
   // wcsPix2TP = cdStuff*sip , so
   GtransfoPoly sip = GtransfoPoly(cdStuff.invert())*wcsPix2Tp;
   Point tangentPoint( proj->TangentPoint());
-  return boost::shared_ptr<TanSipPix2RaDec>(new TanSipPix2RaDec(cdStuff, tangentPoint, &sip));
+  return std::shared_ptr<TanSipPix2RaDec>(new TanSipPix2RaDec(cdStuff, tangentPoint, &sip));
 }
 
 }} // end of namespaces

--- a/src/SipToGtransfo.cc
+++ b/src/SipToGtransfo.cc
@@ -18,12 +18,12 @@ static const int lsstToFitsPixels = +1;
 static const int fitsToLsstPixels = -1;
 
 typedef boost::shared_ptr<jointcal::GtransfoPoly> GtPoly_Ptr;
-	
+
 
 jointcal::TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image::TanWcs> wcs)
 {
   GtPoly_Ptr sipCorr(new jointcal::GtransfoPoly(0));
-  
+
   /* beware : Wcs::getPixelOrigin return crpix_fits +
    fitsToLsstPixels, so all the algebra we perform here happens in the
    "Lsst frame", i.e (0,0)-based. this algebra is justified in the
@@ -39,7 +39,7 @@ jointcal::TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image
       Eigen::MatrixXd sipB;
       lsst::afw::image::TanWcs::decodeSipHeader(*wcsMeta, "A", sipA);
       lsst::afw::image::TanWcs::decodeSipHeader(*wcsMeta, "B", sipB);
-  
+
       int sipOrder = std::max(wcsMeta->get<int>("A_ORDER"), wcsMeta->get<int>("B_ORDER"));
 
       jointcal::GtransfoPoly sipPoly(sipOrder);
@@ -67,7 +67,7 @@ jointcal::TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image
       GtransfoLin id; // identity is the default constructor.
       // This is what is returned by TanWcs::undistortpixel
       jointcal::GtransfoPoly actualSip = id + sipPoly*s2;
-      	
+
       sipCorr.reset(new jointcal::GtransfoPoly(actualSip));
     }
 
@@ -88,7 +88,7 @@ jointcal::TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image
   // the above line returns radians ?!
   double ra  = wcsMeta->get<double>("CRVAL1");
   double dec = wcsMeta->get<double>("CRVAL2");
-  
+
   jointcal::Point tangentPoint(ra,dec);
 
   // return jointcal::TanSipPix2RaDec(linPart, tangentPoint, sipCorr->get());
@@ -146,7 +146,7 @@ PTR(afwImg::TanWcs) GtransfoToTanWcs(const jointcal::TanSipPix2RaDec WcsTransfo,
   cdMat(0,1) = linPart.Coeff(0,1,0); // CD1_2
   cdMat(1,0) = linPart.Coeff(1,0,1); // CD2_1
   cdMat(1,1) = linPart.Coeff(0,1,1); // CD2_2
-  
+
   if (!WcsTransfo.Corr()) // the WCS has no distortions
     return boost::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval,crpix_lsst,cdMat));
 
@@ -178,7 +178,7 @@ PTR(afwImg::TanWcs) GtransfoToTanWcs(const jointcal::TanSipPix2RaDec WcsTransfo,
   jointcal::GtransfoPoly invSipStuff = (*tp2Pix)*linPart;
   delete tp2Pix;
   jointcal::GtransfoPoly sipPolyInv =  (invSipStuff -id)*s2.invert();
-  
+
   // now extract sip coefficients. First forward ones:
   int sipOrder = sipPoly.Degree();
   Eigen::MatrixXd sipA(Eigen::MatrixXd::Zero(sipOrder+1,sipOrder+1));
@@ -204,15 +204,15 @@ PTR(afwImg::TanWcs) GtransfoToTanWcs(const jointcal::TanSipPix2RaDec WcsTransfo,
       }
 
   return boost::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval, crpix_lsst, cdMat, sipA, sipB, sipAp, sipBp));
-  
+
 }
 
 }} // end of namespaces
 
-  
-   
 
 
 
-  
+
+
+
 

--- a/src/SipToGtransfo.cc
+++ b/src/SipToGtransfo.cc
@@ -17,10 +17,10 @@ namespace jointcal {
 static const int lsstToFitsPixels = +1;
 static const int fitsToLsstPixels = -1;
 
-typedef boost::shared_ptr<jointcal::GtransfoPoly> GtPoly_Ptr;
+typedef std::shared_ptr<jointcal::GtransfoPoly> GtPoly_Ptr;
 
 
-jointcal::TanSipPix2RaDec ConvertTanWcs(const boost::shared_ptr<lsst::afw::image::TanWcs> wcs)
+jointcal::TanSipPix2RaDec ConvertTanWcs(const std::shared_ptr<lsst::afw::image::TanWcs> wcs)
 {
   GtPoly_Ptr sipCorr(new jointcal::GtransfoPoly(0));
 
@@ -148,7 +148,7 @@ PTR(afwImg::TanWcs) GtransfoToTanWcs(const jointcal::TanSipPix2RaDec WcsTransfo,
   cdMat(1,1) = linPart.Coeff(0,1,1); // CD2_2
 
   if (!WcsTransfo.Corr()) // the WCS has no distortions
-    return boost::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval,crpix_lsst,cdMat));
+    return std::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval,crpix_lsst,cdMat));
 
   /* We are now given:
      - CRPIX
@@ -203,7 +203,7 @@ PTR(afwImg::TanWcs) GtransfoToTanWcs(const jointcal::TanSipPix2RaDec WcsTransfo,
 	sipBp(i,j) = sipPolyInv.Coeff(i,j,1);
       }
 
-  return boost::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval, crpix_lsst, cdMat, sipA, sipB, sipAp, sipBp));
+  return std::shared_ptr<afwImg::TanWcs>(new afwImg::TanWcs(crval, crpix_lsst, cdMat, sipA, sipB, sipAp, sipBp));
 
 }
 

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -73,7 +73,7 @@ static unsigned chi2_cleanup(StarMatchList &L,  const double Chi2Cut,
     }
   return erased;
 }
-  
+
 
 #ifdef DO_WE_NEED_IT
 static double *get_dist2_array(const StarMatchList &L, const Gtransfo &T)
@@ -215,7 +215,7 @@ Gtransfo* StarMatchList::InverseTransfo() /* it is not const although it tries n
   return inverted_transfo;
 }
 
- 
+
 void StarMatchList::CutTail(const int NKeep)
 {
 iterator si;

--- a/src/test.cc
+++ b/src/test.cc
@@ -21,7 +21,7 @@ namespace afwTable = lsst::afw::table;
 
 namespace lsst {
 namespace jointcal {
-    
+
     void test(
         lsst::afw::table::SourceCatalog const &sourceCat,
         lsst::daf::base::PropertySet const &metaData

--- a/src/test2.cc
+++ b/src/test2.cc
@@ -23,12 +23,12 @@ namespace afwTable = lsst::afw::table;
 
 namespace lsst {
 namespace jointcal {
-    
+
     test2::test2()
 {
     std::cout << "test2 constructor called " << std::endl;
 }
-    
+
 void test2::addSourceTable(
     lsst::afw::table::SourceCatalog const &sourceCat,
     lsst::daf::base::PropertySet const &metaData
@@ -41,9 +41,9 @@ void test2::addSourceTable(
 //        _sources.push_back(metaData);
         std::cout << "tuple feeded with a new source table " << std::endl;
     }
-    
+
 void test2::addMetaList(std::vector<PTR(lsst::daf::base::PropertySet)> ll) {
     std::cout << ll[0]->get<double>("LATITUDE") << std::endl;
 }
-    
+
 }} // end of namespaces

--- a/tests/testJointcal.py
+++ b/tests/testJointcal.py
@@ -10,9 +10,14 @@ import collections
 from lsst.afw import geom, coord, table
 from lsst.meas.astrom import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
 import lsst.utils
+import lsst.pex.exceptions
+from lsst.daf import persistence
 from lsst.jointcal import jointcal
 
-from lsst.daf import persistence
+try:
+    data_dir = lsst.utils.getPackageDir('validation_data_jointcal')
+except lsst.pex.exceptions.NotFoundError:
+    data_dir = None
 
 
 # for MemoryTestCase
@@ -64,7 +69,6 @@ class FakeRef(object):
 
 class JointcalTest(lsst.utils.tests.TestCase):
     def setUp(self):
-        data_dir = lsst.utils.getPackageDir('validation_data_jointcal')
         os.environ['ASTROMETRY_NET_DATA_DIR'] = os.path.join(data_dir, 'twinkles1_and_index')
 
         # position of the Twinkles run 1 catalog
@@ -94,21 +98,26 @@ class JointcalTest(lsst.utils.tests.TestCase):
         self.assertLess(rms_rel, relerr/arcsec_per_radian)
         self.assertLess(rms_abs, absolute_error)
 
+    @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('jointcal currently fails if only given one catalog!')
     def testJointCalTask_1_catalog(self):
         self.jointcalTask.run(self.catalogs[:1])
 
+    @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     def testJointCalTask_2_catalog(self):
         self._testJointCalTask(2, 8.4e-3)
 
+    @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_4_catalog(self):
         self._testJointCalTask(4, 7.8e-3)
 
+    @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_7_catalog(self):
         self._testJointCalTask(7, 7.5e-3)
 
+    @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     def testJointCalTask_10_catalog(self):
         self._testJointCalTask(10, 7.4e-3)
 

--- a/tests/testJointcal.py
+++ b/tests/testJointcal.py
@@ -1,0 +1,238 @@
+# See COPYRIGHT file at the top of the source tree.
+
+from __future__ import division, absolute_import, print_function
+
+import unittest
+import os
+import numpy as np
+import collections
+
+import eups
+
+from lsst.afw import geom, coord, table
+from lsst.meas.astrom import astrometry
+import lsst.utils
+from lsst.jointcal import jointcal
+
+from lsst.daf import persistence
+
+# We don't want the absolute astrometry to become significantly worse
+# than the single-epoch astrometry (about 0.040").
+absolute_error = 42e-3/206265
+# Set to True for a comparison plot and some diagnostic numbers.
+doPlot = False
+
+
+class FakeRef(object):
+    """A mock data ref object, with minimal functionality."""
+
+    def __init__(self, src, calexp_md, dataId):
+        self.src = src
+        self.calexp_md = calexp_md
+        # info about our "telescope"
+        # self.calexp_md.setDouble("AIRMASS", 1)
+        self.calexp_md.setDouble("MJD", 54321.)
+        # self.calexp_md.setDouble("EXPTIME", 30.)
+        self.calexp_md.setDouble("LST", 53.00914)
+        self.calexp_md.setDouble("RA2000", 53.00914)
+        self.calexp_md.setDouble("DEC2000", -27.43895)
+
+        self.dataId = dataId
+        self.dataId['ccd'] = 1
+        self.dataId['tract'] = 1
+
+    def get(self, name, immediate=True):
+        return getattr(self, name)
+
+    def put(self, value, name):
+        setattr(self, name, value)
+
+    def getButler(self):
+        class NamedThing(object):
+            def __init__(self, name):
+                self.name = name
+
+            def getName(self):
+                return self.name
+
+        return {'camera': NamedThing('monkeySim')}
+
+
+class JointcalTest(lsst.utils.tests.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Can only do the eups setup once, so have to do it here only."""
+
+        # NOTE: this may be cheating? How else should I do this?
+        jointcal_reference_dir = os.path.join(os.environ['VALIDATION_DATA_JOINTCAL_DIR'],
+                                              'twinkles1_and_index')
+        eups.setup('astrometry_net_data', productRoot=jointcal_reference_dir)
+
+    def setUp(self):
+
+        data_dir = os.environ['VALIDATION_DATA_JOINTCAL_DIR']
+
+        # position of the Twinkles run 1 catalog
+        center = coord.IcrsCoord(53.00914*geom.degrees, -27.43895*geom.degrees)
+        r = geom.Angle(3, geom.degrees)
+        astrometryTask = astrometry.AstrometryTask()
+        reference = astrometryTask.refObjLoader.loadSkyCircle(center, r, filterName='r')
+        self.reference = reference.refCat.copy()  # for in-memory contiguity.
+
+        # Get a set of source catalogs.
+        self.catalogs = []
+        butler = persistence.Butler(os.path.join(data_dir, 'twinkles1'))
+        for visit in butler.queryMetadata('src', 'visit'):
+            src = butler.get('src', dataId={'visit': visit})
+            dataId = butler.dataRef('src', visit=visit).dataId
+            calexp_md = butler.get('calexp_md', {'visit': visit, 'raft': '2,2', 'sensor': '1,1'})
+            self.catalogs.append(FakeRef(src, calexp_md, dataId))
+
+        self.jointcalTask = jointcal.JointcalTask()
+
+    @unittest.skip('jointcal currently fails if only given one catalog!')
+    def testJointCalTask_1_catalog(self):
+        self.jointcalTask.run(self.catalogs[:1])
+
+    def testJointCalTask_2_catalog(self):
+        ncat = 2
+        self.jointcalTask.run(self.catalogs[:ncat])
+        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
+        # NOTE: this number come from an initial jointcal run.
+        self.assertLess(rms_rel, 8.4e-3/206265)
+        self.assertLess(rms_abs, absolute_error)
+
+    @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
+    def testJointCalTask_4_catalog(self):
+        ncat = 4
+        self.jointcalTask.run(self.catalogs[:ncat])
+        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
+        # NOTE: this number come from an initial jointcal run.
+        self.assertLess(rms_rel, 7.8e-3/206265)
+        self.assertLess(rms_abs, absolute_error)
+
+    @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
+    def testJointCalTask_7_catalog(self):
+        ncat = 7
+        self.jointcalTask.run(self.catalogs[:ncat])
+        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
+        # NOTE: this number come from an initial jointcal run.
+        self.assertLess(rms_rel, 7.5e-3/206265)
+        self.assertLess(rms_abs, absolute_error)
+
+    def testJointCalTask_10_catalog(self):
+        ncat = 10
+        self.jointcalTask.run(self.catalogs[:ncat])
+        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
+        # NOTE: this number comes from an initial jointcal run.
+        self.assertLess(rms_rel, 7.4e-3/206265)
+        self.assertLess(rms_abs, absolute_error)
+
+
+def rms_per_star(data):
+    """Compute the RMS/catalog star; data is a dict of lists of distances."""
+    result = np.empty(len(data))
+    for i, k in enumerate(data):
+        result[i] = np.sqrt(np.mean(np.array(data[k])**2))
+    return result
+
+
+def rms_total(data):
+    """Compute the total rms across all stars."""
+    n = 0
+    total = 0
+    for i, k in enumerate(data):
+        total += sum(np.array(data[k])**2)
+        n += len(data[k])
+    return np.sqrt(total/n)
+
+
+def make_match_dict(reference, catalogs, radius=0.1*geom.arcseconds, fluxlimit=100):
+    """Make a dict of object:delta of all the cross-catalog matches, to calculate the RMS across."""
+
+    deltas = collections.defaultdict(list)
+    for cat in catalogs:
+        good = (cat.src.get('base_PsfFlux_flux')/cat.src.get('base_PsfFlux_fluxSigma')) > fluxlimit
+        # things the classifier called stars.
+        good &= (cat.src.get('base_ClassificationExtendedness_value') == 0)
+        matches = table.matchRaDec(reference, cat.src[good], radius)
+        for m in matches:
+            deltas[m[0].getId()].append(m[2])
+    return deltas
+
+
+# NOTE: Stolen from meas_astrom.fitTanSipWcs.
+def updateSourceCoords(wcs, catalog):
+    """Update coords in a collection of sources, given a WCS."""
+    schema = catalog.src.schema
+    srcCoordKey = table.CoordKey(schema["coord"])
+    for src in catalog.src:
+        src.set(srcCoordKey, wcs.pixelToSky(src.getCentroid()))
+
+
+def compute_rms(reference, catalogs, fluxlimit=100):
+    """Match all catalogs to compute the RMS, for all detections above some flux limit."""
+
+    old_relative = make_match_dict(catalogs[0].src, catalogs[1:])
+    old_absolute = make_match_dict(reference, catalogs, fluxlimit=fluxlimit)
+    # Update coordinates with the new distortion corrections.
+    for cat in catalogs:
+        updateSourceCoords(cat.wcs.getWcs(), cat)
+    new_relative = make_match_dict(catalogs[0].src, catalogs[1:])
+    new_absolute = make_match_dict(reference, catalogs)
+
+    if doPlot:
+        old_rms_relative = rms_per_star(old_relative)
+        old_rms_absolute = rms_per_star(old_absolute)
+        new_rms_relative = rms_per_star(new_relative)
+        new_rms_absolute = rms_per_star(new_absolute)
+        print(len(catalogs))
+        print("relative RMS:", rms_total(old_relative)*206265, rms_total(new_relative)*206265)
+        print("absolute RMS:", rms_total(old_absolute)*206265, rms_total(new_absolute)*206265)
+        plot_deltas(old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_absolute)
+
+    return rms_total(new_relative), rms_total(new_absolute)
+
+
+def plot_deltas(old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_absolute):
+    import matplotlib.pyplot as plt
+    plt.ion()
+
+    plt.figure()
+
+    color_rel = 'green'
+    color_abs = 'blue'
+    plt.title('relative vs. absolute: %d vs. %d'%(len(old_rms_relative), len(old_rms_absolute)))
+
+    # 206265 arcseconds per radian
+    plt.hist(old_rms_relative*206265, color=color_rel, ls='dashed', label='old rel',
+             histtype='step', bins=30, lw=1.5)
+    plt.hist(new_rms_relative*206265, color=color_rel, ls='solid', label='new rel',
+             histtype='step', bins=30, lw=1.5)
+
+    plt.hist(old_rms_absolute*206265, color=color_abs, ls='dashed', label='old abs',
+             histtype='step', bins=30, lw=1.5)
+    plt.hist(new_rms_absolute*206265, color=color_abs, ls='solid', label='new abs',
+             histtype='step', bins=30, lw=1.5)
+
+    plt.xlabel('arcseconds')
+    plt.legend(loc='best')
+
+    # So one can muck-about with things after plotting...
+    import ipdb
+    ipdb.set_trace()
+
+
+def suite():
+    lsst.utils.tests.init()
+    suites = []
+    suites += unittest.makeSuite(JointcalTest)
+    # suites += unittest.makeSuite(lsst.utils.tests.MemoryTestCase)
+    return unittest.TestSuite(suites)
+
+
+def run(shouldExit=False):
+    lsst.utils.tests.run(suite(), shouldExit)
+
+if __name__ == "__main__":
+    run(True)

--- a/tests/testJointcal.py
+++ b/tests/testJointcal.py
@@ -7,18 +7,22 @@ import os
 import numpy as np
 import collections
 
-import eups
-
 from lsst.afw import geom, coord, table
-from lsst.meas import astrom
+from lsst.meas.astrom import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
 import lsst.utils
 from lsst.jointcal import jointcal
 
 from lsst.daf import persistence
 
+
+# for MemoryTestCase
+def setup_module(module):
+    lsst.utils.tests.init()
+
 # We don't want the absolute astrometry to become significantly worse
 # than the single-epoch astrometry (about 0.040").
-absolute_error = 42e-3/206265
+arcsec_per_radian = 206265.
+absolute_error = 42e-3/arcsec_per_radian
 # Set to True for a comparison plot and some diagnostic numbers.
 doPlot = False
 
@@ -59,26 +63,16 @@ class FakeRef(object):
 
 
 class JointcalTest(lsst.utils.tests.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        """Can only do the eups setup once, so have to do it here only."""
-
-        # NOTE: this may be cheating? How else should I do this?
-        jointcal_reference_dir = os.path.join(os.environ['VALIDATION_DATA_JOINTCAL_DIR'],
-                                              'twinkles1_and_index')
-        eups.setup('astrometry_net_data', productRoot=jointcal_reference_dir)
-
     def setUp(self):
-
-        data_dir = os.environ['VALIDATION_DATA_JOINTCAL_DIR']
+        data_dir = lsst.utils.getPackageDir('validation_data_jointcal')
+        os.environ['ASTROMETRY_NET_DATA_DIR'] = os.path.join(data_dir, 'twinkles1_and_index')
 
         # position of the Twinkles run 1 catalog
         center = coord.IcrsCoord(53.00914*geom.degrees, -27.43895*geom.degrees)
         r = geom.Angle(3, geom.degrees)
-        config = astrom.LoadAstrometryNetObjectsTask.ConfigClass()
-        refLoader = astrom.LoadAstrometryNetObjectsTask(config=config)
-        reference = refLoader.loadSkyCircle(center, r, filterName='r')
-        self.reference = reference.refCat.copy()  # for in-memory contiguity.
+        refLoader = LoadAstrometryNetObjectsTask(LoadAstrometryNetObjectsConfig())
+        # Make a copy of the reference catalog for in-memory contiguity.
+        self.reference = refLoader.loadSkyCircle(center, r, filterName='r').refCat.copy()
 
         # Get a set of source catalogs.
         self.catalogs = []
@@ -91,47 +85,42 @@ class JointcalTest(lsst.utils.tests.TestCase):
 
         self.jointcalTask = jointcal.JointcalTask()
 
+    def _testJointCalTask(self, nCatalogs, relerr):
+        """Test jointcal on nCatalogs, requiring < some relative error (arcsec)."""
+
+        self.jointcalTask.run(self.catalogs[:nCatalogs])
+        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:nCatalogs], fluxlimit=100)
+        # NOTE: this number come from an initial jointcal run.
+        self.assertLess(rms_rel, relerr/arcsec_per_radian)
+        self.assertLess(rms_abs, absolute_error)
+
     @unittest.skip('jointcal currently fails if only given one catalog!')
     def testJointCalTask_1_catalog(self):
         self.jointcalTask.run(self.catalogs[:1])
 
     def testJointCalTask_2_catalog(self):
-        ncat = 2
-        self.jointcalTask.run(self.catalogs[:ncat])
-        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
-        # NOTE: this number come from an initial jointcal run.
-        self.assertLess(rms_rel, 8.4e-3/206265)
-        self.assertLess(rms_abs, absolute_error)
+        self._testJointCalTask(2, 8.4e-3)
 
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_4_catalog(self):
-        ncat = 4
-        self.jointcalTask.run(self.catalogs[:ncat])
-        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
-        # NOTE: this number come from an initial jointcal run.
-        self.assertLess(rms_rel, 7.8e-3/206265)
-        self.assertLess(rms_abs, absolute_error)
+        self._testJointCalTask(4, 7.8e-3)
 
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_7_catalog(self):
-        ncat = 7
-        self.jointcalTask.run(self.catalogs[:ncat])
-        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
-        # NOTE: this number come from an initial jointcal run.
-        self.assertLess(rms_rel, 7.5e-3/206265)
-        self.assertLess(rms_abs, absolute_error)
+        self._testJointCalTask(7, 7.5e-3)
 
     def testJointCalTask_10_catalog(self):
-        ncat = 10
-        self.jointcalTask.run(self.catalogs[:ncat])
-        rms_rel, rms_abs = compute_rms(self.reference, self.catalogs[:ncat], fluxlimit=100)
-        # NOTE: this number comes from an initial jointcal run.
-        self.assertLess(rms_rel, 7.4e-3/206265)
-        self.assertLess(rms_abs, absolute_error)
+        self._testJointCalTask(10, 7.4e-3)
 
 
 def rms_per_star(data):
-    """Compute the RMS/catalog star; data is a dict of lists of distances."""
+    """
+    Compute the RMS/catalog star
+
+    @param data (dict) dict of starID:list(measurement deltas for that star)
+
+    @return (np.array) the rms for each starID (no guaranteed order)
+    """
     result = np.empty(len(data))
     for i, k in enumerate(data):
         result[i] = np.sqrt(np.mean(np.array(data[k])**2))
@@ -139,7 +128,13 @@ def rms_per_star(data):
 
 
 def rms_total(data):
-    """Compute the total rms across all stars."""
+    """
+    Compute the total rms across all stars.
+
+    @param data (dict) dict of starID:list(measurement deltas for that star)
+
+    @return (int) the total rms across all stars
+    """
     n = 0
     total = 0
     for i, k in enumerate(data):
@@ -149,7 +144,16 @@ def rms_total(data):
 
 
 def make_match_dict(reference, catalogs, radius=0.1*geom.arcseconds, fluxlimit=100):
-    """Make a dict of object:delta of all the cross-catalog matches, to calculate the RMS across."""
+    """
+    Return a dict of starID:[distances] over the catalogs, for RMS calculations.
+
+    @param reference the reference catalog to use for absolute object positions
+    @param catalogs (list) the catalogs to do the relative matching between
+    @param radius (float arcseonds) source matching radius
+    @param fluxlimit (float) SN (flux/fluxSigma) for sources to be included in match.
+
+    @return (dict) dict of starID:list(measurement deltas for that star)
+    """
 
     deltas = collections.defaultdict(list)
     for cat in catalogs:
@@ -172,7 +176,15 @@ def updateSourceCoords(wcs, catalog):
 
 
 def compute_rms(reference, catalogs, fluxlimit=100):
-    """Match all catalogs to compute the RMS, for all detections above some flux limit."""
+    """
+    Match all catalogs to compute the RMS, for all detections above some flux limit.
+
+    @param reference the reference catalog to use for absolute object positions
+    @param catalogs (list) the catalogs to do the relative matching between
+    @param fluxlimit (float) SN (flux/fluxSigma) for sources to be included in match.
+
+    @return (float, float) relative, absolute RMS of stars, in radians
+    """
 
     old_relative = make_match_dict(catalogs[0].src, catalogs[1:])
     old_absolute = make_match_dict(reference, catalogs, fluxlimit=fluxlimit)
@@ -188,8 +200,10 @@ def compute_rms(reference, catalogs, fluxlimit=100):
         new_rms_relative = rms_per_star(new_relative)
         new_rms_absolute = rms_per_star(new_absolute)
         print(len(catalogs))
-        print("relative RMS:", rms_total(old_relative)*206265, rms_total(new_relative)*206265)
-        print("absolute RMS:", rms_total(old_absolute)*206265, rms_total(new_absolute)*206265)
+        print("relative RMS:", rms_total(old_relative)*arcsec_per_radian,
+              rms_total(new_relative)*arcsec_per_radian)
+        print("absolute RMS:", rms_total(old_absolute)*arcsec_per_radian,
+              rms_total(new_absolute)*arcsec_per_radian)
         plot_deltas(old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_absolute)
 
     return rms_total(new_relative), rms_total(new_absolute)
@@ -205,15 +219,14 @@ def plot_deltas(old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_ab
     color_abs = 'blue'
     plt.title('relative vs. absolute: %d vs. %d'%(len(old_rms_relative), len(old_rms_absolute)))
 
-    # 206265 arcseconds per radian
-    plt.hist(old_rms_relative*206265, color=color_rel, ls='dashed', label='old rel',
+    plt.hist(old_rms_relative*arcsec_per_radian, color=color_rel, ls='dashed', label='old rel',
              histtype='step', bins=30, lw=1.5)
-    plt.hist(new_rms_relative*206265, color=color_rel, ls='solid', label='new rel',
+    plt.hist(new_rms_relative*arcsec_per_radian, color=color_rel, ls='solid', label='new rel',
              histtype='step', bins=30, lw=1.5)
 
-    plt.hist(old_rms_absolute*206265, color=color_abs, ls='dashed', label='old abs',
+    plt.hist(old_rms_absolute*arcsec_per_radian, color=color_abs, ls='dashed', label='old abs',
              histtype='step', bins=30, lw=1.5)
-    plt.hist(new_rms_absolute*206265, color=color_abs, ls='solid', label='new abs',
+    plt.hist(new_rms_absolute*arcsec_per_radian, color=color_abs, ls='solid', label='new abs',
              histtype='step', bins=30, lw=1.5)
 
     plt.xlabel('arcseconds')
@@ -224,16 +237,11 @@ def plot_deltas(old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_ab
     ipdb.set_trace()
 
 
-def suite():
-    lsst.utils.tests.init()
-    suites = []
-    suites += unittest.makeSuite(JointcalTest)
-    # suites += unittest.makeSuite(lsst.utils.tests.MemoryTestCase)
-    return unittest.TestSuite(suites)
+# TODO: the memory test cases currently fail in jointcal. I'll have to clean that up later.
+# class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+#     pass
 
-
-def run(shouldExit=False):
-    lsst.utils.tests.run(suite(), shouldExit)
 
 if __name__ == "__main__":
-    run(True)
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testJointcal.py
+++ b/tests/testJointcal.py
@@ -10,7 +10,7 @@ import collections
 import eups
 
 from lsst.afw import geom, coord, table
-from lsst.meas.astrom import astrometry
+from lsst.meas import astrom
 import lsst.utils
 from lsst.jointcal import jointcal
 
@@ -75,8 +75,9 @@ class JointcalTest(lsst.utils.tests.TestCase):
         # position of the Twinkles run 1 catalog
         center = coord.IcrsCoord(53.00914*geom.degrees, -27.43895*geom.degrees)
         r = geom.Angle(3, geom.degrees)
-        astrometryTask = astrometry.AstrometryTask()
-        reference = astrometryTask.refObjLoader.loadSkyCircle(center, r, filterName='r')
+        config = astrom.LoadAstrometryNetObjectsTask.ConfigClass()
+        refLoader = astrom.LoadAstrometryNetObjectsTask(config=config)
+        reference = refLoader.loadSkyCircle(center, r, filterName='r')
         self.reference = reference.refCat.copy()  # for in-memory contiguity.
 
         # Get a set of source catalogs.

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -1,7 +1,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #define BOOST_TEST_MODULE test_trans
- 
+
 //The boost unit test header
 #include "boost/test/unit_test.hpp"
 
@@ -39,25 +39,25 @@ BOOST_AUTO_TEST_SUITE(test_transfos)
 
 BOOST_AUTO_TEST_CASE(test_wcs)
 {
-  
+
   std::string fileName = "tests/header_only.fits";
 
   lsst::afw::fits::Fits file(fileName, "r",0);
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
-  
+
   const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
-  
+
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
   jointcal::Point where(100.,200.);
   jointcal::Point outPol = gtransfoWcs.apply(where);
   std::cout << std::setprecision(12) << "Poloka : " << outPol.x << ' ' << outPol.y << std::endl;
-  
+
   lsst::afw::geom::Point2D whereSame(100.,200.);
   PTR(lsst::afw::coord::Coord) coord = wcs->pixelToSky(whereSame);
   lsst::afw::geom::Point2D outDeg = coord->getPosition(lsst::afw::geom::degrees);
   std::cout << "Stack : " << outDeg[0] << ' ' << outDeg[1] << std::endl;
-  
+
   BOOST_CHECK_CLOSE(outPol.x, outDeg[0], .000001);
   BOOST_CHECK_CLOSE(outPol.y, outDeg[1], .000001);
 
@@ -74,9 +74,9 @@ BOOST_AUTO_TEST_CASE(test_polyfit)
   lsst::afw::fits::Fits file(fileName, "r",0);
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
-  
+
   const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
-  
+
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
 
   jointcal::StarMatchList sml;
@@ -113,9 +113,9 @@ BOOST_AUTO_TEST_CASE(test_wcs_convertions)
   lsst::afw::fits::Fits file(fileName, "r",0);
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
-  
+
   const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
-  
+
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
   int naxis1 = propSet->get<int>("NAXIS1");
   int naxis2 = propSet->get<int>("NAXIS2");

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(test_wcs)
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
 
-  const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
+  const PTR(afwImg::TanWcs) tanWcs = std::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
 
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
   jointcal::Point where(100.,200.);
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_polyfit)
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
 
-  const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
+  const PTR(afwImg::TanWcs) tanWcs = std::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
 
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
 
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(test_wcs_convertions)
   PTR(lsst::daf::base::PropertySet) propSet = afwImg::readMetadata(fileName);
   PTR(afwImg::Wcs) wcs = afwImg::makeWcs(propSet);
 
-  const PTR(afwImg::TanWcs) tanWcs = boost::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
+  const PTR(afwImg::TanWcs) tanWcs = std::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
 
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::ConvertTanWcs(tanWcs);
   int naxis1 = propSet->get<int>("NAXIS1");

--- a/ups/jointcal.table
+++ b/ups/jointcal.table
@@ -11,6 +11,9 @@ setupRequired(meas_algorithms)
 setupRequired(pipe_tasks)
 setupRequired(jointcal_cholmod)
 
+# for the testing files
+setupOptional(validation_data_jointcal)
+
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 envPrepend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 envPrepend(LSST_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
Jointcal now runs on some lsstSim data (twinkles 1), and includes a pseudo-validation test, to check that the astrometric fits improve as we add more images. There are several hacks to get around the metadata problems that I will deal with in a separate ticket.