### PR TITLE
Fix macOS clang segfaults and cleanup NULLs Tickets/dm 8057

### DIFF
--- a/include/lsst/jointcal/AstromFit.h
+++ b/include/lsst/jointcal/AstromFit.h
@@ -92,7 +92,7 @@ public :
     //! Compute derivatives of measurement terms for this CcdImage
     void LSDerivatives1(const CcdImage &ccdImage,
                         TripletList &tList, Eigen::VectorXd &rhs,
-                        const MeasuredStarList *msList = NULL) const;
+                        const MeasuredStarList *msList = nullptr) const;
 
     //! Compute derivatives of reference terms (if any), associated to the FittedStarList
     void LSDerivatives2(const FittedStarList & fsl, TripletList &tList, Eigen::VectorXd &rhs) const;

--- a/include/lsst/jointcal/BaseStar.h
+++ b/include/lsst/jointcal/BaseStar.h
@@ -73,7 +73,7 @@ double flux;
 
   virtual ~BaseStar(){};
 
-  virtual std::string WriteHeader_(std::ostream & stream = std::cout, const char*i = NULL) const ;
+  virtual std::string WriteHeader_(std::ostream & stream = std::cout, const char*i = nullptr) const ;
 
   virtual void WriteHeader(std::ostream & stream = std::cout) const;
 

--- a/include/lsst/jointcal/FastFinder.h
+++ b/include/lsst/jointcal/FastFinder.h
@@ -51,13 +51,13 @@ public :
 
   //! Find the closest with some rejection capability
   const BaseStar *FindClosest(const Point &Where, const double MaxDist,
-			      bool (*SkipIt)(const BaseStar *) = NULL) const;
+			      bool (*SkipIt)(const BaseStar *) = nullptr) const;
 
   //!
   const BaseStar *SecondClosest(const Point &Where,
 				const double MaxDist,
 				const BaseStar* &Closest,
-  				bool (*SkipIt)(const BaseStar *)= NULL) const;
+  				bool (*SkipIt)(const BaseStar *)= nullptr) const;
 
 
   //! mostly for debugging

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -61,14 +61,14 @@ class FittedStar : public BaseStar, public PmBlock {
  public:
   FittedStar() :
     BaseStar(), mag(-1), emag(-1), col(0.), gen(-1), wmag(0),
-    indexInMatrix(-1), measurementCount(0), refStar(NULL),
+    indexInMatrix(-1), measurementCount(0), refStar(nullptr),
     flux2(-1),
     fluxErr(-1),
     fluxErr2(-1) {}
 
   FittedStar(const BaseStar &B) :
     BaseStar(B), mag(-1), emag(-1), col(0.), gen(-1), wmag(0),
-    indexInMatrix(0), measurementCount(0), refStar(NULL),
+    indexInMatrix(0), measurementCount(0), refStar(nullptr),
     flux2(-1),
     fluxErr(-1),
     fluxErr2(-1) {}
@@ -87,7 +87,7 @@ class FittedStar : public BaseStar, public PmBlock {
   {
     indexInMatrix = -1;
     measurementCount = 0;
-    refStar = NULL;
+    refStar = nullptr;
     wmag = 0;
   }
 
@@ -146,7 +146,7 @@ class FittedStar : public BaseStar, public PmBlock {
   double&        FluxErr2() { return fluxErr2; }
 
   //! write stuff
-  std::string       WriteHeader_(std::ostream& pr=std::cout, const char* i=NULL) const;
+  std::string       WriteHeader_(std::ostream& pr=std::cout, const char* i=nullptr) const;
   virtual void      writen(std::ostream& s) const;
 virtual void      read_it(std::istream& s, const char* format);
 static BaseStar*  read(std::istream& s, const char* format);

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -424,7 +424,7 @@ public:
   using Gtransfo::apply; // to unhide apply(const Point&)
 
     GtransfoLinRot() : GtransfoLin() {};
-    GtransfoLinRot(const double AngleRad, const Point *Center=NULL,
+    GtransfoLinRot(const double AngleRad, const Point *Center=nullptr,
 		   const double ScaleFactor=1.0);
     double fit(const StarMatchList &List);
 
@@ -463,7 +463,7 @@ public :
   using Gtransfo::apply; // to unhide apply(const Point&)
 
   BaseTanWcs(const GtransfoLin &Pix2Tan, const Point &TangentPoint,
-	     const GtransfoPoly* Corrections = NULL);
+	     const GtransfoPoly* Corrections = nullptr);
 
   BaseTanWcs(const BaseTanWcs &Original);
 
@@ -507,7 +507,7 @@ public:
   using Gtransfo::apply; // to unhide apply(const Point&)
     //! Pix2Tan describes the transfo from pix to tangent plane (in degrees). TangentPoint in degrees. Corrections are applied between Lin and deprojection parts (as in Swarp).
   TanPix2RaDec(const GtransfoLin &Pix2Tan, const Point &TangentPoint,
-	       const GtransfoPoly* Corrections = NULL);
+	       const GtransfoPoly* Corrections = nullptr);
 
 
   //! the transformation from pixels to tangent plane (coordinates in degrees)
@@ -551,7 +551,7 @@ public:
 
     //! Pix2Tan describes the transfo from pix to tangent plane (in degrees). TangentPoint in degrees. Corrections are applied before Lin.
   TanSipPix2RaDec(const GtransfoLin &Pix2Tan, const Point &TangentPoint,
-		  const GtransfoPoly* Corrections = NULL);
+		  const GtransfoPoly* Corrections = nullptr);
 
 
   //! the transformation from pixels to tangent plane (coordinates in degrees)

--- a/include/lsst/jointcal/MeasuredStar.h
+++ b/include/lsst/jointcal/MeasuredStar.h
@@ -47,7 +47,7 @@ class MeasuredStar : public BaseStar
       ccdImage(0),
       valid(true) {}
 
-  MeasuredStar(const BaseStar &B, const FittedStar *F = NULL) :
+  MeasuredStar(const BaseStar &B, const FittedStar *F = nullptr) :
     BaseStar(B),
     mag(0.), wmag(0.), eflux(0.), aperrad(0.),
     ccdImage(0),
@@ -85,7 +85,7 @@ class MeasuredStar : public BaseStar
   // No longer decrement counter of associated fitted star in destructor (P. El-Hage le 10/04/2012)
   // ~MeasuredStar() { if (fittedStar) fittedStar->MeasurementCount()--;}
 
-  std::string WriteHeader_(std::ostream & pr = std::cout, const char* i = NULL) const;
+  std::string WriteHeader_(std::ostream & pr = std::cout, const char* i = nullptr) const;
   void writen(std::ostream& s) const;
 static BaseStar*  read(std::istream &s, const char* format);
 };

