### PR TITLE
DM-12602 fitting bugfixes and other cleanups

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-=================
-Joint Calibration
-=================
-
-This package performs joint astrometry and photometry across multiple visits of the same field, fitting models for the astrometric distortions and photometric calibrations of the CCDs and focal plane.
-
-It was derived from lsst_france/meas_simastrom

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,12 @@
+# Joint Calibration
+
+This package performs joint astrometry and photometry across multiple visits of the same field, fitting models for the astrometric distortions and photometric calibrations of the CCDs and focal plane.
+
+It was derived from lsst_france/meas_simastrom
+
+## A note on tests
+
+All of the `tests/test_jointcal_<obs>.py` tests run jointcal on their respective `testdata_jointcal/<obs>` dataset.
+The numeric values being tested (the metrics, pa1, and relative/absolute rms) were not computed in advance, but are empirical, from the first time that test was successfully run.
+They are updated when changes to the algorithm warrants, e.g. a change to outlier rejection might affect the final chi2/ndof for some of the testdata.
+More sophisticated testing of jointcal's validity is handled by `validate_drp` on much larger datasets that have multiple full-focal plane visits.

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -69,6 +69,7 @@ public:
      * @param[in]  bbox       The bounding box of the exposure
      * @param[in]  filter     The exposure's filter
      * @param[in]  photoCalib The exposure's photometric calibration
+     * @param[in]  detector   The exposure's detector
      * @param[in]  visit      The visit identifier
      * @param[in]  ccd        The ccd identifier
      * @param[in]  control    The JointcalControl object

--- a/include/lsst/jointcal/ConstrainedPhotometryModel.h
+++ b/include/lsst/jointcal/ConstrainedPhotometryModel.h
@@ -48,7 +48,8 @@ public:
     void offsetParams(Eigen::VectorXd const &delta) override;
 
     /// @copydoc PhotometryModel::transform
-    double transform(CcdImage const &ccdImage, MeasuredStar const &star, double instFlux) const override;
+    double transform(CcdImage const &ccdImage, MeasuredStar const &measuredStar,
+                     double instFlux) const override;
 
     /// @copydoc PhotometryModel::getMappingIndices
     void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const override;

