### PR TITLE
DM-12310 fix NaNs in photometry and astrometry

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -93,11 +93,14 @@ public:
      * @param      fluxField      The field name in refCat to get the flux from.
      * @param      refFluxMap     fluxes per filter of corresponding refCat objects (can be empty)
      * @param      refFluxErrMap  flux errors per filter of corresponding refCat objects (can be empty)
+     * @param      rejectBadFluxes  Reject reference sources with flux=NaN or 0 and/or fluxErr=NaN or 0.
+     *                              Typically false for astrometry and true for photometry.
      */
     void collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::table::SimpleRecord> &refCat,
                          afw::geom::Angle matchCut, std::string const &fluxField,
                          std::map<std::string, std::vector<double>> const &refFluxMap,
-                         std::map<std::string, std::vector<double>> const &refFluxErrMap);
+                         std::map<std::string, std::vector<double>> const &refFluxErrMap,
+                         bool rejectBadFluxes = false);
 
     //! Sends back the fitted stars coordinates on the sky FittedStarsList::inTangentPlaneCoordinates keeps
     //! track of that.

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -95,13 +95,11 @@ public:
 
     void offsetParams(Eigen::VectorXd const &delta) override;
 
-    void saveResultTuples(std::string const &tupleName) const override;
+    /// @copydoc FitterBase::saveChi2MeasContributions
+    void saveChi2MeasContributions(std::string const &baseName) const override;
 
-    //! Produces a tuple containing residuals of measurement terms.
-    void makeMeasResTuple(std::string const &tupleName) const;
-
-    //! Produces a tuple containing residuals of reference terms.
-    void makeRefResTuple(std::string const &tupleName) const;
+    /// @copydoc FitterBase::saveChi2RefContributions
+    void saveChi2RefContributions(std::string const &baseName) const override;
 
     /**
      * DEBUGGING routine

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -96,12 +96,18 @@ public:
     /**
      * Save the full chi2 term per star that was used in the minimization, for debugging.
      *
-     * Saves results to text files "tupleName-meas" and "tupleName-ref" for the
-     * MeasuredStar and RefStar tuples, respectively.
+     * Saves results to text files "baseName-meas.csv" and "baseName-ref.csv" for the
+     * MeasuredStar and RefStar contributions, respectively.
      * This method is mostly useful for debugging: we will probably want to create a better persistence
-     * system for jointcal's internal representations in the future.
+     * system for jointcal's internal representations in the future (see DM-12446).
      */
-    virtual void saveResultTuples(std::string const &tupleName) const = 0;
+    virtual void saveChi2Contributions(std::string const &baseName) const;
+
+    /// Save a CSV file containing residuals of measurement terms.
+    virtual void saveChi2MeasContributions(std::string const &baseName) const = 0;
+
+    /// Save a CSV file containing residuals of reference terms.
+    virtual void saveChi2RefContributions(std::string const &baseName) const = 0;
 
 protected:
     std::shared_ptr<Associations> _associations;

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -52,7 +52,11 @@ public:
 
     void offsetParams(Eigen::VectorXd const &delta) override;
 
-    void saveResultTuples(std::string const &tupleName) const override;
+    /// @copydoc FitterBase::saveChi2MeasContributions
+    void saveChi2MeasContributions(std::string const &baseName) const override;
+
+    /// @copydoc FitterBase::saveChi2RefContributions
+    void saveChi2RefContributions(std::string const &baseName) const override;
 
 private:
     bool _fittingModel, _fittingFluxes;
@@ -78,12 +82,6 @@ private:
                                          Eigen::VectorXd &grad) const override;
 
 #ifdef STORAGE
-    //! Produces a tuple containing residuals of measurement terms.
-    void makeMeasResTuple(std::string const &tupleName) const;
-
-    //! Produces a tuple containing residuals of reference terms.
-    void makeRefResTuple(std::string const &tupleName) const;
-
     Point transformFittedStar(FittedStar const &fittedStar, Gtransfo const *sky2TP,
                               Point const &refractionVector, double refractionCoeff, double mjd) const;
 #endif