--- a/include/lsst/jointcal/PhotomFit.h
+++ b/include/lsst/jointcal/PhotomFit.h
@@ -55,7 +55,7 @@ class PhotomFit {
   //! Compute the derivatives for this CcdImage. The last argument allows to to process a sub-list (used for outlier removal)
 void LSDerivatives(const CcdImage &Ccd,
 		   TripletList &TList, Eigen::VectorXd &Rhs,
-		   const MeasuredStarList *M=NULL) const;
+		   const MeasuredStarList *M=nullptr) const;
 
   //! Set parameter groups fixed or variable and assign indices to each parameter in the big matrix (which will be used by OffsetParams(...).
   void AssignIndices(const std::string &WhatToFit);

--- a/include/lsst/jointcal/RefStar.h
+++ b/include/lsst/jointcal/RefStar.h
@@ -30,7 +30,7 @@ private :
   RefStar(const BaseStar &, const Point &RaDec);
 
   //!
-  void SetFittedStar(FittedStar &F);
+  void SetFittedStar(FittedStar *F);
 
   //!
   double Ra() const { return raDec.x;}

--- a/include/lsst/jointcal/StarMatch.h
+++ b/include/lsst/jointcal/StarMatch.h
@@ -187,7 +187,7 @@ class StarMatchList : public std::list<StarMatch> {
   //! enables to get a transformed StarMatchList. Only positions are transformed, not attached stars. const routine: "this" remains unchanged.
   void ApplyTransfo(StarMatchList &Transformed,
 		    const Gtransfo *PriorTransfo,
-		    const Gtransfo *PosteriorTransfo = NULL) const;
+		    const Gtransfo *PosteriorTransfo = nullptr) const;
 
   /* constructor */
   StarMatchList() : order(0), chi2(0){};
