### PR TITLE
DM-11614: Reset filter list before running each test

### DIFF
--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -8,6 +8,7 @@ import os
 import inspect
 
 import lsst.afw.geom
+import lsst.afw.image.utils
 from lsst.meas.extensions.astrometryNet import LoadAstrometryNetObjectsTask, LoadAstrometryNetObjectsConfig
 
 from lsst.jointcal import jointcal, utils
@@ -69,6 +70,10 @@ class JointcalTestBase(object):
 
         # Append `msg` arguments to assert failures.
         self.longMessage = True
+
+        # Ensure that the filter list is reset for each test so that we avoid
+        # confusion or contamination from other instruments.
+        lsst.afw.image.utils.resetFilters()
 
     def tearDown(self):
         if getattr(self, 'reference', None) is not None:


### PR DESCRIPTION
Without this, in pytest,  when CFHT tests run they define a "u" filter,
and when the DECam tests run they fail because the "u" filter
has already been defined.