### PR TITLE
Add lsstSim PA1 test and serious bugfix tickets/DM-8551

### DIFF
--- a/bin.src/plot_jointcal_results.py
+++ b/bin.src/plot_jointcal_results.py
@@ -66,17 +66,19 @@ def main():
                         help="Radius (degrees) of sources to load from reference catalog.")
     parser.add_argument("-i", "--interactive", action="store_true",
                         help="Use interactive matplotlib backend and set ion(), in addition to saving files.")
-    parser.add_argument("-o", "--outdir", default=".plots",
+    parser.add_argument("-o", "--outdir", default="plots",
                         help="output directory for plots (default: $(default)s)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print extra things during calculations.")
     args = parser.parse_args()
 
+    if not os.path.isdir(args.outdir):
+        os.mkdir(args.outdir)
+
     butler = lsst.daf.persistence.Butler(inputs=args.repo)
     dataIds = get_valid_dataIds(butler)
 
     data_refs = [butler.dataRef('wcs', dataId=dataId) for dataId in dataIds]
-    visits = [data_ref.dataId['visit'] for data_ref in data_refs]
     old_wcs_list = get_old_wcs_list(data_refs)
 
     os.environ['ASTROMETRY_NET_DATA_DIR'] = args.refcat
@@ -89,10 +91,10 @@ def main():
     reference = prep_reference_loader(center, args.radius*degrees)
 
     jointcalStatistics = utils.JointcalStatistics(verbose=args.verbose)
-    jointcalStatistics.compute_rms(data_refs, visits, reference)
+    jointcalStatistics.compute_rms(data_refs, reference)
 
     name = os.path.basename(os.path.normpath(args.repo))
-    jointcalStatistics.make_plots(data_refs, visits, old_wcs_list, name=name,
+    jointcalStatistics.make_plots(data_refs, old_wcs_list, name=name,
                                   interactive=args.interactive, outdir=args.outdir)
 
 

--- a/tests/test_jointcal_lsstSim.py
+++ b/tests/test_jointcal_lsstSim.py
@@ -24,7 +24,7 @@ except lsst.pex.exceptions.NotFoundError:
 # than the single-epoch astrometry (about 0.040").
 # This value was empirically determined from the first run of jointcal on
 # this data, and will likely vary from survey to survey.
-absolute_error = 42e-3*u.arcsecond
+dist_rms_absolute = 42e-3*u.arcsecond
 
 
 # for MemoryTestCase
@@ -54,32 +54,38 @@ class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Te
     @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
     @unittest.skip('jointcal currently fails if only given one catalog!')
     def testJointCalTask_1_visits(self):
-        self._testJointCalTask(2, 0, absolute_error)
+        dist_rms_relative = 0*u.arcsecond  # there is no such thing as a "relative" test for 1 catalog.
+        pa1 = 2.64e-3
+        self._testJointCalTask(1, dist_rms_relative, dist_rms_absolute, pa1)
 
     @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
     def testJointCalTask_2_visits(self):
         # NOTE: The relative RMS limits were empirically determined from the
         # first run of jointcal on this data. We should always do better than
         # this in the future!
-        relative_error = 9.7e-3*u.arcsecond
-        self._testJointCalTask(2, relative_error, absolute_error)
+        dist_rms_relative = 9.7e-3*u.arcsecond
+        pa1 = 2.64e-3
+        self._testJointCalTask(2, dist_rms_relative, dist_rms_absolute, pa1)
 
     @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_4_visits(self):
-        relative_error = 8.2e-3*u.arcsecond
-        self._testJointCalTask(4, relative_error, absolute_error)
+        dist_rms_relative = 8.2e-3*u.arcsecond
+        pa1 = 2.64e-3
+        self._testJointCalTask(4, dist_rms_relative, dist_rms_absolute, pa1)
 
     @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
     @unittest.skip('Keeping this around for diagnostics on the behavior with n catalogs.')
     def testJointCalTask_7_visits(self):
-        relative_error = 8.1e-3*u.arcsecond
-        self._testJointCalTask(7, relative_error, absolute_error)
+        dist_rms_relative = 8.1e-3*u.arcsecond
+        pa1 = 2.64e-3
+        self._testJointCalTask(7, dist_rms_relative, dist_rms_absolute, pa1)
 
     @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
     def testJointCalTask_10_visits(self):
-        relative_error = 7.9e-3*u.arcsecond
-        self._testJointCalTask(10, relative_error, absolute_error)
+        dist_rms_relative = 7.9e-3*u.arcsecond
+        pa1 = 2.64e-3
+        self._testJointCalTask(10, dist_rms_relative, dist_rms_absolute, pa1)
 
 
 # TODO: the memory test cases currently fail in jointcal. Filed as DM-6626.


### PR DESCRIPTION
While writing the PA1 test for lsstSim, I discovered a bug that changed the results depending on whether it was run via unittest or from plot_jointcal_results.py. The photometric part of that is fixed (the astrometric part is a "feature" of data_ref ordering which is now noted, but probably not worth fixing).