--- a/python/lsst/jointcal/fitter.cc
+++ b/python/lsst/jointcal/fitter.cc
@@ -42,7 +42,7 @@ void declareFitterBase(py::module &mod) {
 
     cls.def("minimize", &FitterBase::minimize, "whatToFit"_a, "nSigRejCut"_a = 0);
     cls.def("computeChi2", &FitterBase::computeChi2);
-    cls.def("saveResultTuples", &FitterBase::saveResultTuples);
+    cls.def("saveChi2Contributions", &FitterBase::saveChi2Contributions);
 }
 
 void declareAstrometryFit(py::module &mod) {

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -274,9 +274,9 @@ class JointcalTask(pipeBase.CmdLineTask):
         goodSrc = self.sourceSelector.selectSources(src)
 
         if len(goodSrc.sourceCat) == 0:
-            self.log.warn("No stars selected in visit %s ccd %s", visit, ccdname)
+            self.log.warn("No sources selected in visit %s ccd %s", visit, ccdname)
         else:
-            self.log.info("%d stars selected in visit %d ccd %d", len(goodSrc.sourceCat), visit, ccdname)
+            self.log.info("%d sources selected in visit %d ccd %d", len(goodSrc.sourceCat), visit, ccdname)
         associations.addImage(goodSrc.sourceCat, tanWcs, visitInfo, bbox, filterName, photoCalib, detector,
                               visit, ccdname, jointcalControl)
 

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -371,7 +371,8 @@ class JointcalTask(pipeBase.CmdLineTask):
                                                       fit_function=self._fit_photometry,
                                                       profile_jointcal=profile_jointcal,
                                                       tract=tract,
-                                                      filters=filters)
+                                                      filters=filters,
+                                                      reject_bad_fluxes=True)
         else:
             photometry = Photometry(None, None)
 