--- a/include/lsst/jointcal/ConstrainedPolyModel.h
+++ b/include/lsst/jointcal/ConstrainedPolyModel.h
@@ -26,12 +26,12 @@ namespace jointcal {
  * transformation depending on the chip number (instrument model) and a
  * transformation per visit (anamorphism). The two-transformation Mapping
  * required for this model is TwoTransfoMapping. This modeling of distortions
- * is meant for set of images from a single mosaic imager.
+ * is meant for a set of images from a single mosaic imager.
  */
 class ConstrainedPolyModel : public AstrometryModel {
 public:
     ConstrainedPolyModel(CcdImageList const &ccdImageList, ProjectionHandler const *projectionHandler,
-                         bool initFromWCS, unsigned nNotFit = 0);
+                         bool initFromWCS, unsigned nNotFit = 0, int chipDegree = 3, int visitDegree = 2);
 
     /// No copy or move: there is only ever one instance of a given model (i.e. per ccd+visit)
     ConstrainedPolyModel(ConstrainedPolyModel const &) = delete;

--- a/include/lsst/jointcal/PhotometryModel.h
+++ b/include/lsst/jointcal/PhotometryModel.h
@@ -54,7 +54,8 @@ public:
     /**
      * Get how this set of parameters (of length Npar()) map into the "grand" fit.
      *
-     * @param[out]    indices   The indices of the mapping associated with ccdImage.
+     * @param[in]  ccdImage  The ccdImage to look up.
+     * @param[out] indices   The indices of the mapping associated with ccdImage.
      */
     virtual void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const = 0;
 

--- a/include/lsst/jointcal/SimplePhotometryModel.h
+++ b/include/lsst/jointcal/SimplePhotometryModel.h
@@ -34,7 +34,8 @@ public:
     void offsetParams(Eigen::VectorXd const &delta) override;
 
     /// @copydoc PhotometryModel::transform
-    double transform(CcdImage const &ccdImage, MeasuredStar const &star, double instFlux) const override;
+    double transform(CcdImage const &ccdImage, MeasuredStar const &measuredStar,
+                     double instFlux) const override;
 
     /// @copydoc PhotometryModel::getMappingIndices
     void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const override;

--- a/python/lsst/jointcal/astrometryModels.cc
+++ b/python/lsst/jointcal/astrometryModels.cc
@@ -55,8 +55,9 @@ void declareConstrainedPolyModel(py::module &mod) {
     py::class_<ConstrainedPolyModel, std::shared_ptr<ConstrainedPolyModel>, AstrometryModel> cls(
             mod, "ConstrainedPolyModel");
 
-    cls.def(py::init<CcdImageList const &, const ProjectionHandler *, bool, unsigned>(), "ccdImageList"_a,
-            "projectionHandler"_a, "initFromWcs"_a, "nNotFit"_a = 0);
+    cls.def(py::init<CcdImageList const &, const ProjectionHandler *, bool, unsigned, int, int>(),
+            "ccdImageList"_a, "projectionHandler"_a, "initFromWcs"_a, "nNotFit"_a = 0, "chipDegree"_a = 3,
+            "visitDegree"_a = 2);
 }
 
 PYBIND11_PLUGIN(astrometryModels) {

--- a/python/lsst/jointcal/dataIds.py
+++ b/python/lsst/jointcal/dataIds.py
@@ -98,7 +98,8 @@ class PerTractCcdDataIdContainer(CoaddDataIdContainer):
                 tract = dataId.pop("tract")
                 # making a DataRef for src fills out any missing keys and allows us to iterate
                 for ref in namespace.butler.subset("src", dataId=dataId):
-                    self._addDataRef(namespace, ref.dataId, tract)
+                    if ref.datasetExists():
+                        self._addDataRef(namespace, ref.dataId, tract)
 
         # Ensure all components of a visit are kept together by putting them all in the same set of tracts
         # NOTE: sorted() here is to keep py2 and py3 dataRefs in the same order.

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -262,7 +262,7 @@ class JointcalTask(pipeBase.CmdLineTask):
 
         visitInfo = dataRef.get('calexp_visitInfo')
         detector = dataRef.get('calexp_detector')
-        ccdname = detector.getId()
+        ccdId = detector.getId()
         calib = dataRef.get('calexp_calib')
         tanWcs = dataRef.get('calexp_wcs')
         bbox = dataRef.get('calexp_bbox')
@@ -274,15 +274,15 @@ class JointcalTask(pipeBase.CmdLineTask):
         goodSrc = self.sourceSelector.selectSources(src)
 
         if len(goodSrc.sourceCat) == 0:
-            self.log.warn("No sources selected in visit %s ccd %s", visit, ccdname)
+            self.log.warn("No sources selected in visit %s ccd %s", visit, ccdId)
         else:
-            self.log.info("%d sources selected in visit %d ccd %d", len(goodSrc.sourceCat), visit, ccdname)
+            self.log.info("%d sources selected in visit %d ccd %d", len(goodSrc.sourceCat), visit, ccdId)
         associations.addImage(goodSrc.sourceCat, tanWcs, visitInfo, bbox, filterName, photoCalib, detector,
-                              visit, ccdname, jointcalControl)
+                              visit, ccdId, jointcalControl)
 
         Result = collections.namedtuple('Result_from_build_CcdImage', ('wcs', 'key', 'filter'))
         Key = collections.namedtuple('Key', ('visit', 'ccd'))
-        return Result(tanWcs, Key(visit, ccdname), filterName)
+        return Result(tanWcs, Key(visit, ccdId), filterName)
 
     @pipeBase.timeMethod
     def run(self, dataRefs, profile_jointcal=False):

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -88,7 +88,8 @@ class JointcalRunner(pipeBase.ButlerInitializedTaskRunner):
             else:
                 exitStatus = 1
                 eName = type(e).__name__
-                task.log.fatal("Failed on dataIds=%s: %s: %s", dataRefList, eName, e)
+                tract = dataRefList[0].dataId['tract']
+                task.log.fatal("Failed processing tract %s, %s: %s", tract, eName, e)
 
         if self.doReturnResults:
             return pipeBase.Struct(result=result, exitStatus=exitStatus)
@@ -638,14 +639,12 @@ class JointcalTask(pipeBase.CmdLineTask):
                 chi2 = fit.computeChi2()
                 self.log.info("Fit completed with: %s", str(chi2))
                 break
-            elif r == MinimizeResult.Failed:
-                self.log.warn("minimization failed")
-                break
             elif r == MinimizeResult.Chi2Increased:
                 self.log.warn("still some ouliers but chi2 increases - retry")
+            elif r == MinimizeResult.Failed:
+                raise RuntimeError("Chi2 minimization failure, cannot complete fit.")
             else:
-                self.log.error("unxepected return code from minimize")
-                break
+                raise RuntimeError("Unxepected return code from minimize().")
         else:
             self.log.error("%s failed to converge after %d steps"%(name, max_steps))
 

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -130,8 +130,18 @@ class JointcalConfig(pexConfig.Config):
         dtype=int,
         default=2,
     )
