### PR TITLE
DM-10066: Provide utility function for wrapping operator<<

### DIFF
--- a/python/lsst/jointcal/chi2.cc
+++ b/python/lsst/jointcal/chi2.cc
@@ -22,6 +22,8 @@
 
 #include "pybind11/pybind11.h"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/jointcal/Chi2.h"
 
 namespace py = pybind11;
@@ -36,11 +38,7 @@ void declareChi2(py::module &mod) {
 
     cls.def(py::init<>());
 
-    cls.def("__str__", [](Chi2Statistic const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
 
     cls.def_readwrite("chi2", &Chi2Statistic::chi2);
     cls.def_readwrite("ndof", &Chi2Statistic::ndof);

--- a/python/lsst/jointcal/photometryModels.cc
+++ b/python/lsst/jointcal/photometryModels.cc
@@ -27,6 +27,8 @@
 #include "ndarray/eigen.h"
 #include "Eigen/Core"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/jointcal/CcdImage.h"
 #include "lsst/jointcal/PhotometryModel.h"
 #include "lsst/jointcal/Point.h"
@@ -59,11 +61,7 @@ void declarePhotometryModel(py::module &mod) {
     cls.def("getNpar", &PhotometryModel::getNpar);
     cls.def("toPhotoCalib", &PhotometryModel::toPhotoCalib);
     cls.def("getMapping", &PhotometryModel::getMapping, py::return_value_policy::reference_internal);
-    cls.def("__str__", [](PhotometryModel const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
 }
 
 void declareSimplePhotometryModel(py::module &mod) {

--- a/python/lsst/jointcal/photometryTransfo.cc
+++ b/python/lsst/jointcal/photometryTransfo.cc
@@ -26,6 +26,8 @@
 #include "ndarray/eigen.h"
 #include "Eigen/Core"
 
+#include "lsst/utils/python.h"
+
 #include "lsst/jointcal/PhotometryTransfo.h"
 
 namespace py = pybind11;
@@ -52,11 +54,7 @@ void declarePhotometryTransfo(py::module &mod) {
                 return derivatives;
             });
 
-    cls.def("__str__", [](PhotometryTransfo const &self) {
-        std::stringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
 }
 
 void declarePhotometryTransfoSpatiallyInvariant(py::module &mod) {

--- a/python/lsst/jointcal/star.cc
+++ b/python/lsst/jointcal/star.cc
@@ -25,6 +25,8 @@
 
 #include <list>
 
+#include "lsst/utils/python.h"
+
 #include "lsst/jointcal/Point.h"
 #include "lsst/jointcal/FatPoint.h"
 #include "lsst/jointcal/BaseStar.h"
@@ -60,11 +62,7 @@ void declareBaseStar(py::module &mod) {
     // cls.def("getFlux", &BaseStar::getFlux);
     cls.def_property_readonly("flux", (double (BaseStar::*)() const) & BaseStar::getFlux);
 
-    cls.def("__str__", [](BaseStar const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    });
+    utils::python::addOutputOp(cls, "__str__");
 }
 
 void declareRefStar(py::module &mod) {


### PR DESCRIPTION
This PR replaces trivial pybind11 wrappers of operator<< with calls to `wrapOutputOp`, which is introduced in lsst/utils#47. Non-trivial wrappers (typically ones that add extra information to `__repr__`) are left untouched.