### PR TITLE
DM-11332: use bboxFromMetadata instead of NAXIS1,NAXIS2

### DIFF
--- a/python/lsst/jointcal/dataIds.py
+++ b/python/lsst/jointcal/dataIds.py
@@ -82,8 +82,7 @@ class PerTractCcdDataIdContainer(CoaddDataIdContainer):
 
                     md = ref.get("calexp_md", immediate=True)
                     wcs = lsst.afw.image.makeWcs(md)
-                    box = lsst.afw.geom.Box2D(lsst.afw.geom.Point2D(0, 0),
-                                              lsst.afw.geom.Point2D(md.get("NAXIS1"), md.get("NAXIS2")))
+                    box = lsst.afw.geom.Box2D(lsst.afw.image.bboxFromMetadata(md))
                     # Going with just the nearest tract.  Since we're throwing all tracts for the visit
                     # together, this shouldn't be a problem unless the tracts are much smaller than a CCD.
                     tract = skymap.findTract(wcs.pixelToSky(box.getCenter()))

--- a/python/lsst/jointcal/utils.py
+++ b/python/lsst/jointcal/utils.py
@@ -18,7 +18,7 @@ from astropy import units as u
 
 import lsst.log
 import lsst.afw.table
-from lsst.afw.image import fluxFromABMag, abMagFromFlux
+from lsst.afw.image import fluxFromABMag, abMagFromFlux, bboxFromMetadata
 from lsst.afw.geom import arcseconds
 
 MatchDict = collections.namedtuple('MatchDict', ['relative', 'absolute'])
@@ -482,8 +482,9 @@ def plot_all_wcs_deltas(plt, data_refs, visits, old_wcs_list, per_ccd_plot=False
     if per_ccd_plot:
         for i, ref in enumerate(data_refs):
             md = ref.get('calexp_md')
+            dims = bboxFromMetadata(md).getDimensions()
             plot_wcs(plt, old_wcs_list[i], ref.get('wcs').getWcs(),
-                     md.get('NAXIS1'), md.get('NAXIS1'),
+                     dims.getWidth(), dims.getHeight(),
                      center=(md.get('CRVAL1'), md.get('CRVAL2')), name='dataRef %d'%i,
                      outdir=outdir)
 
@@ -537,8 +538,9 @@ def plot_all_wcs_quivers(plt, data_refs, visits, old_wcs_list, name, outdir='.pl
             if ref.dataId['visit'] != visit:
                 continue
             md = ref.get('calexp_md')
+            dims = bboxFromMetadata(md).getDimensions()
             Q = plot_wcs_quivers(ax, old_wcs, ref.get('wcs').getWcs(),
-                                 md.get('NAXIS1'), md.get('NAXIS2'))
+                                 dims.getWidth(), dims.getHeight())
             # TODO: add CCD bounding boxes to plot once DM-5503 is finished.
             # TODO: add a circle for the full focal plane.
         length = (0.1*u.arcsecond).to(u.radian).value
@@ -605,7 +607,8 @@ def plot_wcs_magnitude(plt, data_refs, visits, old_wcs_list, name, outdir='.plot
             if ref.dataId['visit'] != visit:
                 continue
             md = ref.get('calexp_md')
-            x1, y1, x2, y2 = make_xy_wcs_grid(md.get('NAXIS1'), md.get('NAXIS2'),
+            dims = bboxFromMetadata(md).getDimensions()
+            x1, y1, x2, y2 = make_xy_wcs_grid(dims.getWidth(), dims.getHeight(),
                                               old_wcs, ref.get('wcs').getWcs())
             uu = x2 - x1
             vv = y2 - y1

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -11,6 +11,7 @@
 #include "lsst/jointcal/Frame.h"
 #include "lsst/afw/image/TanWcs.h"
 #include "lsst/afw/image/Utils.h"
+#include "lsst/afw/image/Image.h"
 #include "lsst/afw/fits.h"
 #include "lsst/daf/base.h"
 
@@ -117,11 +118,8 @@ BOOST_AUTO_TEST_CASE(test_wcs_convertions)
   const PTR(afwImg::TanWcs) tanWcs = std::dynamic_pointer_cast<afwImg::TanWcs>(wcs);
 
   jointcal::TanSipPix2RaDec gtransfoWcs = jointcal::convertTanWcs(tanWcs);
-  int naxis1 = propSet->get<int>("NAXIS1");
-  int naxis2 = propSet->get<int>("NAXIS2");
-  jointcal::Frame imageFrame(0,0,naxis1,naxis2);
-
-
+  auto const bbox = lsst::afw::image::bboxFromMetadata(*propSet);
+  jointcal::Frame const imageFrame(bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY());
 
   // test the back conversion, in two cases
   for (int noLowOrderSipTerm  = 0; noLowOrderSipTerm <=1; noLowOrderSipTerm++) {


### PR DESCRIPTION
Use of NAXIS1,NAXIS2 is being too familiar with the output format.
lsst.afw.image.bboxFromMetadata allows us to abstract the format.
This is especially important once we activate compression.