@@ -386,7 +387,8 @@ class JointcalTask(pipeBase.CmdLineTask):
 
     def _do_load_refcat_and_fit(self, associations, defaultFilter, center, radius,
                                 name="", refObjLoader=None, filters=[], fit_function=None,
-                                tract=None, profile_jointcal=False, match_cut=3.0):
+                                tract=None, profile_jointcal=False, match_cut=3.0,
+                                reject_bad_fluxes=False):
         """Load reference catalog, perform the fit, and return the result.
 
         Parameters
@@ -414,6 +416,8 @@ class JointcalTask(pipeBase.CmdLineTask):
         match_cut : float, optional
             Radius in arcseconds to find cross-catalog matches to during
             associations.associateCatalogs.
+        reject_bad_fluxes : bool, optional
+            Reject refCat sources with NaN/inf flux or NaN/0 fluxErr.
 
         Returns
         -------
@@ -445,7 +449,7 @@ class JointcalTask(pipeBase.CmdLineTask):
             refFluxErrs[filt] = refCat.get(filtKeys[1])
 
         associations.collectRefStars(refCat, self.config.matchCut*afwGeom.arcseconds,
-                                     skyCircle.fluxField, refFluxes, refFluxErrs)
+                                     skyCircle.fluxField, refFluxes, refFluxErrs, reject_bad_fluxes)
         self.metrics['collected%sRefStars' % name] = associations.refStarListSize()
 
         associations.selectFittedStars(self.config.minMeasurements)

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -1,4 +1,5 @@
 // -*- C++ -*-
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <sstream>
@@ -141,7 +142,8 @@ void Associations::associateCatalogs(const double matchCutInArcSec, const bool u
 void Associations::collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::table::SimpleRecord> &refCat,
                                    afw::geom::Angle matchCut, std::string const &fluxField,
                                    std::map<std::string, std::vector<double>> const &refFluxMap,
-                                   std::map<std::string, std::vector<double>> const &refFluxErrMap) {
+                                   std::map<std::string, std::vector<double>> const &refFluxErrMap,
+                                   bool rejectBadFluxes) {
     if (refCat.size() == 0) {
         throw(LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " reference catalog is empty : stop here "));
@@ -196,6 +198,10 @@ void Associations::collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::t
         star->vy = std::pow(0.1 / 3600, 2);
         star->vxy = 0.;
 
+        // Reject sources with non-finite fluxes and flux errors, and fluxErr=0 (which gives chi2=inf).
+        if (rejectBadFluxes &&
+            (!std::isfinite(defaultFlux) || !std::isfinite(defaultFluxErr) || defaultFluxErr == 0))
+            continue;
         refStarList.push_back(star);
     }
 

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -548,58 +548,36 @@ void AstrometryFit::checkStuff() {
     }
 }
 
-void AstrometryFit::saveResultTuples(std::string const &tupleName) const {
-    /* cook-up 2 different file names by inserting something just before
-       the dot (if any), and within the actual file name. */
-    size_t dot = tupleName.rfind('.');
-    size_t slash = tupleName.rfind('/');
-    if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) dot = tupleName.size();
-    std::string meas_tuple(tupleName);
-    meas_tuple.insert(dot, "-meas");
-    makeMeasResTuple(meas_tuple);
-    std::string ref_tuple(tupleName);
-    ref_tuple.insert(dot, "-ref");
-    makeRefResTuple(ref_tuple);
-}
-
-void AstrometryFit::makeMeasResTuple(std::string const &tupleName) const {
-    std::ofstream tuple(tupleName.c_str());
-    tuple << "#xccd: coordinate in CCD" << std::endl
-          << "#yccd: " << std::endl
-          << "#rx:   residual in degrees in TP" << std::endl
-          << "#ry:" << std::endl
-          << "#xtp: transformed coordinate in TP " << std::endl
-          << "#ytp:" << std::endl
-          << "#mag: rough mag" << std::endl
-          << "#jd: Julian date of the measurement" << std::endl
-          << "#rvx: transformed measurement uncertainty " << std::endl
-          << "#rvy:" << std::endl
-          << "#rvxy:" << std::endl
-          << "#color : " << std::endl
-          << "#fsindex: some unique index of the object" << std::endl
-          << "#ra: pos of fitted star" << std::endl
-          << "#dec: pos of fitted star" << std::endl
-          << "#chi2: contribution to Chi2 (2D dofs)" << std::endl
-          << "#nm: number of measurements of this FittedStar" << std::endl
-          << "#chip: chip number" << std::endl
-          << "#visit: visit id" << std::endl
-          << "#end" << std::endl;
-    const CcdImageList &L = _associations->getCcdImageList();
-    for (auto const &i : L) {
-        const CcdImage &im = *i;
-        const MeasuredStarList &cat = im.getCatalogForFit();
-        const Mapping *mapping = _astrometryModel->getMapping(im);
-        const Point &refractionVector = im.getRefractionVector();
-        double mjd = im.getMjd() - _JDRef;
-        for (auto const &is : cat) {
-            const MeasuredStar &ms = *is;
-            if (!ms.isValid()) continue;
+void AstrometryFit::saveChi2MeasContributions(std::string const &baseName) const {
+    std::ofstream ofile(baseName.c_str());
+    std::string separator = "\t";
+    ofile << "#xccd" << separator << "yccd " << separator << "rx" << separator << "ry" << separator << "xtp"
+          << separator << "ytp" << separator << "mag" << separator << "mjd" << separator << "rvx" << separator
+          << "rvy" << separator << "rvxy" << separator << "color" << separator << "fsindex" << separator
+          << "ra" << separator << "dec" << separator << "chi2" << separator << "nm" << separator << "chip"
+          << separator << "visit" << std::endl;
+    ofile << "#coordinates in CCD" << separator << separator << "residual in degrees in TP" << separator
+          << separator << "transformed coordinate in TP" << separator << separator << "rough mag" << separator
+          << "Modified Julian date of the measurement" << separator << "transformed measurement uncertainty"
+          << separator << separator << separator << "currently unused" << separator
+          << "unique index of the fittedStar" << separator << "on sky position of fittedStar" << separator
+          << separator << "contribution to Chi2 (2D dofs)" << separator
+          << "number of measurements of this fittedStar" << separator << "chip id" << separator << "visit id"
+          << std::endl;
+    const CcdImageList &ccdImageList = _associations->getCcdImageList();
+    for (auto const &ccdImage : ccdImageList) {
+        const MeasuredStarList &cat = ccdImage->getCatalogForFit();
+        const Mapping *mapping = _astrometryModel->getMapping(*ccdImage);
+        const Point &refractionVector = ccdImage->getRefractionVector();
+        double mjd = ccdImage->getMjd() - _JDRef;
+        for (auto const &ms : cat) {
+            if (!ms->isValid()) continue;
             FatPoint tpPos;
-            FatPoint inPos = ms;
-            tweakAstromMeasurementErrors(inPos, ms, _posError);
+            FatPoint inPos = *ms;
+            tweakAstromMeasurementErrors(inPos, *ms, _posError);
             mapping->transformPosAndErrors(inPos, tpPos);
-            const Gtransfo *sky2TP = _astrometryModel->getSky2TP(im);
-            auto fs = ms.getFittedStar();
+            const Gtransfo *sky2TP = _astrometryModel->getSky2TP(*ccdImage);
+            auto fs = ms->getFittedStar();
 
             Point fittedStarInTP =
                     transformFittedStar(*fs, sky2TP, refractionVector, _refractionCoefficient, mjd);
@@ -608,33 +586,30 @@ void AstrometryFit::makeMeasResTuple(std::string const &tupleName) const {
             double wxx = tpPos.vy / det;
             double wyy = tpPos.vx / det;
             double wxy = -tpPos.vxy / det;
-            //      double chi2 = rx*(wxx*rx+wxy*ry)+ry*(wxy*rx+wyy*ry);
             double chi2 = wxx * res.x * res.x + wyy * res.y * res.y + 2 * wxy * res.x * res.y;
-            tuple << std::setprecision(9);
-            tuple << ms.x << ' ' << ms.y << ' ' << res.x << ' ' << res.y << ' ' << tpPos.x << ' ' << tpPos.y
-                  << ' ' << fs->getMag() << ' ' << mjd << ' ' << tpPos.vx << ' ' << tpPos.vy << ' '
-                  << tpPos.vxy << ' ' << fs->color << ' ' << fs->getIndexInMatrix() << ' ' << fs->x << ' '
-                  << fs->y << ' ' << chi2 << ' ' << fs->getMeasurementCount() << ' ' << im.getCcdId() << ' '
-                  << im.getVisit() << std::endl;
+            ofile << std::setprecision(9);
+            ofile << ms->x << separator << ms->y << separator << res.x << separator << res.y << separator
+                  << tpPos.x << separator << tpPos.y << separator << fs->getMag() << separator << mjd
+                  << separator << tpPos.vx << separator << tpPos.vy << separator << tpPos.vxy << separator
+                  << fs->color << separator << fs->getIndexInMatrix() << separator << fs->x << separator
+                  << fs->y << separator << chi2 << separator << fs->getMeasurementCount() << separator
+                  << ccdImage->getCcdId() << separator << ccdImage->getVisit() << std::endl;
         }  // loop on measurements in image
     }      // loop on images
 }
 
-void AstrometryFit::makeRefResTuple(std::string const &tupleName) const {
-    std::ofstream tuple(tupleName.c_str());
-    tuple << "#ra: coordinates of FittedStar" << std::endl
-          << "#dec: " << std::endl
-          << "#rx:   residual in degrees in TP" << std::endl
-          << "#ry:" << std::endl
-          << "#mag: mag" << std::endl
-          << "#rvx: transformed measurement uncertainty " << std::endl
-          << "#rvy:" << std::endl
-          << "#rvxy:" << std::endl
-          << "#color : " << std::endl
-          << "#fsindex: some unique index of the object" << std::endl
-          << "#chi2: contribution to Chi2 (2D dofs)" << std::endl
-          << "#nm: number of measurements of this FittedStar" << std::endl
-          << "#end" << std::endl;
+void AstrometryFit::saveChi2RefContributions(std::string const &baseName) const {
+    std::ofstream ofile(baseName.c_str());
+    std::string separator = "\t";
+    ofile << "#ra" << separator << "dec " << separator << "rx" << separator << "ry" << separator << "mag"
+          << separator << "rvx" << separator << "rvy" << separator << "rvxy" << separator << "color"
+          << separator << "fsindex" << separator << "chi2" << separator << "nm" << std::endl;
+    ofile << "#coordinates of fittedStar" << separator << separator << "residual in degrees in TP"
+          << separator << separator << "magnitude" << separator
+          << "refStar transformed measurement uncertainty" << separator << separator << separator
+          << "currently unused" << separator << "unique index of the fittedStar" << separator
+          << "refStar contribution to Chi2 (2D dofs)" << separator
+          << "number of measurements of this FittedStar" << std::endl;
     // The following loop is heavily inspired from AstrometryFit::computeChi2()
     const FittedStarList &fittedStarList = _associations->fittedStarList;
     TanRaDec2Pix proj(GtransfoLin(), Point(0., 0.));
@@ -653,10 +628,11 @@ void AstrometryFit::makeRefResTuple(std::string const &tupleName) const {
         double wyy = rsProj.vx / det;
         double wxy = -rsProj.vxy / det;
         double chi2 = wxx * std::pow(rx, 2) + 2 * wxy * rx * ry + wyy * std::pow(ry, 2);
-        tuple << std::setprecision(9);
-        tuple << fs.x << ' ' << fs.y << ' ' << rx << ' ' << ry << ' ' << fs.getMag() << ' ' << rsProj.vx
-              << ' ' << rsProj.vy << ' ' << rsProj.vxy << ' ' << fs.color << ' ' << fs.getIndexInMatrix()
-              << ' ' << chi2 << ' ' << fs.getMeasurementCount() << std::endl;
+        ofile << std::setprecision(9);
+        ofile << fs.x << separator << fs.y << separator << rx << separator << ry << separator << fs.getMag()
+              << separator << rsProj.vx << separator << rsProj.vy << separator << rsProj.vxy << separator
+              << fs.color << separator << fs.getIndexInMatrix() << separator << chi2 << separator
+              << fs.getMeasurementCount() << std::endl;
     }  // loop on FittedStars
 }
 }  // namespace jointcal

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -399,7 +399,8 @@ void AstrometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
         double wxx = rsProj.vy / det;
         double wyy = rsProj.vx / det;
         double wxy = -rsProj.vxy / det;
-        accum.addEntry(wxx * std::pow(rx, 2) + 2 * wxy * rx * ry + wyy * std::pow(ry, 2), 2, fs);
+        double chi2 = wxx * std::pow(rx, 2) + 2 * wxy * rx * ry + wyy * std::pow(ry, 2);
+        accum.addEntry(chi2, 2, fs);
     }
 }
 

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -117,9 +117,14 @@ CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw
         double cosz = 1. / _airMass;
         double sinz = sqrt(1 - cosz * cosz);  // astronomers usually observe above the horizon
         _tgz = sinz / cosz;
-        _sineta = cos(latitude) * sin(_hourAngle) / sinz;
-        _coseta = sqrt(1 - _sineta * _sineta);
-        if (_boresightRaDec.getDec() > latitude) _coseta = -_coseta;
+        // TODO: as part of DM-12473, we can remove all of this and just call _visitInfo.getParallacticAngle()
+        double dec = _boresightRaDec.getLatitude();
+        // x/y components of refraction angle, eta.]
+        double yEta = sin(_hourAngle);
+        double xEta = cos(dec) * tan(latitude) - sin(dec) * cos(_hourAngle);
+        double eta = atan2(yEta, xEta);
+        _sineta = sin(eta);
+        _coseta = cos(eta);
     }
 }
 

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -220,5 +220,19 @@ void FitterBase::leastSquareDerivatives(TripletList &tripletList, Eigen::VectorX
     leastSquareDerivativesReference(_associations->fittedStarList, tripletList, grad);
 }
 
+void FitterBase::saveChi2Contributions(std::string const &baseName) const {
+    /* cook-up 2 different file names by inserting something just before
+   the dot (if any), and within the actual file name. */
+    size_t dot = baseName.rfind('.');
+    size_t slash = baseName.rfind('/');
+    if (dot == std::string::npos || (slash != std::string::npos && dot < slash)) dot = baseName.size();
+    std::string measTuple(baseName);
+    measTuple.insert(dot, "-meas");
+    saveChi2MeasContributions(measTuple);
+    std::string refTuple(baseName);
+    refTuple.insert(dot, "-ref");
+    saveChi2RefContributions(refTuple);
+}
+
 }  // namespace jointcal
 }  // namespace lsst

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -58,6 +58,9 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         self.config.photometryRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
         self.config.astrometryRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
 
+        # to test whether we got the expected chi2 contribution files.
+        self.other_args.extend(['--config', 'writeChi2ContributionFiles=True'])
+
         # NOTE: The relative RMS limit was empirically determined from the
         # first run of jointcal on this data. We should always do better than
         # this in the future!
@@ -80,6 +83,17 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
                    }
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, pa1, metrics=metrics)
+
+        # Check for the existence of the chi2 contribution files.
+        expected = ['Photometry_initial_chi2-0_r', 'Astrometry_initial_chi2-0_r',
+                    'Photometry_final_chi2-0_r', 'Astrometry_final_chi2-0_r']
+        for partial in expected:
+            name = partial+'-ref.csv'
+            self.assertTrue(os.path.exists(name), msg="Did not find file %s"%name)
+            os.remove(name)
+            name = partial+'-meas.csv'
+            self.assertTrue(os.path.exists(name), msg='Did not find file %s'%name)
+            os.remove(name)
 
     def test_jointcalTask_2_visits_constrainedPoly(self):
         self.config = lsst.jointcal.jointcal.JointcalConfig()

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -67,9 +67,9 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
         pa1 = 0.14
         # NOTE: decam fits are currently not converging; the chi2 jumps around, so skip that Metric.
         metrics = {'collectedAstrometryRefStars': 8194,
-                   'collectedPhotometryRefStars': 8194,
+                   'collectedPhotometryRefStars': 8190,
                    'selectedAstrometryRefStars': 8194,
-                   'selectedPhotometryRefStars': 8194,
+                   'selectedPhotometryRefStars': 8190,
                    'associatedAstrometryFittedStars': 8241,
                    'associatedPhotometryFittedStars': 8241,
                    'selectedAstrometryFittedStars': 2261,


### PR DESCRIPTION
This should fix NaNs that sneak in via bad refractionAngle calculations, refcat sources with `flux=NaN or inf` or `fluxErr=NaN or inf or 0`, and cause early failure if chi2 is NaN before or during the fitting process. I also made some cleanups that helped me debug this but that we'll want for the future.