### PR TITLE
DM-8750 cleanup jointcal compiler warnings

### DIFF
--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -168,12 +168,40 @@ public:
                                Eigen::VectorXd &grad);
 
     /**
-     * returns how many outliers were removed. No refit done. MeasOrRef can be
-     * "Meas" , "Ref", or "Meas Ref".
+     * Discards measurements and reference contributions contributing to the chi2 more than nSigmaCut,
+     * computed as:
+     * @f[
+     *    <chi2> + nSigmaCut + rms(chi2)
+     * @f]
+     * (statistics over contributions to the chi2).
+     * No refit done.
+     *
+     * @param[in]  nSigmaCut  Number of sigma to cut on.
+     * @param[in]  measOrRef  Which outliers to remove. One of "Meas", "Ref" or "Meas Ref".
+     *
+     * @return     Total number of outliers that were removed.
      */
-    unsigned removeOutliers(double nSigCut, const std::string &measOrRef = "Meas Ref");
+    unsigned removeOutliers(double nSigmaCut, const std::string &measOrRef = "Meas Ref");
 
-    unsigned findOutliers(double nSigCut, MeasuredStarList &mSOutliers, FittedStarList &fSOutliers,
+    /**
+     * Find Measurements and references contributing more than a cut, computed as
+     * @f[
+     *     <chi2> + nSigmaCut + rms(chi2).
+     * @f]
+     * The outliers are NOT removed, and no refit is done.
+     *
+     * After returning from here, there are still measurements that
+     * contribute above the cut, but their contribution should be evaluated after a
+     * refit before discarding them.
+     *
+     * @param[in]  nSigmaCut   Number of sigma to select on.
+     * @param[out] mSOutliers  list of MeasuredStar outliers to populate
+     * @param[out] fSOutliers  list of FittedStar outliers to populate
+     * @param[in]  measOrRef   Which outliers to remove. One of "Meas", "Ref" or "Meas Ref".
+     *
+     * @return     Total number of outliers that were removed.
+     */
+    unsigned findOutliers(double nSigmaCut, MeasuredStarList &mSOutliers, FittedStarList &fSOutliers,
                           const std::string &measOrRef = "Meas Ref") const;
 
     //! Just removes outliers from the fit. No Refit done.

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -55,7 +55,10 @@ private:
     double _mjd;      // modified julian date
     PTR(lsst::afw::image::Calib) _calib;
     // refraction
-    double _sineta, _coseta, _tgz, _hourAngle;  // eta : parallactic angle, z: zenithal angle (X = 1/cos(z))
+    // eta : parallactic angle, z: zenithal angle (X = 1/cos(z))
+    double _sineta, _coseta, _tgz;
+    // Local Sidereal Time and hour angle of observation
+    double _lstObs, _hourAngle;
 
     std::string _filter;
 

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -1,8 +1,4 @@
 // -*- LSST-C++ -*-
-
-/// \file gtransfo.h
-/// \brief Geometrical transformations (of 2D points)
-
 #ifndef LSST_JOINTCAL_GTRANSFO_H
 #define LSST_JOINTCAL_GTRANSFO_H
 

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -23,14 +23,13 @@ private:
     Associations &_associations;
     std::string _whatToFit;
     bool _fittingModel, _fittingFluxes;
-    unsigned _nParModel, _nParFluxes, _nParTot;
+    unsigned _nParModel, _nParTot;
     PhotometryModel *_photometryModel;
-    double _fluxError;
     int _lastNTrip;  // last triplet count, used to speed up allocation
 
 public:
     //! this is the only constructor
-    PhotometryFit(Associations &associations, PhotometryModel *model, double fluxError);
+    PhotometryFit(Associations &associations, PhotometryModel *model);
 
     /**
      * Does a 1 step minimization, assuming a linear model.

--- a/include/lsst/jointcal/StarMatch.h
+++ b/include/lsst/jointcal/StarMatch.h
@@ -153,9 +153,6 @@ public:
     //! access to the chi2 of the last call to refineTransfo.
     double getChi2() const { return _chi2; }
 
-    //! returns the degree of freedom for the fit in x and y
-    int getDof(const Gtransfo *gtransfo = nullptr) const;
-
     //! returns the order of the used transfo
     int getTransfoOrder() const { return _order; }
 

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -422,7 +422,7 @@ class JointcalTask(pipeBase.CmdLineTask):
         self.log.info("=== Starting photometric fitting...")
         model = lsst.jointcal.SimplePhotometryModel(associations.getCcdImageList())
 
-        fit = lsst.jointcal.PhotometryFit(associations, model, self.config.posError)
+        fit = lsst.jointcal.PhotometryFit(associations, model)
         fit.minimize("Model")
         chi2 = fit.computeChi2()
         self.log.info(str(chi2))

--- a/python/lsst/jointcal/photometryFit.cc
+++ b/python/lsst/jointcal/photometryFit.cc
@@ -37,8 +37,7 @@ namespace {
 void declarePhotometryFit(py::module &mod) {
     py::class_<PhotometryFit, std::shared_ptr<PhotometryFit>> cls(mod, "PhotometryFit");
 
-    cls.def(py::init<Associations &, PhotometryModel *, double>(), "associations"_a, "photometryModel"_a,
-            "fluxError"_a);
+    cls.def(py::init<Associations &, PhotometryModel *>(), "associations"_a, "photometryModel"_a);
 
     cls.def("minimize", &PhotometryFit::minimize, "whatToFit"_a);
     cls.def("computeChi2", &PhotometryFit::computeChi2);

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -926,7 +926,7 @@ void AstrometryFit::checkStuff() {
 #endif
     const char *what2fit[] = {"Positions", "Distortions", "Positions Distortions"};
     // DEBUG
-    for (int k = 0; k < sizeof(what2fit) / sizeof(what2fit[0]); ++k) {
+    for (unsigned k = 0; k < sizeof(what2fit) / sizeof(what2fit[0]); ++k) {
         assignIndices(what2fit[k]);
         TripletList tList(10000);
         Eigen::VectorXd rhs(_nParTot);

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -609,25 +609,17 @@ void AstrometryFit::outliersContributions(MeasuredStarList &msOutliers, FittedSt
     LSDerivatives2(fOutliers, tList, grad);
 }
 
-//! Discards measurements and reference contributions contributing to the chi2 more than a cut, computed as
-//! <chi2>+nSigCut+rms(chi2) (statistics over contributions to the chi2). Returns the number of removed
-//! outliers. No refit done.
-unsigned AstrometryFit::removeOutliers(double nSigCut, const std::string &measOrRef) {
+unsigned AstrometryFit::removeOutliers(double nSigmaCut, const std::string &measOrRef) {
     MeasuredStarList msOutliers;
     FittedStarList fsOutliers;
-    unsigned n = findOutliers(nSigCut, msOutliers, fsOutliers, measOrRef);
+    unsigned n = findOutliers(nSigmaCut, msOutliers, fsOutliers, measOrRef);
     removeMeasOutliers(msOutliers);
     removeRefOutliers(fsOutliers);
     return n;
 }
 
-//! Find Measurements and references contributing more than a cut, computed as <chi2>+nSigCut+rms(chi2). The
-//! outliers are NOT removed, and no refit is done.
-/*! After returning from here, there are still measurements that
-  contribute above the cut, but their contribution should be
-  evaluated after a refit before discarding them. */
-unsigned AstrometryFit::findOutliers(double nSigCut, MeasuredStarList &msOutliers, FittedStarList &fsOutliers,
-                                     const std::string &measOrRef) const {
+unsigned AstrometryFit::findOutliers(double nSigmaCut, MeasuredStarList &msOutliers,
+                                     FittedStarList &fsOutliers, const std::string &measOrRef) const {
     bool searchMeas = (measOrRef.find("Meas") != std::string::npos);
     bool searchRef = (measOrRef.find("Ref") != std::string::npos);
 
@@ -656,7 +648,7 @@ unsigned AstrometryFit::findOutliers(double nSigCut, MeasuredStarList &msOutlier
     double sigma = sqrt(sum2 / nval - sqr(average));
     LOGLS_DEBUG(_log,
                 "RemoveOutliers chi2 stat: mean/median/sigma " << average << '/' << median << '/' << sigma);
-    double cut = average + nSigCut * sigma;
+    double cut = average + nSigmaCut * sigma;
     /* For each of the parameters, we will not remove more than 1
        measurement that contributes to constraining it. Keep track using
        of what we are touching using an integer vector. This is the

--- a/src/BaseStar.cc
+++ b/src/BaseStar.cc
@@ -11,8 +11,6 @@ namespace pexExcept = lsst::pex::exceptions;
 namespace lsst {
 namespace jointcal {
 
-static double sq(double x) { return x * x; }
-
 bool decreasingFlux(const BaseStar *star1, const BaseStar *star2) {
     return (star1->getFlux() > star2->getFlux());
 }

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -71,14 +71,10 @@ CcdImage::CcdImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceReco
                    const lsst::afw::geom::Box2I &bbox, const std::string &filter,
                    const PTR(lsst::afw::image::Calib) calib, const int &visit, const int &ccdId,
                    const std::string &fluxField)
-        :
-
-          _filter(filter),
+        : _ccdId(ccdId),
           _visit(visit),
-          _ccdId(ccdId),
-          _calib(calib)
-
-{
+          _calib(calib),
+          _filter(filter) {
     LoadCatalog(record, fluxField);
 
     Point lowerLeft(bbox.getMinX(), bbox.getMinY());
@@ -96,7 +92,7 @@ CcdImage::CcdImage(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceReco
     _airMass = visitInfo->getBoresightAirmass();
     _mjd = visitInfo->getDate().get(lsst::daf::base::DateTime::MJD);
     double latitude = visitInfo->getObservatory().getLatitude();
-    double lst_obs = visitInfo->getEra();
+    _lstObs = visitInfo->getEra();
     _hourAngle = visitInfo->getBoresightHourAngle();
 
     // lsstSim doesn't manage ERA (and thus Hour Angle) properly, so it's going to be NaN.

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -191,6 +191,9 @@ std::shared_ptr<TanSipPix2RaDec> ConstrainedPolyModel::produceSipWcs(const CcdIm
 
     GtransfoPoly pix2Tp;
     const GtransfoPoly &t1 = dynamic_cast<const GtransfoPoly &>(mapping->getTransfo1());
+    // TODO: This line produces a warning on clang (t1 is always valid: a failed dynamic_cast of a reference
+    // raises bad_cast instead of returning nullptr like a failed pointer cast), but I'll deal with it as
+    // part of DM-10524 (hopefully removing the necessity of the casts).
     if (!(&t1)) {
         LOGLS_ERROR(_log, "Problem with transform 1 of ccd/visit " << ccdImage.getCcdId() << "/"
                                                                    << ccdImage.getVisit() << ": T1 "

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -131,7 +131,7 @@ void SparseHisto4d::binLimits(const double x[4], const int iDim, double &xMin, d
     int code = code_value(x);
     double xCenter[4];
     inverse_code(code, xCenter);
-    xMin, xCenter[iDim] - 0.5 / _scale[iDim];
+    xMin = xCenter[iDim] - 0.5 / _scale[iDim];
     xMax = xCenter[iDim] + 0.5 / _scale[iDim];
 }
 

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -25,10 +25,9 @@ LOG_LOGGER _log = LOG_GET("jointcal.PhotometryFit");
 namespace lsst {
 namespace jointcal {
 
-PhotometryFit::PhotometryFit(Associations &associations, PhotometryModel *photometryModel, double fluxError)
+PhotometryFit::PhotometryFit(Associations &associations, PhotometryModel *photometryModel)
         : _associations(associations),
           _photometryModel(photometryModel),
-          _fluxError(fluxError),
           _lastNTrip(0) {
     // The various _npar... are initialized in assignIndices.
     // Although there is no reason to adress them before one might be tempted by
@@ -68,7 +67,7 @@ void PhotometryFit::LSDerivatives(const CcdImage &ccdImage, TripletList &triplet
         // tweak the measurement errors
         double sigma = measuredStar.eflux;
 #ifdef FUTURE
-        TweakPhotomMeasurementErrors(inPos, measuredStar, _posError);
+        TweakPhotomMeasurementErrors(inPos, measuredStar, _fluxError);
 #endif
         h.setZero();  // we cannot be sure that all entries will be overwritten.
 
@@ -115,7 +114,7 @@ void PhotometryFit::accumulateStat(ListType &listType, Accum &accum) const {
             // tweak the measurement errors
             double sigma = measuredStar->eflux;
 #ifdef FUTURE
-            TweakPhotomMeasurementErrors(inPos, measuredStar, _posError);
+            TweakPhotomMeasurementErrors(inPos, measuredStar, _fluxError);
 #endif
 
             double pf = _photometryModel->photomFactor(ccdIMage, *measuredStar);
@@ -355,7 +354,7 @@ void PhotometryFit::makeResTuple(const std::string &tupleName) const {
             if (!ms.isValid()) continue;
             double sigma = ms.eflux;
 #ifdef FUTURE
-            tweakPhotomMeasurementErrors(inPos, ms, _posError);
+            tweakPhotomMeasurementErrors(inPos, ms, _fluxError);
 #endif
             double pf = _photometryModel->photomFactor(im, ms);
             double jd = im.getMjd();

--- a/src/SimplePhotometryModel.cc
+++ b/src/SimplePhotometryModel.cc
@@ -13,9 +13,9 @@ namespace lsst {
 namespace jointcal {
 
 SimplePhotometryModel::SimplePhotometryModel(const CcdImageList &ccdImageList) {
-    unsigned refVisit = -1;
+    VisitIdType refVisit = -1;
     for (auto const &ccdImage : ccdImageList) {
-        unsigned visit = ccdImage->getVisit();
+        VisitIdType visit = ccdImage->getVisit();
         if (refVisit == -1) refVisit = visit;
         if (visit == refVisit)
             _myMap[ccdImage.get()].fixed = true;

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -115,7 +115,7 @@ const Gtransfo &SimplePolyModel::getTransfo(const CcdImage &ccdImage) const {
 std::shared_ptr<TanSipPix2RaDec> SimplePolyModel::produceSipWcs(const CcdImage &ccdImage) const {
     const GtransfoPoly &pix2Tp = dynamic_cast<const GtransfoPoly &>(getTransfo(ccdImage));
     const TanRaDec2Pix *proj = dynamic_cast<const TanRaDec2Pix *>(getSky2TP(ccdImage));
-    if (!(&pix2Tp) || !proj) return nullptr;
+    if (!proj) return nullptr;
 
     const GtransfoLin &projLinPart = proj->getLinPart();  // should be the identity, but who knows? So, let us
                                                           // incorporate it into the pix2TP part.

--- a/src/SipToGtransfo.cc
+++ b/src/SipToGtransfo.cc
@@ -14,16 +14,13 @@ namespace afwGeom = lsst::afw::geom;
 namespace lsst {
 namespace jointcal {
 
-static const int lsstToFitsPixels = +1;
-static const int fitsToLsstPixels = -1;
-
 typedef std::shared_ptr<jointcal::GtransfoPoly> GtPoly_Ptr;
 
 jointcal::TanSipPix2RaDec convertTanWcs(const std::shared_ptr<lsst::afw::image::TanWcs> wcs) {
     GtPoly_Ptr sipCorr(new jointcal::GtransfoPoly(0));
 
-    /* beware : Wcs::getPixelOrigin return crpix_fits +
-     fitsToLsstPixels, so all the algebra we perform here happens in the
+    /* beware : Wcs::getPixelOrigin return crpix_fits - 1,
+     so all the algebra we perform here happens in the
      "Lsst frame", i.e (0,0)-based. this algebra is justified in the
      documentation of the package. */
 

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -61,12 +61,6 @@ static unsigned chi2_cleanup(StarMatchList &starMatchList, const double chi2Cut,
     return erased;
 }
 
-int StarMatchList::getDof(const Gtransfo *gtransfo) const {
-    int npar = (gtransfo) ? gtransfo->getNpar() : (&(*_transfo) ? _transfo->getNpar() : 0);
-    int dof = 2 * size() - npar;
-    return (dof > 0) ? dof : 0;
-}
-
 /*! removes pairs beyond nSigmas in distance (where the sigma scale is
    set by the fit) and iterates until stabilization of the number of pairs.
    If the transfo is not assigned, it will be set to a GtransfoLinear. User


### PR DESCRIPTION
Searched for warnings with both `clang-800.0.38` on macOS and `gcc 5.4.0-6ubuntu1~16.04.4` on Linux.