### PR TITLE
Improve jointcal plotting backend Tickets/dm 7444

### DIFF
--- a/bin.src/plot_jointcal_results.py
+++ b/bin.src/plot_jointcal_results.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# See COPYRIGHT file at the top of the source tree.
+"""
+Generate plots from the results of a jointcal run.
+
+Requires a butler repository that has had jointcal successfully run on it, which
+produces a new "wcs" component of the repository.
+"""
+
+import os
+
+import lsst.daf.persistence
+from lsst.meas.astrom import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
+import lsst.afw.image
+from lsst.afw.geom import degrees
+
+from lsst.jointcal import utils
+
+
+def get_valid_dataIds(butler, dataset_type='wcs'):
+    """Return a list of all dataIds that exist in this butler."""
+    data_ids = []
+    for data_ref in butler.subset(dataset_type):
+        if data_ref.datasetExists():
+            data_ids.append(data_ref.dataId)
+    return data_ids
+
+
+def prep_reference_loader(center, radius):
+    """
+    Return an astrometry.net reference loader.
+
+    Parameters
+    ----------
+    center: afw.coord
+        The center of the field you're testing on.
+    radius: afw.geom.angle
+        The radius to load objects around center.
+    """
+    refLoader = LoadAstrometryNetObjectsTask(LoadAstrometryNetObjectsConfig())
+    # Make a copy of the reference catalog for in-memory contiguity.
+    return refLoader.loadSkyCircle(center, radius, filterName='r').refCat.copy()
+
+
+def get_old_wcs_list(data_refs):
+    """Return a list of the original WCSs of the data_refs."""
+    result = []
+    for data_ref in data_refs:
+        md = data_ref.get("calexp_md", immediate=True)
+        tanwcs = lsst.afw.image.TanWcs.cast(lsst.afw.image.makeWcs(md))
+        result.append(tanwcs)
+    return result
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("repo", metavar="repo", help="Directory containing butler repository.")
+    parser.add_argument("refcat", metavar="refcat", help="Directory of reference catalog to match against.")
+    parser.add_argument("ra", default=None, type=float, nargs='?',
+                        help="Decimal degrees center RA of catalog (default uses center of first visit).")
+    parser.add_argument("dec", default=None, type=float, nargs='?',
+                        help="Decimal degrees center Dec of catalog (default uses center of first visit).")
+    parser.add_argument("radius", default=6., type=float, nargs='?',
+                        help="Radius (degrees) of sources to load from reference catalog.")
+    parser.add_argument("-i", "--interactive", action="store_true",
+                        help="Use interactive matplotlib backend and set ion(), in addition to saving files.")
+    parser.add_argument("-o", "--outdir", default=".plots",
+                        help="output directory for plots (default: $(default)s)")
+    args = parser.parse_args()
+
+    butler = lsst.daf.persistence.Butler(inputs=args.repo)
+    dataIds = get_valid_dataIds(butler)
+
+    data_refs = [butler.dataRef('wcs', dataId=dataId) for dataId in dataIds]
+    visits = [data_ref.dataId['visit'] for data_ref in data_refs]
+    old_wcs_list = get_old_wcs_list(data_refs)
+
+    os.environ['ASTROMETRY_NET_DATA_DIR'] = args.refcat
+    if args.ra is None or args.dec is None:
+        calexp = data_refs[0].get('calexp')
+        center = calexp.getInfo().getVisitInfo().getBoresightRaDec()
+    else:
+        center = (args.ra, args.dec)
+
+    reference = prep_reference_loader(center, args.radius*degrees)
+
+    jointcalStatistics = utils.JointcalStatistics()
+    jointcalStatistics.compute_rms(data_refs, visits, reference)
+
+    name = os.path.basename(os.path.normpath(args.repo))
+    jointcalStatistics.make_plots(data_refs, visits, old_wcs_list, name=name,
+                                  interactive=args.interactive, outdir=args.outdir)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/lsst/jointcal/utils.py
+++ b/python/lsst/jointcal/utils.py
@@ -1,0 +1,392 @@
+# See COPYRIGHT file at the top of the source tree.
+"""
+Statistics of jointcal vs. single-frame procesing and diagnostic plots.
+
+NOTE: some of the algorithms and data structures in this code are temporary
+kludges and will no longer be necessary once the following are available:
+ * a composite data structure that contains all ccds from a single visit
+ * an n-way matching system that preserves the separations between sources
+"""
+import collections
+import os
+
+import numpy as np
+from astropy import units as u
+
+import lsst.log
+import lsst.afw.table
+from lsst.afw.geom import arcseconds
+
+
+class JointcalStatistics(object):
+    """Compute statistics on jointcal-processed data, and optionally generate plots."""
+
+    def __init__(self, match_radius=0.1*arcseconds, flux_limit=100.):
+        """
+        Parameters
+        ----------
+        match_radius : lsst.afw.Angle
+            match sources within this radius for RMS statistics
+        flux_limit : float
+            Signal/Noise (flux/fluxSigma) for sources to be included in the RMS cross-match.
+            100 is a balance between good centroids and enough sources.
+        """
+        self.match_radius = match_radius
+        self.flux_limit = flux_limit
+        self.log = lsst.log.Log.getLogger('JointcalStatistics')
+
+    def compute_rms(self, data_refs, visit_list, reference):
+        """
+        Match all data_refs to compute the RMS, for all detections above self.flux_limit.
+
+        Parameters
+        ----------
+        data_refs : list of lsst.daf.persistence.butlerSubset.ButlerDataRef
+            A list of data refs to do the calculations between.
+        visit_list : list of visit id (usually int)
+            list of visit identifiers to do the catalog merge on.
+        reference : lsst reference catalog
+            reference catalog to do absolute matching against.
+
+        Return
+        ------
+        geom.Angle
+            New relative RMS of the matched sources.
+        geom.Angle
+            New absolute RMS of matched sources.
+        """
+        visits_per_dataRef = [dataRef.dataId['visit'] for dataRef in data_refs]
+
+        def compute(catalogs):
+            """Compute the relative and absolute RMS."""
+            visit_catalogs = self._make_visit_catalogs(catalogs, visits_per_dataRef, visit_list)
+            refcat = visit_catalogs.values()[0]  # use the first catalog as the relative reference catalog
+            relative = self._make_match_dict(refcat, visit_catalogs.values()[1:])
+            absolute = self._make_match_dict(reference, visit_catalogs.values())
+            return visit_catalogs, relative, absolute
+
+        old_cats = [dataRef.get('src') for dataRef in data_refs]
+        visit_catalogs, self.old_relative, self.old_absolute = compute(old_cats)
+
+        # Update coordinates with the new wcs including distortion corrections.
+        new_cats = []
+        for dataRef in data_refs:
+            new_cats.append(dataRef.get('src'))
+            lsst.afw.table.utils.updateSourceCoords(dataRef.get('wcs').getWcs(), new_cats[-1])
+        visistCatalogs, self.new_relative, self.new_absolute = compute(new_cats)
+
+        self.old_rel_total = rms_total(self.old_relative)
+        self.new_rel_total = rms_total(self.new_relative)
+        self.old_abs_total = rms_total(self.old_absolute)
+        self.new_abs_total = rms_total(self.new_absolute)
+
+        return self.new_rel_total, self.new_abs_total
+
+    def make_plots(self, data_refs, visit_catalogs, old_wcs_list, name='',
+                   interactive=False, per_ccd_plot=False, outdir='.plots'):
+        """
+        Make plots of various quantites to help with debugging.
+        Requires that `compute_rms()` was run first.
+
+        Parameters
+        ----------
+        data_refs : list of lsst.daf.persistence.butlerSubset.ButlerDataRef
+            A list of data refs to do the calculations between.
+        visit_catalogs : list of lsst.afw.table.SourceCatalog
+            visit source catalogs (values() produced by _make_visit_catalogs) to cross-match.
+        old_wcs_list : list of lsst.afw.image.wcs.Wcs
+            A list of the old (pre-jointcal) WCSs, one-to-one corresponding to data_refs.
+        name : str
+            Name to include in plot titles and save files.
+        interactive : bool
+            Turn on matplotlib interactive mode and drop into a debugger when
+            plotting is finished. Otherwise, use a non-interactive backend.
+        per_ccd_plot : bool
+            Plot the WCS per CCD (takes longer and generates many plots for a large camera)
+        outdir : str
+            directory to save plots to.
+        """
+        import matplotlib
+        if not interactive:
+            # Use a non-interactive backend for faster plotting.
+            matplotlib.use('pdf')
+
+        import matplotlib.pyplot as plt
+        import astropy.visualization
+        # make quantities behave nicely when plotted.
+        astropy.visualization.quantity_support()
+        if interactive:
+            plt.ion()
+
+        old_rms_relative = rms_per_source(self.old_relative)
+        old_rms_absolute = rms_per_source(self.old_absolute)
+        new_rms_relative = rms_per_source(self.new_relative)
+        new_rms_absolute = rms_per_source(self.new_absolute)
+        self.log.info("N data_refs: %d", len(data_refs))
+        self.log.info("relative RMS (old, new): {:.2e} {:.2e}".format(self.old_rel_total, self.new_rel_total))
+        self.log.info("absolute RMS (old, new): {:.2e} {:.2e}".format(self.old_abs_total, self.new_abs_total))
+        plot_rms_histogram(plt, old_rms_relative, old_rms_absolute,
+                           new_rms_relative, new_rms_absolute,
+                           self.old_rel_total, self.old_abs_total,
+                           self.new_rel_total, self.new_abs_total, name, outdir=outdir)
+
+        plot_all_wcs_deltas(plt, data_refs, visit_catalogs, old_wcs_list, name,
+                            outdir=outdir, per_ccd_plot=per_ccd_plot)
+
+        if interactive:
+            plt.show()
+            import pdb
+            pdb.set_trace()
+
+    def _make_match_dict(self, reference, visit_catalogs):
+        """
+        Return a dict of sourceID:[distances] over the catalogs, for RMS calculations.
+
+        Parameters
+        ----------
+        reference : lsst.afw.table.SourceCatalog
+            Catalog to do the matching against.
+        visit_catalogs : list of lsst.afw.table.SourceCatalog
+            Visit source catalogs (values() produced by _make_visit_catalogs)
+            to cross-match against reference.
+
+        Returns
+        -------
+        dict
+            dict of sourceID:list(separation distances for that source)
+        """
+
+        deltas = collections.defaultdict(list)
+        for cat in visit_catalogs:
+            good = (cat.get('base_PsfFlux_flux')/cat.get('base_PsfFlux_fluxSigma')) > self.flux_limit
+            # things the classifier called sources are not extended.
+            good &= (cat.get('base_ClassificationExtendedness_value') == 0)
+            matches = lsst.afw.table.matchRaDec(reference, cat[good], self.match_radius)
+            for m in matches:
+                deltas[m[0].getId()].append(m[2])
+        return deltas
+
+    def _make_visit_catalogs(self, catalogs, visits, visit_list):
+        """
+        Merge all catalogs from the each visit.
+        NOTE: creating this structure is somewhat slow, and will be unnecessary
+        once a full-visit composite dataset is available.
+
+        Parameters
+        ----------
+        catalogs : list of lsst.afw.table.SourceCatalog
+            Catalogs to combine into per-visit catalogs.
+        visits : list of visit id (usually int)
+            list of visit identifiers, one-to-one correspondant with catalogs.
+        visit_list : list of visit id (usually int)
+            list of visit identifiers to do the catalog merge on (a proper subset of visits).
+
+        Returns
+        -------
+        dict
+            dict of visit: catalog of all sources from all CCDs of that visit.
+        """
+        visit_dict = {v: lsst.afw.table.SourceCatalog(catalogs[0].schema) for v in visit_list}
+        for v, cat in zip(visits, catalogs):
+            visit_dict[v].extend(cat)
+        # We want catalog contiguity to do object selection later.
+        for v in visit_dict:
+            visit_dict[v] = visit_dict[v].copy(deep=True)
+
+        return visit_dict
+
+
+def rms_per_source(data):
+    """
+    Compute the RMS for each catalog source.
+
+    Parameters
+    ----------
+    data : dict
+        dict of sourceID:list(measurement deltas for that source)
+
+    Returns
+    -------
+    np.array of astropy.units.arcsecond
+        the RMS for each sourceID (no guaranteed order)
+    """
+    return (np.sqrt(np.array([np.mean(np.array(dd)**2) for dd in data.values()]))*u.radian).to(u.arcsecond)
+
+
+def rms_total(data):
+    """
+    Compute the total rms across all sources.
+    Parameters
+    ----------
+    data : dict
+        dict of sourceID:list(measurement deltas for that source)
+
+    Returns
+    -------
+    astropy.units.arcsecond
+        the total rms across all sources
+    """
+    total = sum(sum(np.array(dd)**2) for dd in data.values())
+    n = sum(len(dd) for dd in data.values())
+    return (np.sqrt(total/n) * u.radian).to(u.arcsecond)
+
+
+def plot_all_wcs_deltas(plt, data_refs, visit_catalogs, old_wcs_list, name,
+                        per_ccd_plot=False, outdir='.plots'):
+    """Various plots of the difference between old and new Wcs."""
+
+    plot_wcs_magnitude(plt, data_refs, visit_catalogs, old_wcs_list, name, outdir=outdir)
+    plot_all_wcs_quivers(plt, data_refs, visit_catalogs, old_wcs_list, name, outdir=outdir)
+
+    if per_ccd_plot:
+        for i, ref in enumerate(data_refs):
+            md = ref.get('calexp_md')
+            plot_wcs(plt, old_wcs_list[i], ref.get('wcs').getWcs(),
+                     dim=(md.get('NAXIS1'), md.get('NAXIS1')),
+                     center=(md.get('CRVAL1'), md.get('CRVAL2')), name='dataRef %d'%i,
+                     outdir=outdir)
+
+
+def make_xy_wcs_grid(dim, wcs1, wcs2, num=50):
+    """Return num x/y grid coordinates for wcs1 and wcs2."""
+    x = np.linspace(0, dim[0], num)
+    y = np.linspace(0, dim[1], num)
+    x1, y1 = wcs_convert(x, y, wcs1)
+    x2, y2 = wcs_convert(x, y, wcs2)
+    return x1, y1, x2, y2
+
+
+def wcs_convert(xv, yv, wcs):
+    """Convert two arrays of x/y points into an on-sky grid."""
+    xout = np.zeros((xv.shape[0], yv.shape[0]))
+    yout = np.zeros((xv.shape[0], yv.shape[0]))
+    for i, x in enumerate(xv):
+        for j, y in enumerate(yv):
+            sky = wcs.pixelToSky(x, y).toFk5()
+            xout[i, j] = sky.getRa()
+            yout[i, j] = sky.getDec()
+    return xout, yout
+
+
+def plot_all_wcs_quivers(plt, data_refs, visit_catalogs, old_wcs_list, name, outdir='.plots'):
+    """Make quiver plots of the WCS deltas for each CCD in each visit."""
+
+    for cat in visit_catalogs:
+        fig = plt.figure()
+        # fig.set_tight_layout(True)
+        ax = fig.add_subplot(111)
+        for old_wcs, ref in zip(old_wcs_list, data_refs):
+            if ref.dataId['visit'] != cat:
+                continue
+            md = ref.get('calexp_md')
+            Q = plot_wcs_quivers(ax, old_wcs, ref.get('wcs').getWcs(),
+                                 dim=(md.get('NAXIS1'), md.get('NAXIS2')))
+            # TODO: add CCD bounding boxes to plot once DM-5503 is finished.
+            # TODO: add a circle for the full focal plane.
+        length = (0.1*u.arcsecond).to(u.radian).value
+        ax.quiverkey(Q, 0.9, 0.95, length, '0.1 arcsec', coordinates='figure', labelpos='W')
+        plt.xlabel('RA')
+        plt.ylabel('Dec')
+        plt.title('visit: {}'.format(cat))
+        filename = os.path.join(outdir, '{}-{}-quivers.pdf')
+        plt.savefig(filename.format(name, cat))
+
+
+def plot_wcs_quivers(ax, wcs1, wcs2, dim):
+    """Plot the delta between wcs1 and wcs2 as vector arrows."""
+
+    x1, y1, x2, y2 = make_xy_wcs_grid(dim, wcs1, wcs2)
+    uu = x2 - x1
+    vv = y2 - y1
+    return ax.quiver(x1, y1, uu, vv, units='x', pivot='tail', scale=1e-3, width=1e-5)
+
+
+def plot_wcs_magnitude(plt, data_refs, visit_catalogs, old_wcs_list, name, outdir='.plots'):
+    """Plot the magnitude of the WCS change between old and new visits as a heat map."""
+    for cat in visit_catalogs:
+        fig = plt.figure()
+        fig.set_tight_layout(True)
+        ax = fig.add_subplot(111)
+        # Start min/max at the "opposite" ends so they always get the first valid value.
+        xmin = np.inf
+        ymin = np.inf
+        xmax = -np.inf
+        ymax = -np.inf
+        for old_wcs, ref in zip(old_wcs_list, data_refs):
+            if ref.dataId['visit'] != cat:
+                continue
+            md = ref.get('calexp_md')
+            x1, y1, x2, y2 = make_xy_wcs_grid((md.get('NAXIS1'), md.get('NAXIS2')),
+                                              old_wcs, ref.get('wcs').getWcs())
+            uu = x2 - x1
+            vv = y2 - y1
+            extent = (x1[0, 0], x1[-1, -1], y1[0, 0], y1[-1, -1])
+            xmin = min(x1.min(), xmin)
+            ymin = min(y1.min(), ymin)
+            xmax = max(x1.max(), xmax)
+            ymax = max(y1.max(), ymax)
+            magnitude = (np.linalg.norm((uu, vv), axis=0)*u.radian).to(u.arcsecond).value
+            img = ax.imshow(magnitude, vmin=0, vmax=0.3,
+                            aspect='auto', extent=extent, cmap=plt.get_cmap('magma'))
+            # TODO: add CCD bounding boxes to the plot once DM-5503 is finished.
+            # TODO: add a circle for the full focal plane.
+
+        # We're reusing only one of the returned images here for colorbar scaling,
+        # but it doesn't matter because we set vmin/vmax so they are all scaled the same.
+        cbar = plt.colorbar(img)
+        cbar.ax.set_ylabel('distortion (arcseconds)')
+        plt.xlim(xmin, xmax)
+        plt.ylim(ymin, ymax)
+        plt.xlabel('RA')
+        plt.ylabel('Dec')
+        plt.title('visit: {}'.format(cat))
+        filename = os.path.join(outdir, '{}-{}-heatmap.pdf')
+        plt.savefig(filename.format(name, cat))
+
+
+def plot_wcs(plt, wcs1, wcs2, dim, center=(0, 0), name="", outdir='.plots'):
+    """Plot the "distortion map": wcs1-wcs2 delta of points in the CCD grid."""
+
+    plt.figure()
+
+    x1, y1, x2, y2 = make_xy_wcs_grid(dim, wcs1, wcs2, num=50)
+    plt.plot((x1 - x2) + center[0], (y1 - y2) + center[1], '-')
+    plt.xlabel('delta RA (arcsec)')
+    plt.ylabel('delta Dec (arcsec)')
+    plt.title(name)
+    filename = os.path.join(outdir, '{}-wcs.pdf')
+    plt.savefig(filename.format(name))
+
+
+def plot_rms_histogram(plt, old_rms_relative, old_rms_absolute,
+                       new_rms_relative, new_rms_absolute,
+                       old_rel_total, old_abs_total, new_rel_total, new_abs_total,
+                       name, outdir='.plots'):
+    """Plot histograms of the source separations and their RMS values."""
+    plt.figure()
+
+    color_rel = 'black'
+    ls_old = 'dotted'
+    color_abs = 'green'
+    ls_new = 'dashed'
+    plotOptions = {'lw': 2, 'range': (0, 0.1)*u.arcsecond, 'normed': True,
+                   'bins': 30, 'histtype': 'step'}
+
+    plt.title('relative vs. absolute: %d vs. %d'%(len(old_rms_relative), len(old_rms_absolute)))
+
+    plt.hist(old_rms_absolute, color=color_abs, ls=ls_old, label='old abs', **plotOptions)
+    plt.hist(new_rms_absolute, color=color_abs, ls=ls_new, label='new abs', **plotOptions)
+
+    plt.hist(old_rms_relative, color=color_rel, ls=ls_old, label='old rel', **plotOptions)
+    plt.hist(new_rms_relative, color=color_rel, ls=ls_new, label='new rel', **plotOptions)
+
+    plt.axvline(x=old_abs_total.value, linewidth=1.5, color=color_abs, ls=ls_old)
+    plt.axvline(x=new_abs_total.value, linewidth=1.5, color=color_abs, ls=ls_new)
+    plt.axvline(x=old_rel_total.value, linewidth=1.5, color=color_rel, ls=ls_old)
+    plt.axvline(x=new_rel_total.value, linewidth=1.5, color=color_rel, ls=ls_new)
+
+    plt.xlim(plotOptions['range'])
+    plt.xlabel('arcseconds')
+    plt.legend(loc='best')
+    filename = os.path.join(outdir, '{}-histogram.pdf')
+    plt.savefig(filename.format(name))

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -287,6 +287,9 @@ void Associations::CollectLSSTRefStars(lsst::afw::table::SortedCatalogT< lsst::a
 //  }
         BaseStar s(ra, dec, mag);
         // cook up errors: 100 mas per cooordinate
+
+        // TODO: What is this? Why are we making fake errors here?
+
         s.vx = sqr(0.1/3600/cos(coord.getLatitude()));
         s.vy = sqr(0.1/3600);
         s.vxy = 0.;

--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -2,20 +2,12 @@
 
 from __future__ import division, absolute_import, print_function
 
-import numpy as np
-import collections
 import os
 
-# NOTE: We use both astropy.units and afw.arcseconds in places because:
-# 1. astropy.units behaves well with matplotlib, while afw.arcseconds does not.
-# 2. afw objects (e.g. Coord) need afw.arcseconds, not astropy.units.
-from astropy import units as u
-
-from lsst.meas.astrom import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
 import lsst.afw.geom
-import lsst.afw.table
+from lsst.meas.astrom import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
 
-from lsst.jointcal import jointcal
+from lsst.jointcal import jointcal, utils
 
 
 class JointcalTestBase(object):
@@ -25,11 +17,38 @@ class JointcalTestBase(object):
     Derive from this first, then from TestCase.
     """
 
-    def setUp(self):
-        self.do_plot = False  # don't make plots unless specifically requested
-        self.match_radius = 0.1*lsst.afw.geom.arcseconds  # match sources within 0.1" for RMS statistics
-        self.all_visits = None  # list of the available visits to generate the parseAndRun arguments
-        self.other_args = []  # optional other arguments for the butler dataId
+    def setUp_base(self, center, radius,
+                   match_radius=0.1*lsst.afw.geom.arcseconds,
+                   input_dir="",
+                   all_visits=None,
+                   other_args=None,
+                   do_plot=False):
+        """
+        Parameters
+        ----------
+        center : lsst.afw.Coord
+            Center of the reference catalog.
+        radius : lsst.afw.Angle
+            Radius from center to load reference catalog objects inside.
+        match_radius : lsst.afw.Angle
+            matching radius when calculating RMS of result.
+        input_dir : str
+            Directory of input butler repository.
+        all_visits : list
+            List of the available visits to generate the parseAndRun arguments.
+        other_args : list
+            Optional other arguments for the butler dataId.
+        do_plot : bool
+            Set to True for a comparison plot and some diagnostic numbers.
+        """
+        self._prep_reference_loader(center, radius)
+        self.jointcalStatistics = utils.JointcalStatistics(match_radius)
+        self.input_dir = input_dir
+        self.all_visits = all_visits
+        if other_args is None:
+            other_args = []
+        self.other_args = other_args
+        self.do_plot = do_plot
         # Signal/Noise (flux/fluxSigma) for sources to be included in the RMS cross-match.
         # 100 is a balance between good centroids and enough sources.
         self.flux_limit = 100
@@ -56,9 +75,12 @@ class JointcalTestBase(object):
     def _testJointCalTask(self, nCatalogs, relative_error, absolute_error):
         """Test parseAndRun for jointcal on nCatalogs, requiring less than some error (arcsec)."""
 
-        self.visit_list = self.all_visits[:nCatalogs]
-        visits = '^'.join(str(v) for v in self.visit_list)
-        output_dir = os.path.join('.test', self.__class__.__name__)
+        visit_list = self.all_visits[:nCatalogs]
+        visits = '^'.join(str(v) for v in visit_list)
+        import inspect
+        # the calling method is one step back on the stack: use it to specify the output repo.
+        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        output_dir = os.path.join('.test', self.__class__.__name__, caller)
         args = [self.input_dir, '--output', output_dir,
                 '--clobber-versions', '--clobber-config',
                 '--doraise',
@@ -67,285 +89,14 @@ class JointcalTestBase(object):
         result = jointcal.JointcalTask.parseAndRun(args=args, doReturnResults=True)
         self.assertNotEqual(result.resultList, [], 'resultList should not be empty')
         self.dataRefs = result.resultList[0].result.dataRefs
-        self.oldWcsList = result.resultList[0].result.oldWcsList
+        oldWcsList = result.resultList[0].result.oldWcsList
 
-        rms_rel, rms_abs = self.compute_rms(self.dataRefs)
+        rms_rel, rms_abs = self.jointcalStatistics.compute_rms(self.dataRefs, visit_list, self.reference)
         self.assertLess(rms_rel, relative_error)
         self.assertLess(rms_abs, absolute_error)
 
-    def compute_rms(self, dataRefs):
-        """
-        !Match all dataRefs to compute the RMS, for all detections above self.flux_limit.
-
-        @param dataRefs (list) the dataRefs to do the relative matching between
-
-        @return (geom.Angle, geom.Angle) relative and absolute RMS of stars
-        """
-        visits_per_dataRef = [dataRef.dataId['visit'] for dataRef in dataRefs]
-
-        def compute(catalogs):
-            """Compute the relative and absolute RMS."""
-            visitCatalogs = self._make_visit_catalogs(catalogs, visits_per_dataRef)
-            refCat = visitCatalogs.values()[0]  # use the first catalog as the relative reference catalog
-            relative = self._make_match_dict(refCat, visitCatalogs.values()[1:])
-            absolute = self._make_match_dict(self.reference, visitCatalogs.values())
-            return visitCatalogs, relative, absolute
-
-        old_cats = [dataRef.get('src') for dataRef in dataRefs]
-        visitCatalogs, old_relative, old_absolute = compute(old_cats)
-
-        # Update coordinates with the new wcs including distortion corrections.
-        new_cats = []
-        for dataRef in dataRefs:
-            new_cats.append(dataRef.get('src'))
-            lsst.afw.table.utils.updateSourceCoords(dataRef.get('wcs').getWcs(), new_cats[-1])
-        visistCatalogs, new_relative, new_absolute = compute(new_cats)
-
-        old_rel_total = rms_total(old_relative)
-        new_rel_total = rms_total(new_relative)
-        old_abs_total = rms_total(old_absolute)
-        new_abs_total = rms_total(new_absolute)
-
         if self.do_plot:
-            self._do_plots(dataRefs, visitCatalogs,
-                           old_relative, old_absolute, new_relative, new_absolute,
-                           old_rel_total, old_abs_total, new_rel_total, new_abs_total)
-
-        return new_rel_total, new_abs_total
-
-    def _make_match_dict(self, reference, visitCatalogs):
-        """
-        !Return a dict of starID:[distances] over the catalogs, for RMS calculations.
-
-        @param reference (SourceCatalog) catalog to do the matching against
-        @param visits (list) visit source catalogs (from _make_visit_catalogs) to cross-match
-
-        @return (dict) dict of starID:list(measurement deltas for that star)
-        """
-
-        deltas = collections.defaultdict(list)
-        for cat in visitCatalogs:
-            good = (cat.get('base_PsfFlux_flux')/cat.get('base_PsfFlux_fluxSigma')) > self.flux_limit
-            # things the classifier called stars are not extended.
-            good &= (cat.get('base_ClassificationExtendedness_value') == 0)
-            matches = lsst.afw.table.matchRaDec(reference, cat[good], self.match_radius)
-            for m in matches:
-                deltas[m[0].getId()].append(m[2])
-        return deltas
-
-    def _make_visit_catalogs(self, catalogs, visits):
-        """
-        !Return a dict of visit: catalog of all sources from all CCDs of that visit.
-
-        @param catalogs (list of SourceCatalogs) catalogs to combine into per-visit catalogs.
-        @param visits (list) list of visit identifiers, one-to-one correspondant with catalogs.
-        """
-        visit_dict = {v: lsst.afw.table.SourceCatalog(catalogs[0].schema) for v in self.visit_list}
-        for v, cat in zip(visits, catalogs):
-            visit_dict[v].extend(cat)
-        # We want catalog contiguity to do object selection later.
-        for v in visit_dict:
-            visit_dict[v] = visit_dict[v].copy(deep=True)
-
-        return visit_dict
-
-    def _do_plots(self, dataRefs, visitCatalogs,
-                  old_relative, old_absolute, new_relative, new_absolute,
-                  old_rel_total, old_abs_total, new_rel_total, new_abs_total):
-        """Make plots of various quantites to help with debugging."""
-        import matplotlib.pyplot as plt
-        import astropy.visualization
-        # make quantities behave nicely when plotted.
-        astropy.visualization.quantity_support()
-        plt.ion()
-
-        name = self.id().strip('__main__.')
-        old_rms_relative = rms_per_star(old_relative)
-        old_rms_absolute = rms_per_star(old_absolute)
-        new_rms_relative = rms_per_star(new_relative)
-        new_rms_absolute = rms_per_star(new_absolute)
-        print("N dataRefs:", len(dataRefs))
-        print("relative RMS (old, new):", old_rel_total, new_rel_total)
-        print("absolute RMS (old, new):", old_abs_total, new_abs_total)
-        plot_rms_histogram(plt, old_rms_relative, old_rms_absolute, new_rms_relative, new_rms_absolute,
-                           old_rel_total, old_abs_total, new_rel_total, new_abs_total, name)
-
-        plot_all_wcs_deltas(plt, dataRefs, visitCatalogs, self.oldWcsList, name)
+            name = self.id.strip('__main__.')
+            self.jointcalStatistics.make_plots(self.dataRefs, self.visitCatalogs, oldWcsList, name=name)
 
 
-def rms_per_star(data):
-    """
-    Compute the RMS for each catalog star.
-
-    @param data (dict) dict of starID:list(measurement deltas for that star)
-
-    @return (np.array, astropy.units.arcsecond) the RMS for each starID (no guaranteed order)
-    """
-    return (np.sqrt(np.array([np.mean(np.array(dd)**2) for dd in data.values()]))*u.radian).to(u.arcsecond)
-
-
-def rms_total(data):
-    """
-    Compute the total rms across all stars.
-
-    @param data (dict) dict of starID:list(measurement deltas for that star)
-
-    @return (astropy.units.arcsecond) the total rms across all stars
-    """
-    total = sum(sum(np.array(dd)**2) for dd in data.values())
-    n = sum(len(dd) for dd in data.values())
-    return (np.sqrt(total/n) * u.radian).to(u.arcsecond)
-
-
-def plot_all_wcs_deltas(plt, dataRefs, visitCatalogs, oldWcsList, name,
-                        perCcdPlots=False):
-    """Various plots of the difference between old and new Wcs."""
-
-    print('plotting heat maps')
-    plot_wcs_magnitude(plt, dataRefs, visitCatalogs, oldWcsList, name)
-    print('plotting quivers')
-    plot_all_wcs_quivers(plt, dataRefs, visitCatalogs, oldWcsList, name)
-
-    if perCcdPlots:
-        for i, ref in enumerate(dataRefs):
-            md = ref.get('calexp_md')
-            plot_wcs(plt, oldWcsList[i], ref.get('wcs').getWcs(),
-                     dim=(md.get('NAXIS1'), md.get('NAXIS1')),
-                     center=(md.get('CRVAL1'), md.get('CRVAL2')), name='dataRef %d'%i)
-
-
-def make_xy_wcs_grid(dim, wcs1, wcs2, num=50):
-    """Return num x/y grid coordinates for wcs1 and wcs2."""
-    x = np.linspace(0, dim[0], num)
-    y = np.linspace(0, dim[1], num)
-    x1, y1 = wcs_convert(x, y, wcs1)
-    x2, y2 = wcs_convert(x, y, wcs2)
-    return x1, y1, x2, y2
-
-
-def wcs_convert(xv, yv, wcs):
-    """Convert two arrays of x/y points into an on-sky grid."""
-    xout = np.zeros((xv.shape[0], yv.shape[0]))
-    yout = np.zeros((xv.shape[0], yv.shape[0]))
-    for i, x in enumerate(xv):
-        for j, y in enumerate(yv):
-            sky = wcs.pixelToSky(x, y).toFk5()
-            xout[i, j] = sky.getRa()
-            yout[i, j] = sky.getDec()
-    return xout, yout
-
-
-def plot_all_wcs_quivers(plt, dataRefs, visitCatalogs, oldWcsList, name):
-    """Make quiver plots of the WCS deltas for each CCD in each visit."""
-
-    for cat in visitCatalogs:
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        for old_wcs, ref in zip(oldWcsList, dataRefs):
-            if ref.dataId['visit'] != cat:
-                continue
-            md = ref.get('calexp_md')
-            Q = plot_wcs_quivers(ax, old_wcs, ref.get('wcs').getWcs(),
-                                 dim=(md.get('NAXIS1'), md.get('NAXIS2')))
-            # TODO: add CCD bounding boxes to plot once DM-5503 is finished.
-            # TODO: add a circle for the full focal plane.
-        length = (0.1*u.arcsecond).to(u.radian).value
-        ax.quiverkey(Q, 0.9, 0.95, length, '0.1 arcsec', coordinates='figure', labelpos='W')
-        plt.xlabel('RA')
-        plt.ylabel('Dec')
-        plt.title('visit: {}'.format(cat))
-        plt.savefig('.plots/{}-{}-quivers.pdf'.format(name, cat))
-
-
-def plot_wcs_quivers(ax, wcs1, wcs2, dim):
-    """Plot the delta between wcs1 and wcs2 as vector arrows."""
-
-    x1, y1, x2, y2 = make_xy_wcs_grid(dim, wcs1, wcs2)
-    uu = x2 - x1
-    vv = y2 - y1
-    return ax.quiver(x1, y1, uu, vv, units='x', pivot='tail', scale=1e-3, width=1e-5)
-
-
-def plot_wcs_magnitude(plt, dataRefs, visitCatalogs, oldWcsList, name):
-    for cat in visitCatalogs:
-        fig = plt.figure()
-        fig.set_tight_layout(True)
-        ax = fig.add_subplot(111)
-        xmin = np.inf
-        ymin = np.inf
-        xmax = -np.inf
-        ymax = -np.inf
-        for old_wcs, ref in zip(oldWcsList, dataRefs):
-            if ref.dataId['visit'] != cat:
-                continue
-            md = ref.get('calexp_md')
-            x1, y1, x2, y2 = make_xy_wcs_grid((md.get('NAXIS1'), md.get('NAXIS2')),
-                                              old_wcs, ref.get('wcs').getWcs())
-            uu = x2 - x1
-            vv = y2 - y1
-            extent = (x1[0, 0], x1[-1, -1], y1[0, 0], y1[-1, -1])
-            xmin = x1.min() if x1.min() < xmin else xmin
-            ymin = y1.min() if y1.min() < ymin else ymin
-            xmax = x1.max() if x1.max() > xmax else xmax
-            ymax = y1.max() if y1.max() > ymax else ymax
-            magnitude = (np.linalg.norm((uu, vv), axis=0)*u.radian).to(u.arcsecond).value
-            img = ax.imshow(magnitude, vmin=0, vmax=0.3,
-                            aspect='auto', extent=extent, cmap=plt.get_cmap('magma'))
-            # TODO: add CCD bounding boxes to the plot once DM-5503 is finished.
-            # TODO: add a circle for the full focal plane.
-
-        # We're reusing only one of the returned images here for colorbar scaling,
-        # but it doesn't matter because we set vmin/vmax so they are all scaled the same.
-        cbar = plt.colorbar(img)
-        cbar.ax.set_ylabel('distortion (arcseconds)')
-        plt.xlim(xmin, xmax)
-        plt.ylim(ymin, ymax)
-        plt.xlabel('RA')
-        plt.ylabel('Dec')
-        plt.title('visit: {}'.format(cat))
-        plt.savefig('.plots/{}-{}-heatmap.pdf'.format(name, cat))
-
-
-def plot_wcs(plt, wcs1, wcs2, dim, center=(0, 0), name=""):
-    """Plot the "distortion map": wcs1-wcs2 delta of points in the CCD grid."""
-
-    plt.figure()
-
-    x1, y1, x2, y2 = make_xy_wcs_grid(dim, wcs1, wcs2, num=50)
-    plt.plot((x1 - x2) + center[0], (y1 - y2) + center[1], '-')
-    plt.xlabel('delta RA (arcsec)')
-    plt.ylabel('delta Dec (arcsec)')
-    plt.title(name)
-
-
-def plot_rms_histogram(plt, old_rms_relative, old_rms_absolute,
-                       new_rms_relative, new_rms_absolute,
-                       old_rel_total, old_abs_total, new_rel_total, new_abs_total,
-                       name):
-    """Plot histograms of the star separations and their RMS values."""
-    plt.figure()
-
-    color_rel = 'black'
-    ls_old = 'dotted'
-    color_abs = 'green'
-    ls_new = 'dashed'
-    plotOptions = {'lw': 2, 'range': (0, 0.1)*u.arcsecond, 'normed': True,
-                   'bins': 30, 'histtype': 'step'}
-
-    plt.title('relative vs. absolute: %d vs. %d'%(len(old_rms_relative), len(old_rms_absolute)))
-
-    plt.hist(old_rms_absolute, color=color_abs, ls=ls_old, label='old abs', **plotOptions)
-    plt.hist(new_rms_absolute, color=color_abs, ls=ls_new, label='new abs', **plotOptions)
-
-    plt.hist(old_rms_relative, color=color_rel, ls=ls_old, label='old rel', **plotOptions)
-    plt.hist(new_rms_relative, color=color_rel, ls=ls_new, label='new rel', **plotOptions)
-
-    plt.axvline(x=old_abs_total.value, linewidth=1.5, color=color_abs, ls=ls_old)
-    plt.axvline(x=new_abs_total.value, linewidth=1.5, color=color_abs, ls=ls_new)
-    plt.axvline(x=old_rel_total.value, linewidth=1.5, color=color_rel, ls=ls_old)
-    plt.axvline(x=new_rel_total.value, linewidth=1.5, color=color_rel, ls=ls_new)
-
-    plt.xlim(plotOptions['range'])
-    plt.xlabel('arcseconds')
-    plt.legend(loc='best')
-    plt.savefig('.plots/%s-histogram.pdf'%name)

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -25,8 +25,6 @@ except lsst.pex.exceptions.NotFoundError:
 # This value was empirically determined from the first run of jointcal on
 # this data, and will likely vary from survey to survey.
 absolute_error = 48e-3*u.arcsecond
-# Set to True for a comparison plot and some diagnostic numbers.
-do_plot = False
 
 
 # for MemoryTestCase
@@ -36,17 +34,19 @@ def setup_module(module):
 
 class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCase):
     def setUp(self):
-        jointcalTestBase.JointcalTestBase.setUp(self)
-        self.do_plot = do_plot
-        self.match_radius = 0.1*lsst.afw.geom.arcseconds
+        do_plot = False
 
         # position of the validation_data_cfht catalog
         center = lsst.afw.coord.IcrsCoord(214.884832*lsst.afw.geom.degrees, 52.6622199*lsst.afw.geom.degrees)
         radius = 3*lsst.afw.geom.degrees
-        self._prep_reference_loader(center, radius)
 
-        self.input_dir = os.path.join(data_dir, 'cfht')
-        self.all_visits = [849375, 850587]
+        input_dir = os.path.join(data_dir, 'cfht')
+        all_visits = [849375, 850587]
+
+        self.setUp_base(center, radius,
+                        input_dir=input_dir,
+                        all_visits=all_visits,
+                        do_plot=do_plot)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     def test_jointcalTask_2_visits(self):

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -25,8 +25,6 @@ except lsst.pex.exceptions.NotFoundError:
 # This value was empirically determined from the first run of jointcal on
 # this data, and will likely vary from survey to survey.
 absolute_error = 62e-3*u.arcsecond
-# Set to True for a comparison plot and some diagnostic numbers.
-do_plot = False
 
 
 # for MemoryTestCase
@@ -36,19 +34,22 @@ def setup_module(module):
 
 class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCase):
     def setUp(self):
-        jointcalTestBase.JointcalTestBase.setUp(self)
-        self.do_plot = do_plot
-        self.match_radius = 0.1*lsst.afw.geom.arcseconds
+        do_plot = False
 
         # position of the validation_data_decam catalog
         center = lsst.afw.coord.IcrsCoord(150.1191666*lsst.afw.geom.degrees, 2.20583333*lsst.afw.geom.degrees)
         radius = 3*lsst.afw.geom.degrees
-        self._prep_reference_loader(center, radius)
 
-        self.input_dir = os.path.join(data_dir, 'decam')
-        self.all_visits = [176837, 176846]
+        input_dir = os.path.join(data_dir, 'decam')
+        all_visits = [176837, 176846]
         ccdnums = '^'.join(str(x) for x in range(10, 19))
-        self.other_args = ['ccdnum=' + ccdnums, ]
+        other_args = ['ccdnum=' + ccdnums, ]
+
+        self.setUp_base(center, radius,
+                        input_dir=input_dir,
+                        all_visits=all_visits,
+                        other_args=other_args,
+                        do_plot=do_plot)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     def test_jointcalTask_2_visits(self):

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -2,11 +2,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-# Have to specify backend before we import any other lsst code, since some of it
-# still mucks with the backend, and then we wouldn't be able to change it.
-import matplotlib
-matplotlib.use('Agg')
-
 import unittest
 import os
 
@@ -30,8 +25,6 @@ except lsst.pex.exceptions.NotFoundError:
 # This value was empirically determined from the first run of jointcal on
 # this data, and will likely vary from survey to survey.
 absolute_error = 52e-3*u.arcsecond
-# Set to True for a comparison plot and some diagnostic numbers.
-do_plot = True
 
 
 # for MemoryTestCase
@@ -41,18 +34,20 @@ def setup_module(module):
 
 class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCase):
     def setUp(self):
-        jointcalTestBase.JointcalTestBase.setUp(self)
-        self.do_plot = do_plot
-        self.match_radius = 0.1*lsst.afw.geom.arcseconds
+        do_plot = False
 
         # position of this validation_data_hsc catalog
         center = lsst.afw.coord.IcrsCoord(320.367492*lsst.afw.geom.degrees, 0.3131554*lsst.afw.geom.degrees)
         radius = 5*lsst.afw.geom.degrees
-        self._prep_reference_loader(center, radius)
 
-        self.input_dir = os.path.join(data_dir, 'DATA', 'rerun', 'validate_drp')
+        input_dir = os.path.join(data_dir, 'DATA', 'rerun', 'validate_drp')
         # self.all_visits = [903334, 903336, 903338, 903342, 903344, 903346]
-        self.all_visits = [903982, 904006, 904828, 904846]
+        all_visits = [903982, 904006, 904828, 904846]
+
+        self.setUp_base(center, radius,
+                        input_dir=input_dir,
+                        all_visits=all_visits,
+                        do_plot=do_plot)
 
     @unittest.skipIf(data_dir is None, "validation_data_hsc not setup")
     def test_jointcalTask_2_visits(self):

--- a/tests/test_jointcal_lsstSim.py
+++ b/tests/test_jointcal_lsstSim.py
@@ -55,11 +55,11 @@ class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Te
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('jointcal currently fails if only given one catalog!')
-    def testJointCalTask_1_catalog(self):
+    def testJointCalTask_1_visits(self):
         self._testJointCalTask(2, 0, absolute_error)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
-    def testJointCalTask_2_catalog(self):
+    def testJointCalTask_2_visits(self):
         # NOTE: The relative RMS limits were empirically determined from the
         # first run of jointcal on this data. We should always do better than
         # this in the future!
@@ -68,18 +68,18 @@ class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Te
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
-    def testJointCalTask_4_catalog(self):
+    def testJointCalTask_4_visits(self):
         relative_error = 8.2e-3*u.arcsecond
         self._testJointCalTask(4, relative_error, absolute_error)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
-    def testJointCalTask_7_catalog(self):
+    def testJointCalTask_7_visits(self):
         relative_error = 8.1e-3*u.arcsecond
         self._testJointCalTask(7, relative_error, absolute_error)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
-    def testJointCalTask_10_catalog(self):
+    def testJointCalTask_10_visits(self):
         relative_error = 7.9e-3*u.arcsecond
         self._testJointCalTask(10, relative_error, absolute_error)
 

--- a/tests/test_jointcal_lsstSim.py
+++ b/tests/test_jointcal_lsstSim.py
@@ -2,11 +2,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-import matplotlib
-# Have to import matplotlib at the top level, because it can be imported by
-# something else further in the stack and then I can't reset the backend.
-matplotlib.use('Agg')
-
 import unittest
 import os
 
@@ -29,8 +24,6 @@ except lsst.pex.exceptions.NotFoundError:
 # This value was empirically determined from the first run of jointcal on
 # this data, and will likely vary from survey to survey.
 absolute_error = 42e-3*u.arcsecond
-# Set to True for a comparison plot and some diagnostic numbers.
-do_plot = False
 
 
 # for MemoryTestCase
@@ -40,18 +33,21 @@ def setup_module(module):
 
 class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCase):
     def setUp(self):
-        jointcalTestBase.JointcalTestBase.setUp(self)
-        self.do_plot = do_plot
-        self.match_radius = 0.1*lsst.afw.geom.arcseconds
+        do_plot = False
 
         # position of the Twinkles run 1 catalog
         center = lsst.afw.coord.IcrsCoord(53.00914*lsst.afw.geom.degrees, -27.43895*lsst.afw.geom.degrees)
         radius = 3*lsst.afw.geom.degrees
-        self._prep_reference_loader(center, radius)
 
-        self.input_dir = os.path.join(data_dir, 'twinkles1')
-        self.all_visits = range(840, 850)
-        self.other_args = ['raft=2,2', 'sensor=1,1', 'filter=r']
+        input_dir = os.path.join(data_dir, 'twinkles1')
+        all_visits = range(840, 850)
+        other_args = ['raft=2,2', 'sensor=1,1', 'filter=r']
+
+        self.setUp_base(center, radius,
+                        input_dir=input_dir,
+                        all_visits=all_visits,
+                        other_args=other_args,
+                        do_plot=do_plot)
 
     @unittest.skipIf(data_dir is None, "validation_data_jointcal not setup")
     @unittest.skip('jointcal currently fails if only given one catalog!')


### PR DESCRIPTION
Moved the jointcal plotting and RMS calculation code out of the tests and into `utils.py`, and added a `bin/` script to make plots outside of test running (which will be helpful for working on plotting later). Also refactored testing base class.

`utils.py` doesn't have any tests, but the algorithms in it are pretty dumb, and should be replaced as part of DM-8664.