@@ -208,7 +208,7 @@ class StarMatchList : public std::list<StarMatch> {
 
 
   //! returns the degree of freedom for the fit in x and y
-  int Dof(const Gtransfo *T=NULL) const;
+  int Dof(const Gtransfo *T=nullptr) const;
 
   //! returns the order of the used transfo
   int TransfoOrder() const {return order;}
@@ -254,12 +254,12 @@ class StarMatchList : public std::list<StarMatch> {
   ~StarMatchList() {/* should delete the transfo.... or use counted refs*/ };
 
   //!: without descriptor for l2tup
-  void write_wnoheader(std::ostream & pr=std::cout, const Gtransfo *T=NULL ) const ;
+  void write_wnoheader(std::ostream & pr=std::cout, const Gtransfo *T=nullptr ) const ;
 
 
   //! write  StarMatchList with a header which  can be read by l2tup
-  void write(const std::string &filename, const Gtransfo *tf=NULL) const;
-  void write(std::ostream &pr, const Gtransfo *tf=NULL) const;
+  void write(const std::string &filename, const Gtransfo *tf=nullptr) const;
+  void write(std::ostream &pr, const Gtransfo *tf=nullptr) const;
 
 
     //! enables to dump a match std::list through : std::cout << List;

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -337,7 +337,7 @@ void Associations::AssociateRefStars(double MatchCutInArcSec, const Gtransfo* T)
     // clear previous associations if any :
     for (RefStarIterator i = refStarList.begin(); i != refStarList.end(); ++i)
     {
-        (*i)->SetFittedStar((FittedStar *) NULL );
+        (*i)->SetFittedStar(nullptr);
     }
 
     std::cout << " AssociateRefStars : MatchCutInArcSec " << MatchCutInArcSec << std::endl;
@@ -621,7 +621,7 @@ void Associations::AssociatePhotometricRefStars(double MatchCutInArcSec)
     RefStarIterator I;
     for (I = photRefStarList.begin(); I != photRefStarList.end(); I++)
     {
-        (*I)->SetFittedStar( *(FittedStar*)NULL ); // mais c'est horrible (!)
+        (*I)->SetFittedStar(nullptr); // mais c'est horrible (!)
         //      cout << " XTP,YTP=" << (*I)->x << " " << (*I)->y << endl;
     }
 

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -337,7 +337,7 @@ void Associations::AssociateRefStars(double MatchCutInArcSec, const Gtransfo* T)
     // clear previous associations if any :
     for (RefStarIterator i = refStarList.begin(); i != refStarList.end(); ++i)
     {
-        (*i)->SetFittedStar(*(FittedStar *) NULL );
+        (*i)->SetFittedStar((FittedStar *) NULL );
     }
 
     std::cout << " AssociateRefStars : MatchCutInArcSec " << MatchCutInArcSec << std::endl;

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -108,7 +108,7 @@ static void readusno(const std::string &filebase,double minra,double maxra,
   char line[80];
   int idx[96],len[96],i,raidx0,pos;
   float junk;
-  FILE *ifp=NULL;
+  FILE *ifp=nullptr;
   unsigned int  raword,decword,magword;
   unsigned int minraword,maxraword,mindecword,maxdecword;
   double mag;
@@ -355,7 +355,7 @@ int UsnoRead(double minra, double maxra,
 	     double mindec, double maxdec, UsnoColor Color,
 	     BaseStarList &ApmList)
 {
-  const char *ascii_source = NULL;
+  const char *ascii_source = nullptr;
 
   const char *env_var = getenv("USNOFILE");
   if (env_var) ascii_source = env_var;

--- a/src/AstromFit.cc
+++ b/src/AstromFit.cc
@@ -49,7 +49,7 @@ public:
         cholmod_sparse *C_cs_perm = cholmod_submatrix(C_cs,
                                     Base::m_cholmodFactor->Perm,
                                     Base::m_cholmodFactor->n,
-                                    NULL, -1, NULL, true, true,
+                                    nullptr, -1, nullptr, true, true,
                                     &this->cholmod());
 
         int ret = cholmod_updown(UpOrDown, &C_cs_perm, Base::m_cholmodFactor, &this->cholmod());
@@ -110,7 +110,7 @@ public:
         cholmod_sparse *C_cs_perm = cholmod_submatrix(&C_cs,
                                     (int *) Base::m_cholmodFactor->Perm,
                                     Base::m_cholmodFactor->n,
-                                    NULL, -1, true, true,
+                                    nullptr, -1, true, true,
                                     &this->cholmod());
         assert(C_cs_perm);
         int ret = cholmod_updown(UpOrDown, C_cs_perm, Base::m_cholmodFactor, &this->cholmod());
@@ -414,7 +414,7 @@ void AstromFit::LSDerivatives2(const FittedStarList &fsl, TripletList &tList, Ei
     {
         const FittedStar &fs = **i;
         const RefStar *rs = fs.GetRefStar();
-        if (rs == NULL) continue;
+        if (rs == nullptr) continue;
         proj.SetTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.
         FatPoint rsProj;
@@ -576,7 +576,7 @@ void AstromFit::AccumulateStatRefStars(Accum &accum) const
     {
         FittedStar &fs = **i;
         const RefStar *rs = fs.GetRefStar();
-        if (rs == NULL) continue;
+        if (rs == nullptr) continue;
         proj.SetTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.
         FatPoint rsProj;
@@ -749,7 +749,7 @@ unsigned AstromFit::FindOutliers(double nSigCut,
          is; we use for that the type of the star attached to
          the Chi2Entry. */
         MeasuredStar *ms = dynamic_cast<MeasuredStar *>(i->ps);
-        FittedStar *fs = NULL;
+        FittedStar *fs = nullptr;
         if (!ms) // it is reference term.
         {
             fs = dynamic_cast<FittedStar *>(i->ps);
@@ -808,7 +808,7 @@ void AstromFit::RemoveRefOutliers(FittedStarList &outliers)
     for (auto i = outliers.begin(); i != outliers.end() ; ++i)
     {
         FittedStar &fs = **i;
-        fs.SetRefStar(NULL);
+        fs.SetRefStar(nullptr);
     }
 }
 
@@ -1215,7 +1215,7 @@ void AstromFit::MakeRefResTuple(const std::string &tupleName) const
     {
         const FittedStar &fs = **i;
         const RefStar *rs = fs.GetRefStar();
-        if (rs == NULL) continue;
+        if (rs == nullptr) continue;
         proj.SetTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.
         FatPoint rsProj;

--- a/src/BaseStar.cc
+++ b/src/BaseStar.cc
@@ -59,7 +59,7 @@ BaseStar* BaseStar::read(std::istream & rd, const char *format)
 
 std::string BaseStar::WriteHeader_(std::ostream & stream, const char*i) const
 {
-  if (i==NULL) i = "";
+  if (i==nullptr) i = "";
   stream << "# x"<< i <<" : x position (pixels)" << std::endl
 	 << "# y"<< i <<" : y position (pixels)" << std::endl
 	 << "# sx"<< i <<" : x position r.m.s " << std::endl

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -112,7 +112,7 @@ reference exposure, expect troubles" << std::endl;
 const Mapping* ConstrainedPolyModel::GetMapping(const CcdImage &C) const
 {
   mappingMapType::const_iterator i = _mappings.find(&C);
-  if  (i==_mappings.end()) return NULL;
+  if  (i==_mappings.end()) return nullptr;
   return (i->second.get());
 }
 
@@ -204,8 +204,11 @@ void ConstrainedPolyModel::FreezeErrorScales()
 const Gtransfo& ConstrainedPolyModel::GetChipTransfo(const unsigned Chip) const
 {
   auto chipp = _chipMap.find(Chip);
-  if (chipp == _chipMap.end())
-    return *static_cast<const Gtransfo*>(NULL);// return 0, basically
+  if (chipp == _chipMap.end()) {
+    std::stringstream errMsg;
+    errMsg << "No such chipId: '" << Chip << "' found in chipMap of:  " << this;
+    throw pexExcept::InvalidParameterError(errMsg.str());
+  }
   return chipp->second->Transfo();
 }
 
@@ -222,8 +225,11 @@ std::vector<ShootIdType> ConstrainedPolyModel::GetShoots() const
 const Gtransfo& ConstrainedPolyModel::GetShootTransfo(const ShootIdType &Shoot) const
 {
   auto shootp = _shootMap.find(Shoot);
-  if (shootp == _shootMap.end())
-    return *static_cast<const Gtransfo*>(NULL); // return 0, basically
+  if (shootp == _shootMap.end()) {
+    std::stringstream errMsg;
+    errMsg << "No such shootId: '" << Shoot << "' found in shootMap of: " << this;
+    throw pexExcept::InvalidParameterError(errMsg.str());
+  }
   return shootp->second->Transfo();
 }
 
@@ -231,13 +237,13 @@ const Gtransfo& ConstrainedPolyModel::GetShootTransfo(const ShootIdType &Shoot) 
 PTR(TanSipPix2RaDec) ConstrainedPolyModel::ProduceSipWcs(const CcdImage &Ccd) const
 {
   mappingMapType::const_iterator i = _mappings.find(&Ccd);
-  if  (i==_mappings.end()) return NULL;
+  if  (i==_mappings.end()) return nullptr;
   const TwoTransfoMapping *m = i->second.get();
 
   const GtransfoPoly &t1=dynamic_cast<const GtransfoPoly&>(m->T1());
   const GtransfoPoly &t2=dynamic_cast<const GtransfoPoly&>(m->T2());
   const TanRaDec2Pix *proj=dynamic_cast<const TanRaDec2Pix*>(Sky2TP(Ccd));
-  if (!(&t1)  || !(&t2) || !proj) return NULL;
+  if (!(&t1)  || !(&t2) || !proj) return nullptr;
 
   GtransfoPoly pix2Tp = t2*t1;
 

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -65,12 +65,12 @@ const BaseStar *FastFinder::FindClosest(const Point &Where,
 					const double MaxDist,
 					bool (*SkipIt)(const BaseStar *)) const
 {
-  if (count == 0) return NULL;
+  if (count == 0) return nullptr;
   FastFinder::Iterator it = begin_scan(Where, MaxDist);
-  if (*it == NULL) return NULL;
-  const BaseStar *pbest = NULL;
+  if (*it == nullptr) return nullptr;
+  const BaseStar *pbest = nullptr;
   double minDist2 = MaxDist*MaxDist;
-  for (      ; *it != NULL ; ++it)
+  for (      ; *it != nullptr ; ++it)
     {
       const BaseStar *p = *it;
       if (SkipIt && SkipIt(p)) continue;
@@ -86,15 +86,15 @@ const BaseStar *FastFinder::SecondClosest(const Point &Where,
 					  const BaseStar* &Closest,
 					  bool (*SkipIt)(const BaseStar *)) const
 {
-  Closest=NULL;
-  if (count == 0) return NULL;
+  Closest=nullptr;
+  if (count == 0) return nullptr;
   FastFinder::Iterator it = begin_scan(Where, MaxDist);
-  if (*it == NULL) return NULL;
-  const BaseStar *pbest1 = NULL; // closest
-  const BaseStar *pbest2 = NULL; // second closest
+  if (*it == nullptr) return nullptr;
+  const BaseStar *pbest1 = nullptr; // closest
+  const BaseStar *pbest2 = nullptr; // second closest
   double minDist1_2 = MaxDist*MaxDist;
   double minDist2_2 = MaxDist*MaxDist;
-  for (      ; *it != NULL ; ++it)
+  for (      ; *it != nullptr ; ++it)
     {
       const BaseStar *p = *it;
       if (SkipIt && SkipIt(p)) continue;
@@ -218,7 +218,7 @@ Iterator::Iterator(const FastFinder &F, const Point &Where,
 FastFinder::stars_element  Iterator::operator*() const
 {
   if (current!=null_value) return *current;
-  return NULL;
+  return nullptr;
 }
 
 void Iterator::operator++()

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -15,7 +15,7 @@ namespace jointcal {
 // cannot be in fittedstar.h, because of "crossed includes"
 FittedStar::FittedStar(const MeasuredStar &M) :
   BaseStar(M), mag(M.Mag()), emag(-1), col(0.), gen(-1), wmag(M.MagWeight()),
-  indexInMatrix(-1), measurementCount(0), refStar(NULL),
+  indexInMatrix(-1), measurementCount(0), refStar(nullptr),
   flux2(-1), fluxErr2(-1)
 {
   fluxErr = M.eflux;
@@ -24,7 +24,7 @@ FittedStar::FittedStar(const MeasuredStar &M) :
 
 void FittedStar::SetRefStar(const RefStar *R)
 {
-  if (refStar != NULL && (R)) // Exception ??
+  if (refStar != nullptr && (R)) // TODO: should we raise an Exception in this case?
     std::cerr << " FittedStar : " << *this
 	      << " is already matched to an other RefStar " << std::endl
 	      << " Clean up your lists " << std::endl;
@@ -151,7 +151,7 @@ template class StarList<FittedStar>;
 std::string FittedStar::WriteHeader_(std::ostream& pr, const char* i) const
 {
  std::string format = BaseStar::WriteHeader_(pr, i);
-  if(i==NULL) i = "";
+  if(i==nullptr) i = "";
 
   pr << "# mag"   << i << " : fitted magnitude" << std::endl;
   pr << "# emag"  << i << " : error on the fitted magnitude" << std::endl;

--- a/src/Gtransfo.cc
+++ b/src/Gtransfo.cc
@@ -21,14 +21,14 @@ namespace jointcal {
 
 
 bool IsIdentity(const Gtransfo *a_transfo)
-{ return (dynamic_cast<const GtransfoIdentity*>(a_transfo) != NULL);}
+{ return (dynamic_cast<const GtransfoIdentity*>(a_transfo) != nullptr);}
 
 static double sqr(double x) {return x*x;}
 
 bool IsIntegerShift(const Gtransfo *a_transfo)
 {
   const GtransfoPoly* shift = dynamic_cast<const GtransfoPoly*>(a_transfo);
-  if (shift == NULL) return false;
+  if (shift == nullptr) return false;
 
   static const double eps = 1e-5;
 
@@ -50,7 +50,7 @@ bool IsIntegerShift(const Gtransfo *a_transfo)
 Gtransfo* Gtransfo::ReduceCompo(const Gtransfo *Right) const
 {// by default no way to compose
   if (Right) {} // avoid a warning
-  return NULL;
+  return nullptr;
 }
 
 
@@ -194,18 +194,14 @@ void Gtransfo::OffsetParams(const double *Params)
   for (int i=0; i<npar ; ++i) ParamRef(i) += Params[i];
 }
 
-double Gtransfo::ParamRef(const int i) const
+double Gtransfo::ParamRef(const int) const
 {
-  if (i) {} // warning killer;
   throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, std::string("Gtransfo::ParamRef should never be called "));
-  return 0;
 }
 
-double &Gtransfo::ParamRef(const int i)
+double &Gtransfo::ParamRef(const int)
 {
-  if (i) {} // warning killer;
-   throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, "Gtransfo::ParamRef should never be called ");
-  return *(double *)(NULL);
+  throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, "Gtransfo::ParamRef should never be called ");
 }
 
 void Gtransfo::ParamDerivatives(const Point &Where,
@@ -462,7 +458,7 @@ Gtransfo *GtransfoCompose(const Gtransfo *Left, const Gtransfo *Right)
   Gtransfo *composition = Left->ReduceCompo(Right);
   /* composition == NULL means no reduction : just build a Composition
      that pipelines "Left" and "Right" */
-  if (composition == NULL) return new GtransfoComposition(Left,Right);
+  if (composition == nullptr) return new GtransfoComposition(Left,Right);
   else return composition;
 }
 
@@ -1086,7 +1082,7 @@ Gtransfo * GtransfoPoly::ReduceCompo(const Gtransfo *Right) const
       else
 	return new GtransfoPoly((*this)*(*p)); // does the composition
     }
-  else return NULL;
+  else return nullptr;
 }
 
 /*  PolyXY the class used to perform polynomial algebra (and in
@@ -1300,12 +1296,12 @@ GtransfoPoly *InversePolyTransfo(const Gtransfo &Direct, const Frame &F, const d
       {
 	Point in((i+0.5)*stepx, (j+0.5)*stepy);
 	Point out(Direct.apply(in));
-	sm.push_back(StarMatch(out, in , NULL,NULL));
+	sm.push_back(StarMatch(out, in , nullptr, nullptr));
       }
   unsigned npairs = sm.size();
   int maxdeg = 9;
   int degree;
-  GtransfoPoly *poly = NULL;
+  GtransfoPoly *poly = nullptr;
   for (degree=1; degree<=maxdeg; ++degree)
     {
       delete poly;
@@ -1536,7 +1532,7 @@ BaseTanWcs::BaseTanWcs(const GtransfoLin &Pix2Tan, const Point &TangentPoint,
   dec0 = deg2rad(TangentPoint.y);
   cos0 = cos(dec0);
   sin0 = sin(dec0);
-  corr = NULL;
+  corr = nullptr;
   if (Corrections) corr = new GtransfoPoly(*Corrections);
 }
 
@@ -1546,7 +1542,7 @@ BaseTanWcs::BaseTanWcs(const GtransfoLin &Pix2Tan, const Point &TangentPoint,
 // ": Gtransfo" suppresses a warning
 BaseTanWcs::BaseTanWcs(const BaseTanWcs &Original) : Gtransfo()
 {
-  corr = NULL;
+  corr = nullptr;
   *this = Original;
 }
 
@@ -1557,7 +1553,7 @@ void  BaseTanWcs::operator = (const BaseTanWcs &Original)
   dec0 = Original.dec0;
   cos0 = cos(dec0);
   sin0 = sin(dec0);
-  corr = NULL;
+  corr = nullptr;
   if (Original.corr) corr = new GtransfoPoly(*Original.corr);
 }
 
@@ -1604,7 +1600,7 @@ GtransfoLin BaseTanWcs::LinPart() const
 void BaseTanWcs::SetCorrections(const GtransfoPoly *Corrections)
 {
   if (corr) delete corr;
-  corr = NULL;
+  corr = nullptr;
   if (Corrections)
     {
       corr = (GtransfoPoly*) Corrections->Clone();
@@ -1641,7 +1637,7 @@ TanPix2RaDec::TanPix2RaDec(const GtransfoLin &Pix2Tan,
 
 
 // ": Gtransfo" suppresses a warning
-TanPix2RaDec::TanPix2RaDec() : BaseTanWcs(GtransfoLin(), Point(0,0), NULL)
+TanPix2RaDec::TanPix2RaDec() : BaseTanWcs(GtransfoLin(), Point(0,0), nullptr)
 {
 }
 
@@ -1650,7 +1646,7 @@ Gtransfo * TanPix2RaDec::ReduceCompo(const Gtransfo *Right) const
 {
   const GtransfoLin *lin = dynamic_cast<const GtransfoLin *>(Right);
   if (lin && lin->Degree() == 1) return new TanPix2RaDec((*this)*(*lin));
-  return NULL;
+  return nullptr;
 }
 
 
@@ -1663,7 +1659,7 @@ TanPix2RaDec TanPix2RaDec::operator *(const GtransfoLin &Right) const
 
 TanRaDec2Pix TanPix2RaDec::invert() const
 {
-  if (corr != NULL)
+  if (corr != nullptr)
     {
       cerr << " You are inverting a TanPix2RaDec with corrections " << endl;
       cerr << " The inverse you get ignores the corrections !!!!!!" << endl;
@@ -1745,7 +1741,7 @@ TanSipPix2RaDec::TanSipPix2RaDec(const GtransfoLin &Pix2Tan,
 
 
 // ": Gtransfo" suppresses a warning
-TanSipPix2RaDec::TanSipPix2RaDec() : BaseTanWcs(GtransfoLin(), Point(0,0), NULL)
+TanSipPix2RaDec::TanSipPix2RaDec() : BaseTanWcs(GtransfoLin(), Point(0,0), nullptr)
 {
 }
 

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -18,7 +18,7 @@ SparseHisto4d::SparseHisto4d(const int N1, double Min1, double Max1,
 			     const int nEntries)
 {
   double indexMax = N1*N2*N3*N4;
-  data = NULL;
+  data = nullptr;
   if (indexMax > double(INT_MAX))
     {
       cerr << " cannot hold a 4D histo with more than " << INT_MAX 	   << " values " <<  endl;

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -343,7 +343,7 @@ static StarMatchList *ListMatchupRotShift_New(BaseStarList &L1, BaseStarList &L2
   if (L1.size() <= 4 || L2.size() <= 4)
     {
       std::cout << " ListMatchupRotShift_New : (at least) one of the lists is too short " << std::endl;
-      return NULL;
+      return nullptr;
     }
 
   SegmentList sList1(L1, Conditions.NStarsL1, Tin);
@@ -479,7 +479,7 @@ SolList Solutions;
       std::cout << " error In ListMatchup : not a single pair match " << std::endl;
       std::cout << " Probably, the relative scale of lists is not within bounds" << std::endl;
       std::cout << " here : " << minRatio << ' ' << maxRatio << std::endl;
-      return NULL;
+      return nullptr;
     }
 
 
@@ -522,7 +522,7 @@ StarMatchList *MatchSearchRotShiftFlip(BaseStarList &L1, BaseStarList &L2, const
   GtransfoLin flip(0,0,1,0,0,-1);
   StarMatchList *flipped   =  ListMatchupRotShift(L1,L2,flip, Conditions);
   StarMatchList *unflipped =  ListMatchupRotShift(L1,L2, GtransfoIdentity(), Conditions);
-  if (! flipped  || !unflipped) return NULL;
+  if (! flipped  || !unflipped) return nullptr;
   if (Conditions.PrintLevel >=1)
     {
       std::cout << " unflipped  Residual " << unflipped->Residual() << " nused " << unflipped->size() << std::endl;
@@ -553,7 +553,7 @@ StarMatchList *MatchSearchRotShiftFlip(BaseStarList &L1, BaseStarList &L2, const
 GtransfoLin *ListMatchupShift(const BaseStarList &L1, const BaseStarList &L2, const Gtransfo &Tin, double MaxShift)
 {
   int ncomb = L1.size() * L2.size();
-  if (!ncomb) return NULL;
+  if (!ncomb) return nullptr;
   int nx;
   if (ncomb > 10000) nx = 100; else nx = (int) sqrt(ncomb);
 
@@ -587,7 +587,7 @@ GtransfoLin *ListMatchupShift(const BaseStarList &L1, const BaseStarList &L2, co
     {
     int ncomb = L1.size() * L2.size();
     if (ncomb > 10000) nx = 100; else nx = (int) sqrt(double(ncomb));
-    if (!ncomb) return NULL;
+    if (!ncomb) return nullptr;
     }
   else nx = int(2*MaxShift/BinSize+0.5);
 
@@ -700,7 +700,7 @@ StarMatchList *CollectAndFit(const BaseStarList &L1, const BaseStarList &L2,
 			     const Gtransfo *Guess, const double MaxDist)
 {
   const Gtransfo *bestTransfo = Guess;
-  StarMatchList *prevMatch = NULL;
+  StarMatchList *prevMatch = nullptr;
   while (true)
     {
       StarMatchList *m = ListMatchCollect(L1,L2,bestTransfo, MaxDist);

--- a/src/MeasuredStar.cc
+++ b/src/MeasuredStar.cc
@@ -44,7 +44,7 @@ namespace jointcal {
 MeasuredStar::MeasuredStar( const SEStar &S) :
   BaseStar(S),
   mag(0.), wmag(0.), eflux(0.), aperrad(0.), ccdImage(0),
-  fittedStar((const FittedStar *)NULL),
+  fittedStar(nullptr),
   valid(true)
 {
   eflux = S.EFlux();
@@ -97,7 +97,7 @@ const BaseStarList* Measured2Base(const MeasuredStarList *This)
 {
   //  string format = BaseStar::WriteHeader_(pr,i);
   std::string format = BaseStar::WriteHeader_(pr,i);
-  if(i==NULL) i = "";
+  if(i==nullptr) i = "";
 
   pr << "# eflux" << i << " : " << std::endl
      << "# mag" << i << " : " << std::endl
@@ -319,7 +319,7 @@ CatalogLoader * CatalogLoader::getDefaultCatalogLoader(){
 	   << APER_CATALOG << ',' << SE_CATALOG << std::endl;
       throw(PolokaException(" Unkown catalog type in CatalogLoader::getDefaultCatalogLoader "));
     }
-  return NULL;
+  return nullptr;
 }
 
 #endif /* WE_WILL_USE_SOME_OTHER_MECHANISM */

--- a/src/PhotomFit.cc
+++ b/src/PhotomFit.cc
@@ -651,7 +651,7 @@ void PhotomFit::MakeRefResTuple(const std::string &TupleName) const
     {
       const FittedStar &fs = **i;
       const RefStar *rs = fs.GetRefStar();
-      if (rs == NULL) continue;
+      if (rs == nullptr) continue;
       proj.SetTangentPoint(fs);
       // fs projects to (0,0), no need to compute its transform.
       FatPoint rsProj;

--- a/src/Projectionhandler.cc
+++ b/src/Projectionhandler.cc
@@ -25,7 +25,7 @@ OneTPPerShoot::OneTPPerShoot(const CcdImageList &L)
 const Gtransfo* OneTPPerShoot::Sky2TP(const CcdImage &C) const
 {
   auto it=tMap.find(C.Shoot());
-  if (it==tMap.end()) return NULL;
+  if (it==tMap.end()) return nullptr;
   return &*(it->second);
 }
 

--- a/src/RefStar.cc
+++ b/src/RefStar.cc
@@ -17,9 +17,8 @@ RefStar::RefStar(const BaseStar &B, const Point &RaDec)
   raDec = RaDec;
 }
 
-void RefStar::SetFittedStar(FittedStar &F)
+void RefStar::SetFittedStar(FittedStar *fittedStar)
 {
-  fittedStar = &F;
   if (fittedStar) fittedStar->SetRefStar(this);
 }
 

--- a/src/RefStar.cc
+++ b/src/RefStar.cc
@@ -13,7 +13,7 @@ RefStar::RefStar(const BaseStar &B, const Point &RaDec)
   : BaseStar(B), index(0)
 {
 
-  fittedStar = (FittedStar*) NULL;
+  fittedStar = nullptr;
   raDec = RaDec;
 }
 

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -129,7 +129,7 @@ PTR(TanSipPix2RaDec) SimplePolyModel::ProduceSipWcs(const CcdImage &Ccd) const
 {
   const GtransfoPoly &pix2Tp=dynamic_cast<const GtransfoPoly&>(GetTransfo(Ccd));
   const TanRaDec2Pix *proj=dynamic_cast<const TanRaDec2Pix*>(sky2TP(Ccd));
-  if (!(&pix2Tp)  || ! proj) return NULL;
+  if (!(&pix2Tp)  || ! proj) return nullptr;
 
   const GtransfoLin &projLinPart = proj->LinPart(); // should be the identity, but who knows? So, let us incorporate it into the pix2TP part.
   GtransfoPoly wcsPix2Tp = GtransfoPoly(projLinPart.invert())*pix2Tp;

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -79,7 +79,7 @@ static unsigned chi2_cleanup(StarMatchList &L,  const double Chi2Cut,
 static double *get_dist2_array(const StarMatchList &L, const Gtransfo &T)
 {
   unsigned npair = L.size();
-  if (npair == 0) return NULL;
+  if (npair == 0) return nullptr;
   double *dist = new double [npair];
 
   unsigned i=0;
@@ -198,7 +198,7 @@ void StarMatchList::SetTransfoOrder(const int Order)
    might shorten the list */
 Gtransfo* StarMatchList::InverseTransfo() /* it is not const although it tries not to change anything  */
 {
-  if (!transfo) return NULL;
+  if (!transfo) return nullptr;
 
   Gtransfo *old_transfo = transfo->Clone();
   double old_chi2 = chi2;


### PR DESCRIPTION
The first commit fixes the segfault, while the second replaces NULL with nullptr everywhere plus some cleanups where an exception should have been raised instead. Hopefully that removes any other problems like the one that caused this in the first place.