### PR TITLE
DM-7070 Move consts from top of Associations.cc into JointcalConfig

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -88,8 +88,15 @@ public:
                            const bool useFittedList = false,
                            const bool enlargeFittedList = true);
 
-    //! Collect stars from an external reference catalog
-    void collectRefStars(lsst::afw::table::SortedCatalogT< lsst::afw::table::SimpleRecord > &Ref,
+    /**
+     * @brief      Collect stars from an external reference catalog and associate them with fittedStars.
+     *
+     * @param      refCat     The catalog of reference sources
+     * @param[in]  matchCut   Separation radius to match fitted and reference stars.
+     * @param      fluxField  The field name in refCat to get the flux from.
+     */
+    void collectRefStars(lsst::afw::table::SortedCatalogT< lsst::afw::table::SimpleRecord > &refCat,
+                         afw::geom::Angle matchCut,
                          std::string const &fluxField);
 
     //! Sends back the fitted stars coordinates on the sky FittedStarsList::inTangentPlaneCoordinates keeps track of that.
@@ -104,8 +111,12 @@ public:
                              double MatchCutArcSec);
 #endif
 
-    //! apply cuts (mainly number of measurements) on potential FittedStars
-    void selectFittedStars();
+    /**
+     * @brief      Apply quality cuts on potential FittedStars
+     *
+     * @param[in]  minMeasurements  The minimum number of measuredStars for a FittedStar to be included.
+     */
+    void selectFittedStars(int minMeasurements);
 
     const CcdImageList& getCcdImageList() const {return ccdImageList;}
 

--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -130,9 +130,11 @@ class JointcalTestBase(object):
         if self.do_plot:
             self._plotJointcalTask(data_refs, oldWcsList, caller)
 
-        self.assertLess(rms_result.dist_relative, dist_rms_relative)
-        self.assertLess(rms_result.dist_absolute, dist_rms_absolute)
-        self.assertLess(rms_result.pa1, pa1)
+        if dist_rms_relative is not None and dist_rms_absolute is not None:
+            self.assertLess(rms_result.dist_relative, dist_rms_relative)
+            self.assertLess(rms_result.dist_absolute, dist_rms_absolute)
+        if pa1 is not None:
+            self.assertLess(rms_result.pa1, pa1)
 
         return data_refs
 

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -200,6 +200,68 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         dist_rms_absolute = 56e-3*u.arcsecond
         self._testJointcalTask(2, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
 
+    @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
+    def test_jointcalTask_2_visits_no_photometry_match_cut_10(self):
+        self.config = lsst.jointcal.jointcal.JointcalConfig()
+        self.config.matchCut = 10.0  # TODO: once DM-6885 is fixed, we need to put `*lsst.afw.geom.arcseconds`
+        self.config.doPhotometry = False
+        self.jointcalStatistics.do_photometry = False
+
+        dist_rms_relative = 17e-3*u.arcsecond
+        metrics = {'collectedAstrometryRefStars': 2187,
+                   'selectedAstrometryRefStars': 2187,
+                   'associatedAstrometryFittedStars': 1151,
+                   'selectedAstrometryFittedStars': 790,
+                   'selectedAstrometryCcdImageList': 6,
+                   'astrometryFinalChi2': 690.509,
+                   'astrometryFinalNdof': 1856,
+                   }
+        pa1 = None
+        self._testJointcalTask(2, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
+
+    @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
+    def test_jointcalTask_3_visits_no_photometry(self):
+        """3 visit, default config to compare with min_measurements_3 test."""
+        self.config = lsst.jointcal.jointcal.JointcalConfig()
+        self.config.minMeasurements = 2
+        self.config.doPhotometry = False
+        self.jointcalStatistics.do_photometry = False
+
+        dist_rms_relative = 17e-3*u.arcsecond
+        metrics = {'collectedAstrometryRefStars': 2187,
+                   'selectedAstrometryRefStars': 2187,
+                   'associatedAstrometryFittedStars': 1270,
+                   'selectedAstrometryFittedStars': 946,
+                   'selectedAstrometryCcdImageList': 8,
+                   'astrometryFinalChi2': 1229.212,
+                   'astrometryFinalNdof': 3008,
+                   }
+        pa1 = None
+        self._testJointcalTask(3, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
+
+    @unittest.skipIf(data_dir is None, "testdata_jointcal not setup")
+    def test_jointcalTask_3_visits_no_photometry_min_measurements_3(self):
+        """Raising min_measurements to 3 will reduce the number of selected
+        fitted stars (and thus the chisq and Ndof), but should not change the
+        other values."""
+        self.config = lsst.jointcal.jointcal.JointcalConfig()
+        self.config.minMeasurements = 3
+        self.config.doPhotometry = False
+        self.jointcalStatistics.do_photometry = False
+
+        dist_rms_relative = 17e-3*u.arcsecond
+        metrics = {'collectedAstrometryRefStars': 2187,
+                   'selectedAstrometryRefStars': 2187,
+                   'associatedAstrometryFittedStars': 1270,
+                   'selectedAstrometryFittedStars': 696,
+                   'selectedAstrometryCcdImageList': 8,
+                   'astrometryFinalChi2': 1047.57,
+                   'astrometryFinalNdof': 2526,
+                   }
+        pa1 = None
+        self._testJointcalTask(3, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
+
+
 # TODO: the memory test cases currently fail in jointcal. Filed as DM-6626.
 # class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
 #     pass


### PR DESCRIPTION
cleanMatches looks like it was used to debug starMatchList: probably don't
need it any more.

Add tests for minMeasurements and matchCut, plus a test for 3 visits with the
default config, to test setting minMeasurements to 3 (since it obviously won't
work with only 2 visits).