-    polyOrder = pexConfig.Field(
-        doc="Polynomial order for fitting distorsion",
+    astrometrySimpleDegree = pexConfig.Field(
+        doc="Polynomial degree for fitting the simple astrometry model.",
+        dtype=int,
+        default=3,
+    )
+    astrometryChipDegree = pexConfig.Field(
+        doc="Degree of the per-chip transform for the constrained astrometry model.",
+        dtype=int,
+        default=2,
+    )
+    astrometryVisitDegree = pexConfig.Field(
+        doc="Degree of the per-visit transform for the constrained astrometry model.",
         dtype=int,
         default=3,
     )
@@ -572,11 +582,13 @@ class JointcalTask(pipeBase.CmdLineTask):
 
         if self.config.astrometryModel == "constrainedPoly":
             model = lsst.jointcal.ConstrainedPolyModel(associations.getCcdImageList(),
-                                                       sky_to_tan_projection, True, 0)
+                                                       sky_to_tan_projection, True, 0,
+                                                       chipDegree=self.config.astrometryChipDegree,
+                                                       visitDegree=self.config.astrometryVisitDegree)
         elif self.config.astrometryModel == "simplePoly":
             model = lsst.jointcal.SimplePolyModel(associations.getCcdImageList(),
                                                   sky_to_tan_projection,
-                                                  True, 0, self.config.polyOrder)
+                                                  True, 0, self.config.astrometrySimpleDegree)
 
         fit = lsst.jointcal.AstrometryFit(associations, model, self.config.posError)
         chi2 = fit.computeChi2()

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -200,7 +200,7 @@ std::shared_ptr<TanSipPix2RaDec> ConstrainedPolyModel::produceSipWcs(CcdImage co
     } catch (std::bad_cast &) {
         try {
             const GtransfoPoly &t2_poly = dynamic_cast<const GtransfoPoly &>(mapping->getTransfo2());
-            pix2Tp = t1 * t2_poly;
+            pix2Tp = t2_poly * t1;
         } catch (std::bad_cast &) {
             LOGLS_ERROR(_log, "Problem with transform 2 of ccd/visit " << ccdImage.getCcdId() << "/"
                                                                        << ccdImage.getVisit() << ": T2 "

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -153,7 +153,7 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
         offsetParams(delta);
         Chi2Statistic currentChi2(computeChi2());
         LOGLS_DEBUG(_log, currentChi2);
-        if (currentChi2.chi2 > oldChi2) {
+        if (currentChi2.chi2 > oldChi2 && totalOutliers != 0) {
             LOGL_WARN(_log, "chi2 went up, skipping outlier rejection loop");
             returnCode = MinimizeResult::Chi2Increased;
             break;

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -105,18 +105,19 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         # NOTE: The relative RMS limit was empirically determined from the
         # first run of jointcal on this data. We should always do better than
         # this in the future!
-        dist_rms_relative = 12e-3*u.arcsecond
+        dist_rms_relative = 16e-3*u.arcsecond
+        dist_rms_absolute = 54e-3*u.arcsecond
         pa1 = None
         metrics = {'collectedAstrometryRefStars': 825,
                    'selectedAstrometryRefStars': 825,
                    'associatedAstrometryFittedStars': 2269,
                    'selectedAstrometryFittedStars': 1239,
                    'selectedAstrometryCcdImageList': 12,
-                   'astrometryFinalChi2': 1241.6,
-                   'astrometryFinalNdof': 2640,
+                   'astrometryFinalChi2': 1376.24,
+                   'astrometryFinalNdof': 2630,
                    }
 
-        self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, pa1, metrics=metrics)
+        self._testJointcalTask(2, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
 
     def test_jointcalTask_2_visits_constrainedPhotometry_no_astrometry(self):
         self.config = lsst.jointcal.jointcal.JointcalConfig()

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -82,7 +82,9 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
                    'photometryFinalNdof': 2333,
                    }
 
-        self._testJointcalTask(2, relative_error, self.dist_rms_absolute, pa1, metrics=metrics)
+        # TODO DM-12653: decam fails due to factorization problems.
+        with self.assertRaises(RuntimeError):
+            self._testJointcalTask(2, relative_error, self.dist_rms_absolute, pa1, metrics=metrics)
 
     def test_jointcalTask_2_visits_constrainedPoly(self):
         self.config = lsst.jointcal.jointcal.JointcalConfig()
@@ -106,7 +108,9 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
                    'astrometryFinalNdof': 4530,
                    }
 
-        self._testJointcalTask(2, relative_error, self.dist_rms_absolute, pa1, metrics=metrics)
+        # TODO DM-12653: decam fails due to factorization problems.
+        with self.assertRaises(RuntimeError):
+            self._testJointcalTask(2, relative_error, self.dist_rms_absolute, pa1, metrics=metrics)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -79,7 +79,7 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
                    'astrometryFinalChi2': None,
                    'astrometryFinalNdof': 4306,
                    'photometryFinalChi2': None,
-                   'photometryFinalNdof': 2391,
+                   'photometryFinalNdof': 2333,
                    }
 
         self._testJointcalTask(2, relative_error, self.dist_rms_absolute, pa1, metrics=metrics)


### PR DESCRIPTION
This is a bit of a grab-bag of changes, but it was spurred by some changes I needed for DM-11785, and some bugs in the fitting code discovered by @boutigny and @PierreAstier .

Jointcal now raises an exception if there's a CHOLMOD error, instead of printing a message and continuing on. Making that error more obvious seems like the right approach.