### PR TITLE
DM-12959: Run clang-tidy

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -82,7 +82,7 @@ public:
                   lsst::jointcal::JointcalControl const &control);
 
     //! incrementaly builds a merged catalog of all image catalogs
-    void associateCatalogs(const double matchCutInArcsec = 0, const bool useFittedList = false,
+    void associateCatalogs(const double matchCutInArcSec = 0, const bool useFittedList = false,
                            const bool enlargeFittedList = true);
 
     /**
@@ -140,7 +140,7 @@ public:
     size_t nFittedStarsWithAssociatedRefStar() const;
 
 private:
-    void associateRefStars(double matchCutInArcsec, Gtransfo const *gtransfo);
+    void associateRefStars(double matchCutInArcSec, Gtransfo const *gtransfo);
 
     void assignMags();
 

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -140,7 +140,7 @@ public:
     size_t nFittedStarsWithAssociatedRefStar() const;
 
 private:
-    void associateRefStars(double matchCutInArcsec, const Gtransfo *gtransfo);
+    void associateRefStars(double matchCutInArcsec, Gtransfo const *gtransfo);
 
     void assignMags();
 

--- a/include/lsst/jointcal/AstroUtils.h
+++ b/include/lsst/jointcal/AstroUtils.h
@@ -10,7 +10,7 @@ namespace jointcal {
 class Frame;
 class Gtransfo;
 //! Transform a Frame through a Transfo.
-Frame applyTransfo(const Frame& inputframe, const Gtransfo& gtransfo, const WhichTransformed which);
+Frame applyTransfo(Frame const & inputframe, Gtransfo const & gtransfo, const WhichTransformed which);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/AstroUtils.h
+++ b/include/lsst/jointcal/AstroUtils.h
@@ -10,7 +10,7 @@ namespace jointcal {
 class Frame;
 class Gtransfo;
 //! Transform a Frame through a Transfo.
-Frame applyTransfo(Frame const & inputframe, Gtransfo const & gtransfo, const WhichTransformed which);
+Frame applyTransfo(Frame const& inputframe, Gtransfo const& gtransfo, const WhichTransformed which);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -122,11 +122,11 @@ private:
     double _posError;  // constant term on error on position (in pixel unit)
 
     void leastSquareDerivativesMeasurement(CcdImage const &ccdImage, TripletList &tripletList,
-                                           Eigen::VectorXd &grad,
+                                           Eigen::VectorXd &fullGrad,
                                            MeasuredStarList const *msList = nullptr) const override;
 
     void leastSquareDerivativesReference(FittedStarList const &fittedStarList, TripletList &tripletList,
-                                         Eigen::VectorXd &grad) const override;
+                                         Eigen::VectorXd &fullGrad) const override;
 
     void accumulateStatImageList(CcdImageList const &ccdImageList, Chi2Accumulator &accum) const override;
 

--- a/include/lsst/jointcal/AstrometryModel.h
+++ b/include/lsst/jointcal/AstrometryModel.h
@@ -21,7 +21,7 @@ the top of simplepolymodel.h */
 class AstrometryModel {
 public:
     //! Mapping associated to a given CcdImage
-    virtual const Mapping *getMapping(CcdImage const &) const = 0;
+    virtual Mapping const *getMapping(CcdImage const &) const = 0;
 
     //! Assign indices to parameters involved in mappings, starting at firstIndex. Returns the highest
     //! assigned index.
@@ -35,7 +35,7 @@ public:
     //! The transformation used to project the positions of FittedStars.
     /*! This defines the coordinate system into which the Mapping of
         this Ccdimage maps the pixel coordinates. */
-    virtual const Gtransfo *getSky2TP(CcdImage const &ccdImage) const = 0;
+    virtual Gtransfo const *getSky2TP(CcdImage const &ccdImage) const = 0;
 
     //! Cook up a SIP WCS.
     virtual std::shared_ptr<TanSipPix2RaDec> produceSipWcs(CcdImage const &ccdImage) const = 0;

--- a/include/lsst/jointcal/BaseStar.h
+++ b/include/lsst/jointcal/BaseStar.h
@@ -53,7 +53,7 @@ public:
         return (*this);
     };
 
-    static const char *typeName() { return "BaseStar"; }
+    static char const *typeName() { return "BaseStar"; }
 
     virtual ~BaseStar(){};
 

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -35,7 +35,7 @@ std::ostream &operator<<(std::ostream &out, CcdImageKey const &key);
 class CcdImage {
 public:
     CcdImage(afw::table::SourceCatalog &record, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-             const std::shared_ptr<lsst::afw::image::VisitInfo>& visitInfo, afw::geom::Box2I const &bbox,
+             const std::shared_ptr<lsst::afw::image::VisitInfo> &visitInfo, afw::geom::Box2I const &bbox,
              std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
              std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccd,
              std::string const &fluxField);

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -34,10 +34,10 @@ std::ostream &operator<<(std::ostream &out, CcdImageKey const &key);
  */
 class CcdImage {
 public:
-    CcdImage(afw::table::SourceCatalog &record, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
+    CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
              const std::shared_ptr<lsst::afw::image::VisitInfo> &visitInfo, afw::geom::Box2I const &bbox,
              std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
-             std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccd,
+             std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccdId,
              std::string const &fluxField);
 
     /// No move or copy: each CCD image is unique to that ccd+visit, and Associations holds all CcdImages.
@@ -144,7 +144,7 @@ public:
     Frame const &getImageFrame() const { return _imageFrame; }
 
 private:
-    void loadCatalog(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> const &Cat,
+    void loadCatalog(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> const &catalog,
                      std::string const &fluxField);
 
     Frame _imageFrame;  // in pixels

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -35,7 +35,7 @@ std::ostream &operator<<(std::ostream &out, CcdImageKey const &key);
 class CcdImage {
 public:
     CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-             const std::shared_ptr<lsst::afw::image::VisitInfo> &visitInfo, afw::geom::Box2I const &bbox,
+             std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo, afw::geom::Box2I const &bbox,
              std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
              std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccdId,
              std::string const &fluxField);

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -35,7 +35,7 @@ std::ostream &operator<<(std::ostream &out, CcdImageKey const &key);
 class CcdImage {
 public:
     CcdImage(afw::table::SourceCatalog &record, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-             std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo, afw::geom::Box2I const &bbox,
+             const std::shared_ptr<lsst::afw::image::VisitInfo>& visitInfo, afw::geom::Box2I const &bbox,
              std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
              std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccd,
              std::string const &fluxField);

--- a/include/lsst/jointcal/ConstrainedPolyModel.h
+++ b/include/lsst/jointcal/ConstrainedPolyModel.h
@@ -53,7 +53,7 @@ public:
      * Dispaches the offsets after a fit step into the actual locations of
      * parameters.
      */
-    void offsetParams(Eigen::VectorXd const &Delta);
+    void offsetParams(Eigen::VectorXd const &delta);
 
     /**
      * From there on, measurement errors are propagated using the current

--- a/include/lsst/jointcal/ConstrainedPolyModel.h
+++ b/include/lsst/jointcal/ConstrainedPolyModel.h
@@ -75,18 +75,18 @@ public:
      * stars are reported) onto the Tangent plane (into which the pixel coordinates
      * are transformed).
      */
-    const Gtransfo *getSky2TP(CcdImage const &ccdImage) const { return _sky2TP->getSky2TP(ccdImage); }
+    Gtransfo const *getSky2TP(CcdImage const &ccdImage) const { return _sky2TP->getSky2TP(ccdImage); }
 
     std::shared_ptr<TanSipPix2RaDec> produceSipWcs(CcdImage const &ccdImage) const;
 
 private:
-    typedef std::map<const CcdImage *, std::unique_ptr<TwoTransfoMapping>> mappingMapType;
+    typedef std::map<CcdImage const *, std::unique_ptr<TwoTransfoMapping>> mappingMapType;
     mappingMapType _mappings;
     typedef std::map<CcdIdType, std::unique_ptr<SimpleGtransfoMapping>> chipMapType;
     chipMapType _chipMap;
     typedef std::map<VisitIdType, std::unique_ptr<SimpleGtransfoMapping>> visitMapType;
     visitMapType _visitMap;
-    const ProjectionHandler *_sky2TP;
+    ProjectionHandler const *_sky2TP;
     bool _fittingChips, _fittingVisits;
 };
 }  // namespace jointcal

--- a/include/lsst/jointcal/FastFinder.h
+++ b/include/lsst/jointcal/FastFinder.h
@@ -47,16 +47,16 @@ public:
     typedef decltype(stars)::const_iterator pstar;
 
     //! Constructor
-    FastFinder(const BaseStarList &list, const unsigned nXSlice = 100);
+    FastFinder(BaseStarList const &list, const unsigned nXSlice = 100);
 
     //! Find the closest with some rejection capability
-    std::shared_ptr<const BaseStar> findClosest(const Point &where, const double maxDist,
-                                                bool (*SkipIt)(const BaseStar &) = nullptr) const;
+    std::shared_ptr<const BaseStar> findClosest(Point const &where, const double maxDist,
+                                                bool (*SkipIt)(BaseStar const &) = nullptr) const;
 
     //!
-    std::shared_ptr<const BaseStar> secondClosest(const Point &where, const double maxDist,
+    std::shared_ptr<const BaseStar> secondClosest(Point const &where, const double maxDist,
                                                   std::shared_ptr<const BaseStar> &closest,
-                                                  bool (*SkipIt)(const BaseStar &) = nullptr) const;
+                                                  bool (*SkipIt)(BaseStar const &) = nullptr) const;
 
     //! mostly for debugging
     void dump() const;
@@ -66,7 +66,7 @@ public:
 
     class Iterator {
     public:  // could be made private, but what for??
-        const FastFinder &finder;
+        FastFinder const &finder;
         int currentSlice, endSlice;
         double yStart, yEnd;  // Y limits ( for all stripes)
         /* pointers to the first and beyond last stars in the y range for
@@ -77,12 +77,12 @@ public:
         void check() const;
 
     public:
-        Iterator(const FastFinder &f, const Point &where, double maxDist);
+        Iterator(FastFinder const &f, Point const &where, double maxDist);
         void operator++();
         stars_element operator*() const;
     };
 
-    Iterator beginScan(const Point &where, double maxDist) const;
+    Iterator beginScan(Point const &where, double maxDist) const;
 
     void findRangeInSlice(const int iSlice, const double yStart, const double yEnd, pstar &start,
                           pstar &end) const;

--- a/include/lsst/jointcal/FastFinder.h
+++ b/include/lsst/jointcal/FastFinder.h
@@ -77,7 +77,7 @@ public:
         void check() const;
 
     public:
-        Iterator(FastFinder const &f, Point const &where, double maxDist);
+        Iterator(FastFinder const &F, Point const &where, double maxDist);
         void operator++();
         stars_element operator*() const;
     };

--- a/include/lsst/jointcal/FatPoint.h
+++ b/include/lsst/jointcal/FatPoint.h
@@ -17,7 +17,7 @@ public:
         vxy = 0;
     };
 
-    FatPoint(Point const & P, double Vx = 1, double Vy = 1, double Vxy = 0)
+    FatPoint(Point const& P, double Vx = 1, double Vy = 1, double Vxy = 0)
             : Point(P), vx(Vx), vy(Vy), vxy(Vxy){};
 
     FatPoint(const double X, const double Y, const double Vx = 1, const double Vy = 1, const double Vxy = 0)

--- a/include/lsst/jointcal/FatPoint.h
+++ b/include/lsst/jointcal/FatPoint.h
@@ -17,7 +17,7 @@ public:
         vxy = 0;
     };
 
-    FatPoint(const Point& P, double Vx = 1, double Vy = 1, double Vxy = 0)
+    FatPoint(Point const & P, double Vx = 1, double Vy = 1, double Vxy = 0)
             : Point(P), vx(Vx), vy(Vy), vxy(Vxy){};
 
     FatPoint(const double X, const double Y, const double Vx = 1, const double Vy = 1, const double Vxy = 0)

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -99,7 +99,7 @@ public:
     int getIndexInMatrix() const { return _indexInMatrix; }
 
     //! Set the astrometric reference star associated with this star.
-    void setRefStar(RefStar const* _refStar);
+    void setRefStar(RefStar const* refStar);
 
     //! Get the astrometric reference star associated with this star.
     RefStar const* getRefStar() const { return _refStar; };

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -45,7 +45,7 @@ public:
               _measurementCount(0),
               _refStar(nullptr) {}
 
-    FittedStar(BaseStar const & baseStar)
+    FittedStar(BaseStar const& baseStar)
             : BaseStar(baseStar),
               _mag(-1),
               _gen(-1),
@@ -55,7 +55,7 @@ public:
               _refStar(nullptr) {}
 
     //!
-    FittedStar(MeasuredStar const & measuredStar);
+    FittedStar(MeasuredStar const& measuredStar);
 
     /// No move, allow copy constructor: we may copy the fitted StarLists when associating and matching
     /// catalogs, otherwise Stars should be managed by shared_ptr only.
@@ -93,16 +93,16 @@ public:
     void addMagMeasurement(double magValue, double magWeight);
 
     //! index is a value that a fit can set and reread....
-    void setIndexInMatrix(unsigned const & index) { _indexInMatrix = index; };
+    void setIndexInMatrix(unsigned const& index) { _indexInMatrix = index; };
 
     //!
     int getIndexInMatrix() const { return _indexInMatrix; }
 
     //! Set the astrometric reference star associated with this star.
-    void setRefStar(RefStar const * _refStar);
+    void setRefStar(RefStar const* _refStar);
 
     //! Get the astrometric reference star associated with this star.
-    RefStar const * getRefStar() const { return _refStar; };
+    RefStar const* getRefStar() const { return _refStar; };
 
 private:
     double _mag;
@@ -110,7 +110,7 @@ private:
     double _wmag;
     unsigned _indexInMatrix;
     int _measurementCount;
-    RefStar const * _refStar;
+    RefStar const* _refStar;
 
     double _fluxErr;
 };
@@ -131,8 +131,8 @@ typedef FittedStarList::iterator FittedStarIterator;
 
 BaseStarList& Fitted2Base(FittedStarList& This);
 BaseStarList* Fitted2Base(FittedStarList* This);
-BaseStarList const & Fitted2Base(FittedStarList const & This);
-BaseStarList const * Fitted2Base(FittedStarList const * This);
+BaseStarList const& Fitted2Base(FittedStarList const& This);
+BaseStarList const* Fitted2Base(FittedStarList const* This);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -45,7 +45,7 @@ public:
               _measurementCount(0),
               _refStar(nullptr) {}
 
-    FittedStar(const BaseStar& baseStar)
+    FittedStar(BaseStar const & baseStar)
             : BaseStar(baseStar),
               _mag(-1),
               _gen(-1),
@@ -55,7 +55,7 @@ public:
               _refStar(nullptr) {}
 
     //!
-    FittedStar(const MeasuredStar& measuredStar);
+    FittedStar(MeasuredStar const & measuredStar);
 
     /// No move, allow copy constructor: we may copy the fitted StarLists when associating and matching
     /// catalogs, otherwise Stars should be managed by shared_ptr only.
@@ -93,16 +93,16 @@ public:
     void addMagMeasurement(double magValue, double magWeight);
 
     //! index is a value that a fit can set and reread....
-    void setIndexInMatrix(const unsigned& index) { _indexInMatrix = index; };
+    void setIndexInMatrix(unsigned const & index) { _indexInMatrix = index; };
 
     //!
     int getIndexInMatrix() const { return _indexInMatrix; }
 
     //! Set the astrometric reference star associated with this star.
-    void setRefStar(const RefStar* _refStar);
+    void setRefStar(RefStar const * _refStar);
 
     //! Get the astrometric reference star associated with this star.
-    const RefStar* getRefStar() const { return _refStar; };
+    RefStar const * getRefStar() const { return _refStar; };
 
 private:
     double _mag;
@@ -110,7 +110,7 @@ private:
     double _wmag;
     unsigned _indexInMatrix;
     int _measurementCount;
-    const RefStar* _refStar;
+    RefStar const * _refStar;
 
     double _fluxErr;
 };
@@ -131,8 +131,8 @@ typedef FittedStarList::iterator FittedStarIterator;
 
 BaseStarList& Fitted2Base(FittedStarList& This);
 BaseStarList* Fitted2Base(FittedStarList* This);
-const BaseStarList& Fitted2Base(const FittedStarList& This);
-const BaseStarList* Fitted2Base(const FittedStarList* This);
+BaseStarList const & Fitted2Base(FittedStarList const & This);
+BaseStarList const * Fitted2Base(FittedStarList const * This);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/Frame.h
+++ b/include/lsst/jointcal/Frame.h
@@ -29,7 +29,7 @@ public:
     Frame(double xMin, double yMin, double xMax, double yMax);
 
     //! typical use: Frame(Point(xmin,ymin),Point(xmax,ymax))
-    Frame(const Point &lowerLeft, const Point &upperRight);
+    Frame(Point const &lowerLeft, Point const &upperRight);
 
     //! size along x axis
     double getWidth() const { return xMax - xMin; }
@@ -41,16 +41,16 @@ public:
     Point getCenter() const { return Point((xMax + xMin) * 0.5, (yMax + yMin) * 0.5); }
 
     //! intersection of Frame's.
-    Frame operator*(const Frame &right) const; /* intersection : a = b n c */
+    Frame operator*(Frame const &right) const; /* intersection : a = b n c */
 
     //! intersection of Frame's
-    Frame &operator*=(const Frame &right); /* intersection : a = a n b */
+    Frame &operator*=(Frame const &right); /* intersection : a = a n b */
 
     //! union of Frames
-    Frame operator+(const Frame &right) const; /* union : a = b u c */
+    Frame operator+(Frame const &right) const; /* union : a = b u c */
 
     //! union of Frames
-    Frame &operator+=(const Frame &right); /* intersection : a = a u b */
+    Frame &operator+=(Frame const &right); /* intersection : a = a u b */
 
     //! shrinks the frame (if marginSize>0), enlarges it (if marginSize<0).
     void cutMargin(const double marginSize);
@@ -59,10 +59,10 @@ public:
     void cutMargin(const double marginX, const double marginY);
 
     //! necessary for comparisons (!= is defined from this one implicitely)
-    bool operator==(const Frame &right) const;
+    bool operator==(Frame const &right) const;
 
     //! comparison
-    bool operator!=(const Frame &right) const { return !(*this == right); }
+    bool operator!=(Frame const &right) const { return !(*this == right); }
 
     //! rescale it. The center does not move.
     Frame rescale(const double factor) const;
@@ -74,15 +74,15 @@ public:
     bool inFrame(double x, double y) const;
 
     //! same as above
-    bool inFrame(const Point &point) const { return inFrame(point.x, point.y); }
+    bool inFrame(Point const &point) const { return inFrame(point.x, point.y); }
 
     //! distance to closest boundary.
-    double minDistToEdges(const Point &point) const;
+    double minDistToEdges(Point const &point) const;
 
     void dump(std::ostream &stream = std::cout) const;
 
     //! allows \verbatim std::cout << frame; \endverbatim.
-    friend std::ostream &operator<<(std::ostream &stream, const Frame &right) {
+    friend std::ostream &operator<<(std::ostream &stream, Frame const &right) {
         right.dump(stream);
         return stream;
     };

--- a/include/lsst/jointcal/Frame.h
+++ b/include/lsst/jointcal/Frame.h
@@ -26,7 +26,7 @@ public:
 
     //! this one is dangerous: you may swap the 2 middle arguments.
     //! Prefer next one
-    Frame(double xMin, double yMin, double xMax, double yMax);
+    Frame(double xmin, double ymin, double xmax, double ymax);
 
     //! typical use: Frame(Point(xmin,ymin),Point(xmax,ymax))
     Frame(Point const &lowerLeft, Point const &upperRight);

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -176,9 +176,9 @@ public:
     //! linear approximation.
     virtual GtransfoLin linearApproximation(Point const &where, const double step = 0.01) const;
 
-    void write(std::ostream &s) const;
+    void write(std::ostream &stream) const;
 
-    void read(std::istream &s);
+    void read(std::istream &stream);
 
     //    ClassDef(GtransfoIdentity,1)
 };
@@ -240,13 +240,13 @@ public:
     std::unique_ptr<Gtransfo> clone() const { return std::unique_ptr<Gtransfo>(new GtransfoPoly(*this)); }
 
     //! access to coefficients (read only)
-    double coeff(const unsigned powX, const unsigned powY, const unsigned whichCoord) const;
+    double coeff(const unsigned degX, const unsigned degY, const unsigned whichCoord) const;
 
     //! write access
-    double &coeff(const unsigned powX, const unsigned powY, const unsigned whichCoord);
+    double &coeff(const unsigned degX, const unsigned degY, const unsigned whichCoord);
 
     //! read access, zero if beyond degree
-    double coeffOrZero(const unsigned powX, const unsigned powY, const unsigned whichCoord) const;
+    double coeffOrZero(const unsigned degX, const unsigned degY, const unsigned whichCoord) const;
 
     double determinant() const;
 
@@ -264,7 +264,8 @@ public:
     void read(std::istream &s);
 
 private:
-    double computeFit(StarMatchList const &starMatchList, Gtransfo const &InTransfo, const bool UseErrors);
+    double computeFit(StarMatchList const &starMatchList, Gtransfo const &shiftToCenter,
+                      const bool useErrors);
 
     unsigned _degree;             // the degree
     unsigned _nterms;             // number of parameters per coordinate
@@ -284,8 +285,8 @@ private:
 };
 
 //! approximates the inverse by a polynomial, up to required precision.
-std::unique_ptr<GtransfoPoly> inversePolyTransfo(Gtransfo const &Direct, Frame const &frame,
-                                                 const double Prec);
+std::unique_ptr<GtransfoPoly> inversePolyTransfo(Gtransfo const &direct, Frame const &frame,
+                                                 const double precision);
 
 GtransfoLin normalizeCoordinatesTransfo(Frame const &frame);
 
@@ -319,8 +320,8 @@ public:
     // double fit(StarMatchList const &starMatchList);
 
     //! Construct a GtransfoLin from parameters
-    GtransfoLin(const double ox, const double oy, const double aa11, const double aa12, const double aa21,
-                const double aa22);
+    GtransfoLin(const double Dx, const double Dy, const double A11, const double A12, const double A21,
+                const double A22);
 
     //! Handy converter:
     GtransfoLin(GtransfoIdentity const &) : GtransfoPoly(1){};
@@ -606,7 +607,7 @@ public:
     using Gtransfo::apply;  // to unhide apply(Point const &)
 
     //! the transfo routine and extra data that it may need.
-    UserTransfo(GtransfoFun &fun, void const *userData);
+    UserTransfo(GtransfoFun &userFun, void const *userData);
 
     void apply(const double xIn, const double yIn, double &xOut, double &yOut) const;
 

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -44,11 +44,11 @@ public:
     virtual void apply(const double xIn, const double yIn, double &xOut, double &yOut) const = 0;
 
     //! applies the tranfo to in and writes into out. Is indeed virtual.
-    void apply(const Point &in, Point &out) const { apply(in.x, in.y, out.x, out.y); }
+    void apply(Point const &in, Point &out) const { apply(in.x, in.y, out.x, out.y); }
 
     //! All these apply(..) shadow the virtual one in derived classes, unless one writes "using
     //! Gtransfo::apply".
-    Point apply(const Point &in) const {
+    Point apply(Point const &in) const {
         double xout, yout;
         apply(in.x, in.y, xout, yout);
         return Point(xout, yout);
@@ -68,20 +68,20 @@ public:
       The returned value is the sum of squared residuals.
       If you want to fit a partial transfo (e.g. such that
       this(T1(p1)) = T2(p2), use StarMatchList::applyTransfo beforehand. */
-    virtual double fit(const StarMatchList &starMatchList) = 0;
+    virtual double fit(StarMatchList const &starMatchList) = 0;
 
     //! allows to write MyTransfo(MyStar)
     void transformStar(FatPoint &in) const { transformPosAndErrors(in, in); }
 
     //! returns the local jacobian.
-    virtual double getJacobian(const Point &point) const { return getJacobian(point.x, point.y); }
+    virtual double getJacobian(Point const &point) const { return getJacobian(point.x, point.y); }
 
     //! returns a copy (allocated by new) of the transformation.
     virtual std::unique_ptr<Gtransfo> clone() const = 0;
 
     //! to be overloaded by derived classes if they can really "reduce" the composition (e.g. composition of
     //! Polynomial can be reduced)
-    virtual std::unique_ptr<Gtransfo> reduceCompo(const Gtransfo *right) const;
+    virtual std::unique_ptr<Gtransfo> reduceCompo(Gtransfo const *right) const;
 
     //! returns the local jacobian.
     virtual double getJacobian(const double x, const double y) const;
@@ -91,21 +91,21 @@ public:
      *
      * Step is used for numerical derivation.
      */
-    virtual void computeDerivative(const Point &where, GtransfoLin &derivative,
+    virtual void computeDerivative(Point const &where, GtransfoLin &derivative,
                                    const double step = 0.01) const;
 
     //! linear (local) approximation.
-    virtual GtransfoLin linearApproximation(const Point &where, const double step = 0.01) const;
+    virtual GtransfoLin linearApproximation(Point const &where, const double step = 0.01) const;
 
-    virtual void transformPosAndErrors(const FatPoint &in, FatPoint &out) const;
+    virtual void transformPosAndErrors(FatPoint const &in, FatPoint &out) const;
 
     //! transform errors (represented as double[3] in order V(xx),V(yy),Cov(xy))
-    virtual void transformErrors(const Point &where, const double *vIn, double *vOut) const;
+    virtual void transformErrors(Point const &where, double const *vIn, double *vOut) const;
 
     //! returns an inverse transfo. Numerical if not overloaded.
     /*! precision and region refer to the "input" side of this,
       and hence to the output side of the returned Gtransfo. */
-    virtual std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
+    virtual std::unique_ptr<Gtransfo> inverseTransfo(const double precision, Frame const &region) const;
 
     //! params should be at least Npar() long
     void getParams(double *params) const;
@@ -121,12 +121,12 @@ public:
 
     //! Derivative w.r.t parameters. Derivatives should be al least 2*NPar long. first Npar, for x, last Npar
     //! for y.
-    virtual void paramDerivatives(const Point &where, double *dx, double *dy) const;
+    virtual void paramDerivatives(Point const &where, double *dx, double *dy) const;
 
     //! Rough inverse.
     /*! Stored by the numerical inverter to guess starting point
        for the trials. Just here to enable overloading. */
-    virtual std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
+    virtual std::unique_ptr<Gtransfo> roughInverse(Frame const &region) const;
 
     //! returns the number of parameters (to compute chi2's)
     virtual int getNpar() const { return 0; }
@@ -139,12 +139,12 @@ public:
 };
 
 //! allows 'stream << Transfo;' (by calling gtransfo.dump(stream)).
-std::ostream &operator<<(std::ostream &stream, const Gtransfo &gtransfo);
+std::ostream &operator<<(std::ostream &stream, Gtransfo const &gtransfo);
 
 //! Returns a pointer to a composition. if left->reduceCompo(right) return NULL, builds a GtransfoComposition
 //! and returns it. deletion of returned value to be done by caller
 
-std::unique_ptr<Gtransfo> gtransfoCompose(const Gtransfo *left, const Gtransfo *right);
+std::unique_ptr<Gtransfo> gtransfoCompose(Gtransfo const *left, Gtransfo const *right);
 
 /*=============================================================*/
 //! A do-nothing transformation. It anyway has dummy routines to mimick a Gtransfo
@@ -160,21 +160,21 @@ public:
         yOut = yIn;
     };  // to speed up
 
-    double fit(const StarMatchList &starMatchList) {
+    double fit(StarMatchList const &starMatchList) {
         throw pexExcept::TypeError(
                 "GtransfoIdentity is the identity transformation: it cannot be fit to anything.");
     }
 
-    std::unique_ptr<Gtransfo> reduceCompo(const Gtransfo *right) const { return right->clone(); }
+    std::unique_ptr<Gtransfo> reduceCompo(Gtransfo const *right) const { return right->clone(); }
     void dump(std::ostream &stream = std::cout) const { stream << "x' = x\ny' = y" << std::endl; }
 
     int getNpar() const { return 0; }
     std::unique_ptr<Gtransfo> clone() const { return std::unique_ptr<Gtransfo>(new GtransfoIdentity); }
 
-    void computeDerivative(const Point &where, GtransfoLin &derivative, const double step = 0.01) const;
+    void computeDerivative(Point const &where, GtransfoLin &derivative, const double step = 0.01) const;
 
     //! linear approximation.
-    virtual GtransfoLin linearApproximation(const Point &where, const double step = 0.01) const;
+    virtual GtransfoLin linearApproximation(Point const &where, const double step = 0.01) const;
 
     void write(std::ostream &s) const;
 
@@ -184,10 +184,10 @@ public:
 };
 
 //! Shorthand test to tell if a transfo belongs to the GtransfoIdentity class.
-bool isIdentity(const Gtransfo *gtransfo);
+bool isIdentity(Gtransfo const *gtransfo);
 
 //! Shorthand test to tell if a transfo is a simple integer shift
-bool isIntegerShift(const Gtransfo *gtransfo);
+bool isIntegerShift(Gtransfo const *gtransfo);
 
 /*====================   GtransfoPoly  =======================*/
 
@@ -199,20 +199,20 @@ public:
     GtransfoPoly(const unsigned degree = 1);
 
     //! Constructs a "polynomial image" from an existing transfo, over a specified domain
-    GtransfoPoly(const Gtransfo *gtransfo, const Frame &frame, unsigned degree, unsigned nPoint = 1000);
+    GtransfoPoly(Gtransfo const *gtransfo, Frame const &frame, unsigned degree, unsigned nPoint = 1000);
 
     // sets the polynomial degree.
     void setDegree(const unsigned degree);
 
-    using Gtransfo::apply;  // to unhide Gtransfo::apply(const Point &)
+    using Gtransfo::apply;  // to unhide Gtransfo::apply(Point const &)
 
     void apply(const double xIn, const double yIn, double &xOut, double &yOut) const;
 
     //! specialised analytic routine
-    void computeDerivative(const Point &where, GtransfoLin &derivative, const double step = 0.01) const;
+    void computeDerivative(Point const &where, GtransfoLin &derivative, const double step = 0.01) const;
 
     //! a mix of apply and Derivative
-    virtual void transformPosAndErrors(const FatPoint &in, FatPoint &out) const;
+    virtual void transformPosAndErrors(FatPoint const &in, FatPoint &out) const;
 
     //! returns degree
     unsigned getDegree() const { return _degree; }
@@ -224,18 +224,18 @@ public:
     void dump(std::ostream &stream = std::cout) const;
 
     //! guess what
-    double fit(const StarMatchList &starMatchList);
+    double fit(StarMatchList const &starMatchList);
 
     //! Composition (internal stuff in quadruple precision)
-    GtransfoPoly operator*(const GtransfoPoly &right) const;
+    GtransfoPoly operator*(GtransfoPoly const &right) const;
 
     //! Addition
-    GtransfoPoly operator+(const GtransfoPoly &right) const;
+    GtransfoPoly operator+(GtransfoPoly const &right) const;
 
     //! Subtraction
-    GtransfoPoly operator-(const GtransfoPoly &right) const;
+    GtransfoPoly operator-(GtransfoPoly const &right) const;
 
-    std::unique_ptr<Gtransfo> reduceCompo(const Gtransfo *right) const;
+    std::unique_ptr<Gtransfo> reduceCompo(Gtransfo const *right) const;
 
     std::unique_ptr<Gtransfo> clone() const { return std::unique_ptr<Gtransfo>(new GtransfoPoly(*this)); }
 
@@ -258,13 +258,13 @@ public:
 
     //! Derivative w.r.t parameters. Derivatives should be al least 2*NPar long. first Npar, for x, last Npar
     //! for y.
-    void paramDerivatives(const Point &where, double *dx, double *dy) const;
+    void paramDerivatives(Point const &where, double *dx, double *dy) const;
 
     void write(std::ostream &s) const;
     void read(std::istream &s);
 
 private:
-    double computeFit(const StarMatchList &starMatchList, const Gtransfo &InTransfo, const bool UseErrors);
+    double computeFit(StarMatchList const &starMatchList, Gtransfo const &InTransfo, const bool UseErrors);
 
     unsigned _degree;             // the degree
     unsigned _nterms;             // number of parameters per coordinate
@@ -284,25 +284,25 @@ private:
 };
 
 //! approximates the inverse by a polynomial, up to required precision.
-std::unique_ptr<GtransfoPoly> inversePolyTransfo(const Gtransfo &Direct, const Frame &frame,
+std::unique_ptr<GtransfoPoly> inversePolyTransfo(Gtransfo const &Direct, Frame const &frame,
                                                  const double Prec);
 
-GtransfoLin normalizeCoordinatesTransfo(const Frame &frame);
+GtransfoLin normalizeCoordinatesTransfo(Frame const &frame);
 
 /*=============================================================*/
 //! implements the linear transformations (6 real coefficients).
 class GtransfoLin : public GtransfoPoly {
 public:
-    using GtransfoPoly::apply;  // to unhide Gtransfo::apply(const Point &)
+    using GtransfoPoly::apply;  // to unhide Gtransfo::apply(Point const &)
 
     //! the default constructor constructs the do-nothing transformation.
     GtransfoLin() : GtransfoPoly(1){};
 
     //! This triggers an exception if P.degree() != 1
-    explicit GtransfoLin(const GtransfoPoly &gtransfoPoly);
+    explicit GtransfoLin(GtransfoPoly const &gtransfoPoly);
 
     //!  enables to combine linear tranformations: T1=T2*T3 is legal.
-    GtransfoLin operator*(const GtransfoLin &right) const;
+    GtransfoLin operator*(GtransfoLin const &right) const;
 
     //! returns the inverse: T1 = T2.invert();
     GtransfoLin invert() const;
@@ -310,24 +310,24 @@ public:
     // useful?    double jacobian(const double x, const double y) const { return determinant();}
 
     //!
-    void computeDerivative(const Point &where, GtransfoLin &derivative, const double step = 0.01) const;
+    void computeDerivative(Point const &where, GtransfoLin &derivative, const double step = 0.01) const;
     //!
-    GtransfoLin linearApproximation(const Point &where, const double step = 0.01) const;
+    GtransfoLin linearApproximation(Point const &where, const double step = 0.01) const;
 
     //  void dump(std::ostream &stream = std::cout) const;
 
-    // double fit(const StarMatchList &starMatchList);
+    // double fit(StarMatchList const &starMatchList);
 
     //! Construct a GtransfoLin from parameters
     GtransfoLin(const double ox, const double oy, const double aa11, const double aa12, const double aa21,
                 const double aa22);
 
     //! Handy converter:
-    GtransfoLin(const GtransfoIdentity &) : GtransfoPoly(1){};
+    GtransfoLin(GtransfoIdentity const &) : GtransfoPoly(1){};
 
     std::unique_ptr<Gtransfo> clone() const { return std::unique_ptr<Gtransfo>(new GtransfoLin(*this)); }
 
-    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
+    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, Frame const &region) const;
 
     double A11() const { return coeff(1, 0, 0); }
     double A12() const { return coeff(0, 1, 0); }
@@ -357,11 +357,11 @@ private:
 //! just here to provide a specialized constructor, and fit.
 class GtransfoLinShift : public GtransfoLin {
 public:
-    using Gtransfo::apply;  // to unhide Gtransfo::apply(const Point &)
+    using Gtransfo::apply;  // to unhide Gtransfo::apply(Point const &)
     //! Add ox and oy.
     GtransfoLinShift(double ox = 0., double oy = 0.) : GtransfoLin(ox, oy, 1., 0., 0., 1.) {}
-    GtransfoLinShift(const Point &point) : GtransfoLin(point.x, point.y, 1., 0., 0., 1.){};
-    double fit(const StarMatchList &starMatchList);
+    GtransfoLinShift(Point const &point) : GtransfoLin(point.x, point.y, 1., 0., 0., 1.){};
+    double fit(StarMatchList const &starMatchList);
 
     int getNpar() const { return 2; }
 };
@@ -370,11 +370,11 @@ public:
 //! just here to provide a specialized constructor, and fit.
 class GtransfoLinRot : public GtransfoLin {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
 
     GtransfoLinRot() : GtransfoLin(){};
-    GtransfoLinRot(const double angleRad, const Point *center = nullptr, const double scaleFactor = 1.0);
-    double fit(const StarMatchList &starMatchList);
+    GtransfoLinRot(const double angleRad, Point const *center = nullptr, const double scaleFactor = 1.0);
+    double fit(StarMatchList const &starMatchList);
 
     int getNpar() const { return 4; }
 };
@@ -384,7 +384,7 @@ public:
 //! just here to provide specialized constructors. GtransfoLin fit routine.
 class GtransfoLinScale : public GtransfoLin {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
     //!
     GtransfoLinScale(const double scale = 1) : GtransfoLin(0.0, 0.0, scale, 0., 0., scale){};
     //!
@@ -416,7 +416,7 @@ public:
     void dump(std::ostream &stream = std::cout) const override;
 
     /// Not implemented; throws pex::exceptions::LogicError
-    double fit(const StarMatchList &starMatchList) override;
+    double fit(StarMatchList const &starMatchList) override;
 
     std::unique_ptr<Gtransfo> clone() const override;
 
@@ -430,14 +430,14 @@ private:
 
 class BaseTanWcs : public Gtransfo {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
 
-    BaseTanWcs(const GtransfoLin &pix2Tan, const Point &tangentPoint,
-               const GtransfoPoly *corrections = nullptr);
+    BaseTanWcs(GtransfoLin const &pix2Tan, Point const &tangentPoint,
+               GtransfoPoly const *corrections = nullptr);
 
-    BaseTanWcs(const BaseTanWcs &original);
+    BaseTanWcs(BaseTanWcs const &original);
 
-    void operator=(const BaseTanWcs &original);
+    void operator=(BaseTanWcs const &original);
 
     /// Transform pixels to ICRS RA, Dec in degrees
     void apply(const double xIn, const double yIn, double &xOut, double &yOut) const;
@@ -449,7 +449,7 @@ public:
     GtransfoLin getLinPart() const;
 
     //! Get a non-owning pointer to the correction transform polynomial
-    const GtransfoPoly *getCorr() const { return corr.get(); }
+    GtransfoPoly const *getCorr() const { return corr.get(); }
 
     //! Assign the correction polynomial (what it means is left to derived classes)
     void setCorrections(std::unique_ptr<GtransfoPoly> corrections);
@@ -479,11 +479,11 @@ class TanRaDec2Pix;  // the inverse of TanPix2RaDec.
 //! the transformation that handles pix to sideral transfos (Gnomonic, possibly with polynomial distortions).
 class TanPix2RaDec : public BaseTanWcs {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
     //! pix2Tan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
     //! Corrections are applied between Lin and deprojection parts (as in Swarp).
-    TanPix2RaDec(const GtransfoLin &pix2Tan, const Point &tangentPoint,
-                 const GtransfoPoly *corrections = nullptr);
+    TanPix2RaDec(GtransfoLin const &pix2Tan, Point const &tangentPoint,
+                 GtransfoPoly const *corrections = nullptr);
 
     //! the transformation from pixels to tangent plane (degrees)
     GtransfoPoly getPix2TangentPlane() const;
@@ -494,26 +494,26 @@ public:
     TanPix2RaDec();
 
     //! composition with GtransfoLin
-    TanPix2RaDec operator*(const GtransfoLin &right) const;
+    TanPix2RaDec operator*(GtransfoLin const &right) const;
 
-    std::unique_ptr<Gtransfo> reduceCompo(const Gtransfo *right) const;
+    std::unique_ptr<Gtransfo> reduceCompo(Gtransfo const *right) const;
 
     //! approximate inverse : it ignores corrections;
     TanRaDec2Pix invert() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
-    std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
+    std::unique_ptr<Gtransfo> roughInverse(Frame const &region) const;
 
     //! Inverse transfo: returns a TanRaDec2Pix if there are no corrections, or the iterative solver if there
     //! are.
-    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
+    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, Frame const &region) const;
 
     std::unique_ptr<Gtransfo> clone() const;
 
     void dump(std::ostream &stream) const;
 
     //! Not implemented yet, because we do it otherwise.
-    double fit(const StarMatchList &starMatchList);
+    double fit(StarMatchList const &starMatchList);
 };
 
 //! Implements the (forward) SIP distorsion scheme
@@ -521,8 +521,8 @@ class TanSipPix2RaDec : public BaseTanWcs {
 public:
     //! pix2Tan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
     //! Corrections are applied before Lin.
-    TanSipPix2RaDec(const GtransfoLin &pix2Tan, const Point &tangentPoint,
-                    const GtransfoPoly *corrections = nullptr);
+    TanSipPix2RaDec(GtransfoLin const &pix2Tan, Point const &tangentPoint,
+                    GtransfoPoly const *corrections = nullptr);
 
     //! the transformation from pixels to tangent plane (degrees)
     GtransfoPoly getPix2TangentPlane() const;
@@ -534,14 +534,14 @@ public:
 
     //! Inverse transfo: returns a TanRaDec2Pix if there are no corrections, or the iterative solver if there
     //! are.
-    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
+    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, Frame const &region) const;
 
     std::unique_ptr<Gtransfo> clone() const;
 
     void dump(std::ostream &stream) const;
 
     //! Not implemented yet, because we do it otherwise.
-    double fit(const StarMatchList &starMatchList);
+    double fit(StarMatchList const &starMatchList);
 };
 
 //! This one is the Tangent Plane (called gnomonic) projection (from celestial sphere to tangent plane)
@@ -553,10 +553,10 @@ public:
 
 class TanRaDec2Pix : public Gtransfo {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
 
     //! assume degrees everywhere.
-    TanRaDec2Pix(const GtransfoLin &tan2Pix, const Point &tangentPoint);
+    TanRaDec2Pix(GtransfoLin const &tan2Pix, Point const &tangentPoint);
 
     //!
     TanRaDec2Pix();
@@ -565,7 +565,7 @@ public:
     GtransfoLin getLinPart() const;
 
     //! Resets the projection (or tangent) point
-    void setTangentPoint(const Point &tangentPoint);
+    void setTangentPoint(Point const &tangentPoint);
 
     //! tangent point coordinates (degrees)
     Point getTangentPoint() const;
@@ -574,22 +574,22 @@ public:
     void apply(const double xIn, const double yIn, double &xOut, double &yOut) const;
 
     //! transform with analytical derivatives
-    void transformPosAndErrors(const FatPoint &in, FatPoint &out) const;
+    void transformPosAndErrors(FatPoint const &in, FatPoint &out) const;
 
     //! exact typed inverse:
     TanPix2RaDec invert() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
-    std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
+    std::unique_ptr<Gtransfo> roughInverse(Frame const &region) const;
 
     //! Inverse transfo: returns a TanPix2RaDec.
-    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
+    std::unique_ptr<Gtransfo> inverseTransfo(const double precision, Frame const &region) const;
 
     void dump(std::ostream &stream) const;
 
     std::unique_ptr<Gtransfo> clone() const;
 
-    double fit(const StarMatchList &starMatchList);
+    double fit(StarMatchList const &starMatchList);
 
 private:
     double ra0, dec0;  // tangent point (radians)
@@ -598,27 +598,27 @@ private:
 };
 
 //! signature of the user-provided routine that actually does the coordinate transfo for UserTransfo.
-typedef void(GtransfoFun)(const double, const double, double &, double &, const void *);
+typedef void(GtransfoFun)(const double, const double, double &, double &, void const *);
 
 //! a run-time transfo that allows users to define a Gtransfo with minimal coding (just the transfo routine).
 class UserTransfo : public Gtransfo {
 public:
-    using Gtransfo::apply;  // to unhide apply(const Point&)
+    using Gtransfo::apply;  // to unhide apply(Point const &)
 
     //! the transfo routine and extra data that it may need.
-    UserTransfo(GtransfoFun &fun, const void *userData);
+    UserTransfo(GtransfoFun &fun, void const *userData);
 
     void apply(const double xIn, const double yIn, double &xOut, double &yOut) const;
 
     void dump(std::ostream &stream = std::cout) const;
 
-    double fit(const StarMatchList &starMatchList);
+    double fit(StarMatchList const &starMatchList);
 
     std::unique_ptr<Gtransfo> clone() const;
 
 private:
     GtransfoFun *_userFun;
-    const void *_userData;
+    void const *_userData;
 };
 
 //! The virtual constructor from a file

--- a/include/lsst/jointcal/Histo2d.h
+++ b/include/lsst/jointcal/Histo2d.h
@@ -8,7 +8,7 @@ namespace jointcal {
 class Histo2d {
 public:
     Histo2d() : data() {}
-    Histo2d(int nx, float minx, float maxx, int ny, float miny, float maxy);
+    Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float mmaxy);
 
     Histo2d(Histo2d const &other);
 

--- a/include/lsst/jointcal/Histo2d.h
+++ b/include/lsst/jointcal/Histo2d.h
@@ -10,7 +10,7 @@ public:
     Histo2d() : data() {}
     Histo2d(int nx, float minx, float maxx, int ny, float miny, float maxy);
 
-    Histo2d(const Histo2d &other);
+    Histo2d(Histo2d const &other);
 
     void fill(float x, float y, float weight = 1.);
 
@@ -28,7 +28,7 @@ public:
     ~Histo2d() {}
 
 private:
-    void operator=(const Histo2d &right);
+    void operator=(Histo2d const &right);
     bool indices(double x, double y, int &ix, int &iy) const;
 
     std::unique_ptr<float[]> data;

--- a/include/lsst/jointcal/Histo4d.h
+++ b/include/lsst/jointcal/Histo4d.h
@@ -25,7 +25,7 @@ public:
     void zeroBin(double x[4]);
 
     //! return the bin limits of dimension idim (0<=idim<4), around point X.
-    void binLimits(const double x[4], const int idim, double &xMin, double &xMax) const;
+    void binLimits(const double x[4], const int iDim, double &xMin, double &xMax) const;
 
     //!
     int getNEntries() const { return _ndata; }

--- a/include/lsst/jointcal/ListMatch.h
+++ b/include/lsst/jointcal/ListMatch.h
@@ -59,37 +59,37 @@ The various cuts are contained in conditions (see listmatch.h) for its contents.
 This routine searches a transformation that involves a shift and a rotation. */
 
 std::unique_ptr<StarMatchList> matchSearchRotShift(BaseStarList &list1, BaseStarList &list2,
-                                                   const MatchConditions &conditions);
+                                                   MatchConditions const &conditions);
 
 //! same as above but searches also a flipped solution.
 
 std::unique_ptr<StarMatchList> matchSearchRotShiftFlip(BaseStarList &list1, BaseStarList &list2,
-                                                       const MatchConditions &conditions);
+                                                       MatchConditions const &conditions);
 
 //! assembles star matches.
 /*! It picks stars in list1, transforms them through guess, and collects
 closest star in list2, and builds a match if closer than maxDist). */
 
-std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const BaseStarList &list2,
-                                                const Gtransfo *guess, const double maxDist);
+std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseStarList const &list2,
+                                                Gtransfo const *guess, const double maxDist);
 
 //! same as before except that the transfo is the identity
 
-std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const BaseStarList &list2,
+std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseStarList const &list2,
                                                 const double maxDist);
 
 //! searches for a 2 dimensional shift using a very crude histogram method.
 
-std::unique_ptr<GtransfoLin> listMatchupShift(const BaseStarList &list1, const BaseStarList &list2,
-                                              const Gtransfo &gtransfo, double maxShift, double binSize = 0);
+std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseStarList const &list2,
+                                              Gtransfo const &gtransfo, double maxShift, double binSize = 0);
 
-std::unique_ptr<Gtransfo> listMatchCombinatorial(const BaseStarList &list1, const BaseStarList &list2,
-                                                 const MatchConditions &conditions = MatchConditions());
-std::unique_ptr<Gtransfo> listMatchRefine(const BaseStarList &list1, const BaseStarList &list2,
+std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &list1, BaseStarList const &list2,
+                                                 MatchConditions const &conditions = MatchConditions());
+std::unique_ptr<Gtransfo> listMatchRefine(BaseStarList const &list1, BaseStarList const &list2,
                                           std::unique_ptr<Gtransfo> transfo, const int maxOrder = 3);
 
 #ifdef DO_WE_NEED_THAT
-inline Gtransfo *ListMatch(const BaseStarList &list1, const BaseStarList &list2, const int maxOrder = 3) {
+inline Gtransfo *ListMatch(BaseStarList const &list1, BaseStarList const &list2, const int maxOrder = 3) {
     Gtransfo *transfo = listMatchCombinatorial(list1, list2);
     transfo = listMatchRefine(list1, list2, transfo, maxOrder);
     return transfo;

--- a/include/lsst/jointcal/ListMatch.h
+++ b/include/lsst/jointcal/ListMatch.h
@@ -83,9 +83,9 @@ std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseS
 std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseStarList const &list2,
                                               Gtransfo const &gtransfo, double maxShift, double binSize = 0);
 
-std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &list1, BaseStarList const &list2,
+std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &List1, BaseStarList const &List2,
                                                  MatchConditions const &conditions = MatchConditions());
-std::unique_ptr<Gtransfo> listMatchRefine(BaseStarList const &list1, BaseStarList const &list2,
+std::unique_ptr<Gtransfo> listMatchRefine(BaseStarList const &List1, BaseStarList const &List2,
                                           std::unique_ptr<Gtransfo> transfo, const int maxOrder = 3);
 
 #ifdef DO_WE_NEED_THAT

--- a/include/lsst/jointcal/MeasuredStar.h
+++ b/include/lsst/jointcal/MeasuredStar.h
@@ -84,7 +84,7 @@ public:
 
     CcdImage const &getCcdImage() const { return *_ccdImage; };
 
-    void setCcdImage(const CcdImage *ccdImage) { _ccdImage = ccdImage; };
+    void setCcdImage(CcdImage const *ccdImage) { _ccdImage = ccdImage; };
 
     //! Fits may use that to discard outliers
     bool isValid() const { return _valid; }
@@ -98,7 +98,7 @@ private:
     double _instFlux;
     double _instFluxErr;
 
-    const CcdImage *_ccdImage;
+    CcdImage const *_ccdImage;
     // Note: _fittedStar is not const, but measuredStar won't modify it.
     std::shared_ptr<FittedStar> _fittedStar;
     bool _valid;
@@ -113,7 +113,7 @@ class MeasuredStarList : public StarList<MeasuredStar> {
 public:
     MeasuredStarList(){};
 
-    void setCcdImage(const CcdImage *_ccdImage);
+    void setCcdImage(CcdImage const *_ccdImage);
 };
 
 typedef MeasuredStarList::const_iterator MeasuredStarCIterator;
@@ -121,8 +121,8 @@ typedef MeasuredStarList::iterator MeasuredStarIterator;
 
 BaseStarList &Measured2Base(MeasuredStarList &This);
 BaseStarList *Measured2Base(MeasuredStarList *This);
-const BaseStarList &Measured2Base(const MeasuredStarList &This);
-const BaseStarList *Measured2Base(const MeasuredStarList *This);
+BaseStarList const &Measured2Base(MeasuredStarList const &This);
+BaseStarList const *Measured2Base(MeasuredStarList const *This);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/MeasuredStar.h
+++ b/include/lsst/jointcal/MeasuredStar.h
@@ -113,7 +113,7 @@ class MeasuredStarList : public StarList<MeasuredStar> {
 public:
     MeasuredStarList(){};
 
-    void setCcdImage(CcdImage const *_ccdImage);
+    void setCcdImage(CcdImage const *ccdImage);
 };
 
 typedef MeasuredStarList::const_iterator MeasuredStarCIterator;

--- a/include/lsst/jointcal/Point.h
+++ b/include/lsst/jointcal/Point.h
@@ -24,32 +24,32 @@ public:
     Point(double xx, double yy) : x(xx), y(yy){};
 
     //! -
-    double Distance(Point const & other) const {
+    double Distance(Point const& other) const {
         return sqrt((x - other.x) * (x - other.x) + (y - other.y) * (y - other.y));
     };
 
     //! distance squared to other
-    double computeDist2(Point const & other) const {
+    double computeDist2(Point const& other) const {
         return ((x - other.x) * (x - other.x) + (y - other.y) * (y - other.y));
     };
 
     //! Sum
-    Point operator+(Point const & Right) const { return Point(x + Right.x, y + Right.y); }
+    Point operator+(Point const& Right) const { return Point(x + Right.x, y + Right.y); }
 
     //! Difference
-    Point operator-(Point const & Right) const { return Point(x - Right.x, y - Right.y); }
+    Point operator-(Point const& Right) const { return Point(x - Right.x, y - Right.y); }
 
     //! utility
     virtual void dump(std::ostream& s = std::cout) const { s << " x " << x << " y " << y; }
 
     //! -
-    friend std::ostream& operator<<(std::ostream& stream, Point const & point) {
+    friend std::ostream& operator<<(std::ostream& stream, Point const& point) {
         point.dump(stream);
         return stream;
     }
 };
 
-std::ostream& operator<<(std::ostream& stream, Point const & point);
+std::ostream& operator<<(std::ostream& stream, Point const& point);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/Point.h
+++ b/include/lsst/jointcal/Point.h
@@ -24,32 +24,32 @@ public:
     Point(double xx, double yy) : x(xx), y(yy){};
 
     //! -
-    double Distance(const Point& other) const {
+    double Distance(Point const & other) const {
         return sqrt((x - other.x) * (x - other.x) + (y - other.y) * (y - other.y));
     };
 
     //! distance squared to other
-    double computeDist2(const Point& other) const {
+    double computeDist2(Point const & other) const {
         return ((x - other.x) * (x - other.x) + (y - other.y) * (y - other.y));
     };
 
     //! Sum
-    Point operator+(const Point& Right) const { return Point(x + Right.x, y + Right.y); }
+    Point operator+(Point const & Right) const { return Point(x + Right.x, y + Right.y); }
 
     //! Difference
-    Point operator-(const Point& Right) const { return Point(x - Right.x, y - Right.y); }
+    Point operator-(Point const & Right) const { return Point(x - Right.x, y - Right.y); }
 
     //! utility
     virtual void dump(std::ostream& s = std::cout) const { s << " x " << x << " y " << y; }
 
     //! -
-    friend std::ostream& operator<<(std::ostream& stream, const Point& point) {
+    friend std::ostream& operator<<(std::ostream& stream, Point const & point) {
         point.dump(stream);
         return stream;
     }
 };
 
-std::ostream& operator<<(std::ostream& stream, const Point& point);
+std::ostream& operator<<(std::ostream& stream, Point const & point);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/ProjectionHandler.h
+++ b/include/lsst/jointcal/ProjectionHandler.h
@@ -18,7 +18,7 @@ class CcdImage;
  * (where they are compared to transformed measurements)
  */
 struct ProjectionHandler {
-    virtual const Gtransfo *getSky2TP(const CcdImage &ccdImage) const = 0;
+    virtual Gtransfo const *getSky2TP(CcdImage const &ccdImage) const = 0;
 
     virtual ~ProjectionHandler(){};
 };
@@ -32,7 +32,7 @@ class IdentityProjectionHandler : public ProjectionHandler {
     GtransfoIdentity id;
 
 public:
-    const Gtransfo *getSky2TP(const CcdImage &ccdImage) const { return &id; };
+    Gtransfo const *getSky2TP(CcdImage const &ccdImage) const { return &id; };
 };
 
 /**
@@ -47,9 +47,9 @@ class OneTPPerVisitHandler : public ProjectionHandler {
     TransfoMap tMap;
 
 public:
-    OneTPPerVisitHandler(const CcdImageList &ccdImageList);
+    OneTPPerVisitHandler(CcdImageList const &ccdImageList);
 
-    const Gtransfo *getSky2TP(const CcdImage &ccdImage) const;
+    Gtransfo const *getSky2TP(CcdImage const &ccdImage) const;
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/RefStar.h
+++ b/include/lsst/jointcal/RefStar.h
@@ -61,8 +61,8 @@ typedef RefStarList::iterator RefStarIterator;
 
 BaseStarList& Ref2Base(RefStarList& This);
 BaseStarList* Ref2Base(RefStarList* This);
-BaseStarList const & Ref2Base(RefStarList const & This);
-BaseStarList const * Ref2Base(RefStarList const * This);
+BaseStarList const& Ref2Base(RefStarList const& This);
+BaseStarList const* Ref2Base(RefStarList const* This);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/RefStar.h
+++ b/include/lsst/jointcal/RefStar.h
@@ -61,8 +61,8 @@ typedef RefStarList::iterator RefStarIterator;
 
 BaseStarList& Ref2Base(RefStarList& This);
 BaseStarList* Ref2Base(RefStarList* This);
-const BaseStarList& Ref2Base(const RefStarList& This);
-const BaseStarList* Ref2Base(const RefStarList* This);
+BaseStarList const & Ref2Base(RefStarList const & This);
+BaseStarList const * Ref2Base(RefStarList const * This);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/SimplePhotometryModel.h
+++ b/include/lsst/jointcal/SimplePhotometryModel.h
@@ -34,11 +34,10 @@ public:
     void offsetParams(Eigen::VectorXd const &delta) override;
 
     /// @copydoc PhotometryModel::transform
-    double transform(CcdImage const &ccdImage, MeasuredStar const &measuredStar,
-                     double instFlux) const override;
+    double transform(CcdImage const &ccdImage, MeasuredStar const &star, double instFlux) const override;
 
     /// @copydoc PhotometryModel::transformError
-    double transformError(CcdImage const &ccdImage, MeasuredStar const &measuredStar,
+    double transformError(CcdImage const &ccdImage, MeasuredStar const &star,
                           double instFluxErr) const override;
 
     /// @copydoc PhotometryModel::freezeErrorTransform

--- a/include/lsst/jointcal/SimplePolyMapping.h
+++ b/include/lsst/jointcal/SimplePolyMapping.h
@@ -190,7 +190,7 @@ public:
     //! Access to the (fitted) transfo
     Gtransfo const &getTransfo() const {
         // Cannot fail given the contructor:
-        const GtransfoPoly *fittedPoly = dynamic_cast<const GtransfoPoly *>(&(*transfo));
+        GtransfoPoly const *fittedPoly = dynamic_cast<GtransfoPoly const *>(&(*transfo));
         actualResult = (*fittedPoly) * _centerAndScale;
         return actualResult;
     }

--- a/include/lsst/jointcal/SimplePolyModel.h
+++ b/include/lsst/jointcal/SimplePolyModel.h
@@ -30,7 +30,7 @@ class SimplePolyModel : public AstrometryModel {
 public:
     //! Sky2TP is just a name, it can be anything
     SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHandler const *projectionHandler,
-                    bool initFromWCS, unsigned nNotFit = 0, unsigned degree = 3);
+                    bool initFromWcs, unsigned nNotFit = 0, unsigned degree = 3);
 
     /// No copy or move: there is only ever one instance of a given model (i.e.. per ccd+visit)
     SimplePolyModel(SimplePolyModel const &) = delete;

--- a/include/lsst/jointcal/SimplePolyModel.h
+++ b/include/lsst/jointcal/SimplePolyModel.h
@@ -40,7 +40,7 @@ public:
 
     // The following routines are the interface to AstrometryFit
     //!
-    const Mapping *getMapping(CcdImage const &) const;
+    Mapping const *getMapping(CcdImage const &) const;
 
     //! Positions the various parameter sets into the parameter vector, starting at firstIndex
     unsigned assignIndices(unsigned firstIndex, std::string const &whatToFit);
@@ -51,7 +51,7 @@ public:
     /*! the mapping of sky coordinates (i.e. the coordinate system
     in which fitted stars are reported) onto the Tangent plane
     (into which the pixel coordinates are transformed) */
-    const Gtransfo *getSky2TP(CcdImage const &ccdImage) const { return _sky2TP->getSky2TP(ccdImage); }
+    Gtransfo const *getSky2TP(CcdImage const &ccdImage) const { return _sky2TP->getSky2TP(ccdImage); }
 
     //!
     virtual void freezeErrorTransform();
@@ -64,9 +64,9 @@ public:
     ~SimplePolyModel(){};
 
 private:
-    typedef std::map<const CcdImage *, std::unique_ptr<SimpleGtransfoMapping>> mapType;
+    typedef std::map<CcdImage const *, std::unique_ptr<SimpleGtransfoMapping>> mapType;
     mapType _myMap;
-    const ProjectionHandler *_sky2TP;
+    ProjectionHandler const *_sky2TP;
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/SipToGtransfo.h
+++ b/include/lsst/jointcal/SipToGtransfo.h
@@ -14,7 +14,7 @@ class Frame;
 
 //! Transform the other way around
 std::shared_ptr<lsst::afw::geom::SkyWcs>
-gtransfoToTanWcs(const lsst::jointcal::TanSipPix2RaDec wcsTransfo, const lsst::jointcal::Frame &ccdFrame,
+gtransfoToTanWcs(const lsst::jointcal::TanSipPix2RaDec& wcsTransfo, const lsst::jointcal::Frame &ccdFrame,
                  const bool noLowOrderSipTerms = false);
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/SipToGtransfo.h
+++ b/include/lsst/jointcal/SipToGtransfo.h
@@ -13,9 +13,9 @@ namespace jointcal {
 class Frame;
 
 //! Transform the other way around
-std::shared_ptr<lsst::afw::geom::SkyWcs>
-gtransfoToTanWcs(const lsst::jointcal::TanSipPix2RaDec& wcsTransfo, const lsst::jointcal::Frame &ccdFrame,
-                 const bool noLowOrderSipTerms = false);
+std::shared_ptr<lsst::afw::geom::SkyWcs> gtransfoToTanWcs(const lsst::jointcal::TanSipPix2RaDec& wcsTransfo,
+                                                          const lsst::jointcal::Frame& ccdFrame,
+                                                          const bool noLowOrderSipTerms = false);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/StarList.h
+++ b/include/lsst/jointcal/StarList.h
@@ -60,7 +60,7 @@ public:
     void cutTail(const int nKeep);
 
     //! copy the part of the std::list which is included in the frame at the end of another std::list
-    void extractInFrame(StarList<Star> &out, const Frame &frame) const;
+    void extractInFrame(StarList<Star> &out, Frame const &frame) const;
 
     //! clears copy and makes a copy of the std::list to copy
     void copyTo(StarList<Star> &copy) const;
@@ -72,7 +72,7 @@ public:
     /*! could be extended to other type of transformations. */
 
     template <class Operator>
-    void applyTransfo(const Operator &op) {
+    void applyTransfo(Operator const &op) {
         for (auto &p : *this) op.transformStar(*(p));
     }
 };

--- a/include/lsst/jointcal/StarMatch.h
+++ b/include/lsst/jointcal/StarMatch.h
@@ -71,7 +71,7 @@ public:
     /* comparison that ensures that after a sort, duplicates are next one another */
     explicit StarMatch(){};
 
-    friend std::ostream &operator<<(std::ostream &stream, StarMatch const &Match);
+    friend std::ostream &operator<<(std::ostream &stream, StarMatch const &match);
 
     ~StarMatch() {}
 
@@ -198,10 +198,10 @@ private:
 };
 
 //! sum of distance squared
-double computeDist2(StarMatchList const &S, Gtransfo const &gtransfo);
+double computeDist2(StarMatchList const &starMatchList, Gtransfo const &gtransfo);
 
 //! the actual chi2
-double computeChi2(StarMatchList const &L, Gtransfo const &gtransfo);
+double computeChi2(StarMatchList const &starMatchList, Gtransfo const &gtransfo);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/StarMatch.h
+++ b/include/lsst/jointcal/StarMatch.h
@@ -43,7 +43,7 @@ public:
     //! constructor.
     /*! gives 2 points (that contain the geometry), plus pointers to the Star objects
       (which are there for user convenience). */
-    StarMatch(const FatPoint &point1, const FatPoint &point2, std::shared_ptr<const BaseStar> star1,
+    StarMatch(FatPoint const &point1, FatPoint const &point2, std::shared_ptr<const BaseStar> star1,
               std::shared_ptr<const BaseStar> star2)
             : point1(point1), point2(point2), s1(std::move(star1)), s2(std::move(star2)), distance(0.){};
 
@@ -51,15 +51,15 @@ public:
     // StarMatch(BaseStar *star1, BaseStar *star2) : point1(*star1), point2(*star2), s1(star1), s2(star2) {};
 
     //! returns the distance from gtransfo(point1) to point2.
-    double computeDistance(const Gtransfo &gtransfo) const {
+    double computeDistance(Gtransfo const &gtransfo) const {
         return point2.Distance(gtransfo.apply(point1));
     };
 
     //! returns the chi2 (using errors in the FatPoint's)
-    double computeChi2(const Gtransfo &gtransfo) const;
+    double computeChi2(Gtransfo const &gtransfo) const;
 
     //! to be used before sorting on distances.
-    void setDistance(const Gtransfo &gtransfo) { distance = computeDistance(gtransfo); };
+    void setDistance(Gtransfo const &gtransfo) { distance = computeDistance(gtransfo); };
     //! returns the value computed by the above one.
     double getDistance() const { return distance; }
 
@@ -71,40 +71,40 @@ public:
     /* comparison that ensures that after a sort, duplicates are next one another */
     explicit StarMatch(){};
 
-    friend std::ostream &operator<<(std::ostream &stream, const StarMatch &Match);
+    friend std::ostream &operator<<(std::ostream &stream, StarMatch const &Match);
 
     ~StarMatch() {}
 
 private:
-    //  bool operator <  (const StarMatch & other) const { return (s1 > other.s1) ? s1 > other.s1 : s2 >
+    //  bool operator <  (StarMatch const & other) const { return (s1 > other.s1) ? s1 > other.s1 : s2 >
     //  other.s2;}
 
     /* for unique to remove duplicates */
-    bool operator==(const StarMatch &other) const { return (s1 == other.s1 && s2 == other.s2); };
-    bool operator!=(const StarMatch &other) const { return (s1 != other.s1 || s2 != other.s2); };
+    bool operator==(StarMatch const &other) const { return (s1 == other.s1 && s2 == other.s2); };
+    bool operator!=(StarMatch const &other) const { return (s1 != other.s1 || s2 != other.s2); };
 
-    friend bool compareStar1(const StarMatch &one, const StarMatch &two);
-    friend bool sameStar1(const StarMatch &one, const StarMatch &two);
-    friend bool compareStar2(const StarMatch &one, const StarMatch &two);
-    friend bool sameStar2(const StarMatch &one, const StarMatch &two);
+    friend bool compareStar1(StarMatch const &one, StarMatch const &two);
+    friend bool sameStar1(StarMatch const &one, StarMatch const &two);
+    friend bool compareStar2(StarMatch const &one, StarMatch const &two);
+    friend bool sameStar2(StarMatch const &one, StarMatch const &two);
 };
 
-inline bool compareStar1(const StarMatch &one, const StarMatch &two) {
+inline bool compareStar1(StarMatch const &one, StarMatch const &two) {
     return ((one.s1 == two.s1) ? (one.distance < two.distance) : (&(*one.s1) > &(*two.s1)));
 }
 
-inline bool sameStar1(const StarMatch &one, const StarMatch &two) { return (one.s1 == two.s1); }
+inline bool sameStar1(StarMatch const &one, StarMatch const &two) { return (one.s1 == two.s1); }
 
-inline bool compareStar2(const StarMatch &one, const StarMatch &two) {
+inline bool compareStar2(StarMatch const &one, StarMatch const &two) {
     return ((one.s2 == two.s2) ? (one.distance < two.distance) : (&(*one.s2) > &(*two.s2)));
 }
 
-inline bool sameStar2(const StarMatch &one, const StarMatch &two) { return (one.s2 == two.s2); }
+inline bool sameStar2(StarMatch const &one, StarMatch const &two) { return (one.s2 == two.s2); }
 
 /* =================================== StarMatchList
  * ============================================================ */
 
-std::ostream &operator<<(std::ostream &stream, const StarMatch &match);
+std::ostream &operator<<(std::ostream &stream, StarMatch const &match);
 
 //#ifdef TO_BE_FIXED
 typedef ::std::list<StarMatch>::iterator StarMatchIterator;
@@ -121,7 +121,7 @@ utilities such as listMatchCollect. StarMatchList's have write
 capabilities.  NStarMatchList is a generalization of this 2-match to n-matches.
 */
 
-std::ostream &operator<<(std::ostream &stream, const StarMatchList &starMatchList);
+std::ostream &operator<<(std::ostream &stream, StarMatchList const &starMatchList);
 
 class StarMatchList : public std::list<StarMatch> {
 public:
@@ -129,8 +129,8 @@ public:
 
     //! enables to get a transformed StarMatchList. Only positions are transformed, not attached stars. const
     //! routine: "this" remains unchanged.
-    void applyTransfo(StarMatchList &transformed, const Gtransfo *priorTransfo,
-                      const Gtransfo *posteriorTransfo = nullptr) const;
+    void applyTransfo(StarMatchList &transformed, Gtransfo const *priorTransfo,
+                      Gtransfo const *posteriorTransfo = nullptr) const;
 
     /* constructor */
     StarMatchList() : _order(0), _chi2(0){};
@@ -158,12 +158,12 @@ public:
     /*! cleans up the std::list of pairs for pairs that share one of their stars, keeping the closest one.
        The distance is computed using gtransfo. which = 1 (2) removes ambiguities
        on the first (second) term of the match. which=3 does both.*/
-    unsigned removeAmbiguities(const Gtransfo &gtransfo, int which = 3);
+    unsigned removeAmbiguities(Gtransfo const &gtransfo, int which = 3);
 
     //! sets a transfo between the 2 std::lists and deletes the previous or default one.  No fit.
-    void setTransfo(const Gtransfo *gtransfo) { _transfo = gtransfo->clone(); }
+    void setTransfo(Gtransfo const *gtransfo) { _transfo = gtransfo->clone(); }
     //!
-    void setTransfo(const Gtransfo &gtransfo) { _transfo = gtransfo.clone(); }
+    void setTransfo(Gtransfo const &gtransfo) { _transfo = gtransfo.clone(); }
     void setTransfo(std::shared_ptr<Gtransfo> gtransfo) { _transfo = std::move(gtransfo); }
 
     //! set transfo according to the given order.
@@ -174,7 +174,7 @@ public:
     std::unique_ptr<Gtransfo> inverseTransfo();
 
     //! Sets the distance (residual) field of all std::list elements. Mandatory before sorting on distances
-    void setDistance(const Gtransfo &gtransfo);
+    void setDistance(Gtransfo const &gtransfo);
 
     //! deletes the tail of the match std::list
     void cutTail(int nKeep);
@@ -188,8 +188,8 @@ public:
     ~StarMatchList(){/* should delete the transfo.... or use counted refs*/};
 
 private:
-    StarMatchList(const StarMatchList &);  // copies nor properly handled
-    void operator=(const StarMatchList &);
+    StarMatchList(StarMatchList const &);  // copies nor properly handled
+    void operator=(StarMatchList const &);
 
     int _order;
     double _chi2;
@@ -198,10 +198,10 @@ private:
 };
 
 //! sum of distance squared
-double computeDist2(const StarMatchList &S, const Gtransfo &gtransfo);
+double computeDist2(StarMatchList const &S, Gtransfo const &gtransfo);
 
 //! the actual chi2
-double computeChi2(const StarMatchList &L, const Gtransfo &gtransfo);
+double computeChi2(StarMatchList const &L, Gtransfo const &gtransfo);
 }  // namespace jointcal
 }  // namespace lsst
 

--- a/include/lsst/jointcal/TwoTransfoMapping.h
+++ b/include/lsst/jointcal/TwoTransfoMapping.h
@@ -15,7 +15,7 @@ namespace jointcal {
 class TwoTransfoMapping : public Mapping {
 public:
     //!
-    TwoTransfoMapping(SimpleGtransfoMapping *chipMapping, SimpleGtransfoMapping *visitMapping);
+    TwoTransfoMapping(SimpleGtransfoMapping *mapping1, SimpleGtransfoMapping *mapping2);
 
     /// No copy or move: there is only ever one instance of a given model (i.e.. per ccd+visit)
     TwoTransfoMapping(TwoTransfoMapping const &) = delete;

--- a/python/lsst/jointcal/astrometryModels.cc
+++ b/python/lsst/jointcal/astrometryModels.cc
@@ -47,7 +47,7 @@ void declareSimplePolyModel(py::module &mod) {
     py::class_<SimplePolyModel, std::shared_ptr<SimplePolyModel>, AstrometryModel> cls(mod,
                                                                                        "SimplePolyModel");
 
-    cls.def(py::init<CcdImageList const &, const ProjectionHandler *, bool, unsigned, unsigned>(),
+    cls.def(py::init<CcdImageList const &, ProjectionHandler const *, bool, unsigned, unsigned>(),
             "ccdImageList"_a, "projectionHandler"_a, "initFromWcs"_a, "nNotFit"_a = 0, "degree"_a = 3);
 }
 
@@ -55,7 +55,7 @@ void declareConstrainedPolyModel(py::module &mod) {
     py::class_<ConstrainedPolyModel, std::shared_ptr<ConstrainedPolyModel>, AstrometryModel> cls(
             mod, "ConstrainedPolyModel");
 
-    cls.def(py::init<CcdImageList const &, const ProjectionHandler *, bool, unsigned, int, int>(),
+    cls.def(py::init<CcdImageList const &, ProjectionHandler const *, bool, unsigned, int, int>(),
             "ccdImageList"_a, "projectionHandler"_a, "initFromWcs"_a, "nNotFit"_a = 0, "chipDegree"_a = 3,
             "visitDegree"_a = 2);
 }

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -197,7 +197,7 @@ void Associations::collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::t
         if (rejectBadFluxes &&
             (!std::isfinite(defaultFlux) || !std::isfinite(defaultFluxErr) || defaultFluxErr == 0)) {
             continue;
-}
+        }
         refStarList.push_back(star);
     }
 
@@ -219,7 +219,7 @@ const lsst::afw::geom::Box2D Associations::getRaDecBBox() {
             tangentPlaneFrame = CTPFrame;
         } else {
             tangentPlaneFrame += CTPFrame;
-}
+        }
     }
 
     // convert tangent plane coordinates to RaDec:
@@ -323,7 +323,7 @@ void Associations::normalizeFittedStars() const {
                 throw(LSST_EXCEPT(
                         pex::exceptions::RuntimeError,
                         "All measuredStars must have a fittedStar: did you call selectFittedStars()?"));
-}
+            }
             auto point = toCommonTangentPlane->apply(*mi);
             fittedStar->x += point.x;
             fittedStar->y += point.y;

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -195,8 +195,9 @@ void Associations::collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::t
 
         // Reject sources with non-finite fluxes and flux errors, and fluxErr=0 (which gives chi2=inf).
         if (rejectBadFluxes &&
-            (!std::isfinite(defaultFlux) || !std::isfinite(defaultFluxErr) || defaultFluxErr == 0))
+            (!std::isfinite(defaultFlux) || !std::isfinite(defaultFluxErr) || defaultFluxErr == 0)) {
             continue;
+}
         refStarList.push_back(star);
     }
 
@@ -214,10 +215,11 @@ const lsst::afw::geom::Box2D Associations::getRaDecBBox() {
     for (auto const &ccdImage : ccdImageList) {
         Frame CTPFrame =
                 applyTransfo(ccdImage->getImageFrame(), *(ccdImage->getPix2CommonTangentPlane()), LargeFrame);
-        if (tangentPlaneFrame.getArea() == 0)
+        if (tangentPlaneFrame.getArea() == 0) {
             tangentPlaneFrame = CTPFrame;
-        else
+        } else {
             tangentPlaneFrame += CTPFrame;
+}
     }
 
     // convert tangent plane coordinates to RaDec:
@@ -317,10 +319,11 @@ void Associations::normalizeFittedStars() const {
         MeasuredStarList &catalog = ccdImage->getCatalogForFit();
         for (auto &mi : catalog) {
             auto fittedStar = mi->getFittedStar();
-            if (fittedStar == nullptr)
+            if (fittedStar == nullptr) {
                 throw(LSST_EXCEPT(
                         pex::exceptions::RuntimeError,
                         "All measuredStars must have a fittedStar: did you call selectFittedStars()?"));
+}
             auto point = toCommonTangentPlane->apply(*mi);
             fittedStar->x += point.x;
             fittedStar->y += point.y;

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -67,7 +67,7 @@ void Associations::associateCatalogs(const double matchCutInArcSec, const bool u
     if (!useFittedList) fittedStarList.clear();
 
     for (auto &ccdImage : ccdImageList) {
-        const Gtransfo *toCommonTangentPlane = ccdImage->getPix2CommonTangentPlane();
+        Gtransfo const *toCommonTangentPlane = ccdImage->getPix2CommonTangentPlane();
 
         // Clear the catalog to fit and copy the whole catalog into it.
         // This allows reassociating from scratch after a fit.
@@ -232,7 +232,7 @@ const lsst::afw::geom::Box2D Associations::getRaDecBBox() {
     return box;
 }
 
-void Associations::associateRefStars(double matchCutInArcSec, const Gtransfo *gtransfo) {
+void Associations::associateRefStars(double matchCutInArcSec, Gtransfo const *gtransfo) {
     // associate with FittedStars
     // 3600 because coordinates are in degrees (in CTP).
     auto starMatchList = listMatchCollect(Ref2Base(refStarList), Fitted2Base(fittedStarList), gtransfo,
@@ -244,11 +244,11 @@ void Associations::associateRefStars(double matchCutInArcSec, const Gtransfo *gt
 
     // actually associate things
     for (auto const &starMatch : *starMatchList) {
-        const BaseStar &bs = *starMatch.s1;
-        const auto &rs_const = dynamic_cast<const RefStar &>(bs);
+        BaseStar const &bs = *starMatch.s1;
+        auto const &rs_const = dynamic_cast<RefStar const &>(bs);
         auto &rs = const_cast<RefStar &>(rs_const);
-        const BaseStar &bs2 = *starMatch.s2;
-        const auto &fs_const = dynamic_cast<const FittedStar &>(bs2);
+        BaseStar const &bs2 = *starMatch.s2;
+        auto const &fs_const = dynamic_cast<FittedStar const &>(bs2);
         auto &fs = const_cast<FittedStar &>(fs_const);
         // rs->setFittedStar(*fs);
         fs.setRefStar(&rs);
@@ -313,7 +313,7 @@ void Associations::normalizeFittedStars() const {
 
     // Iterate over measuredStars to add their values into their fittedStars
     for (auto const &ccdImage : ccdImageList) {
-        const Gtransfo *toCommonTangentPlane = ccdImage->getPix2CommonTangentPlane();
+        Gtransfo const *toCommonTangentPlane = ccdImage->getPix2CommonTangentPlane();
         MeasuredStarList &catalog = ccdImage->getCatalogForFit();
         for (auto &mi : catalog) {
             auto fittedStar = mi->getFittedStar();
@@ -444,7 +444,7 @@ void Associations::setFittedStarColors(std::string dicStarListName, std::string 
     // The color List is to be projected:
     TStarList projected_cList((BaseStarList &)cList, proj);
     // Associate
-    auto starMatchList = listMatchCollect(Fitted2Base(fittedStarList), (const BaseStarList &)projected_cList,
+    auto starMatchList = listMatchCollect(Fitted2Base(fittedStarList), (BaseStarList const &)projected_cList,
                                           id_or_proj, matchCutArcSec / 3600);
 
     LOGLS_INFO(_log, "Matched " << starMatchList->size() << '/' << fittedStarList.size()
@@ -454,8 +454,8 @@ void Associations::setFittedStarColors(std::string dicStarListName, std::string 
         BaseStar *s1 = i->s1;
         FittedStar *fs = dynamic_cast<FittedStar *>(s1);
         BaseStar *s2 = i->s2;
-        const TStar *ts = dynamic_cast<const TStar *>(s2);
-        const DicStar *ds = dynamic_cast<const DicStar *>(ts->get_original());
+        TStar const *ts = dynamic_cast<TStar const *>(s2);
+        DicStar const *ds = dynamic_cast<DicStar const *>(ts->get_original());
         fs->color = ds->getval(c1);
         if (compute_diff) fs->color -= ds->getval(c2);
     }

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -139,7 +139,7 @@ void Associations::collectRefStars(lsst::afw::table::SortedCatalogT<lsst::afw::t
                                    std::map<std::string, std::vector<double>> const &refFluxMap,
                                    std::map<std::string, std::vector<double>> const &refFluxErrMap,
                                    bool rejectBadFluxes) {
-    if (refCat.size() == 0) {
+    if (refCat.empty()) {
         throw(LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " reference catalog is empty : stop here "));
     }
@@ -245,11 +245,11 @@ void Associations::associateRefStars(double matchCutInArcSec, const Gtransfo *gt
     // actually associate things
     for (auto const &starMatch : *starMatchList) {
         const BaseStar &bs = *starMatch.s1;
-        const RefStar &rs_const = dynamic_cast<const RefStar &>(bs);
-        RefStar &rs = const_cast<RefStar &>(rs_const);
+        const auto &rs_const = dynamic_cast<const RefStar &>(bs);
+        auto &rs = const_cast<RefStar &>(rs_const);
         const BaseStar &bs2 = *starMatch.s2;
-        const FittedStar &fs_const = dynamic_cast<const FittedStar &>(bs2);
-        FittedStar &fs = const_cast<FittedStar &>(fs_const);
+        const auto &fs_const = dynamic_cast<const FittedStar &>(bs2);
+        auto &fs = const_cast<FittedStar &>(fs_const);
         // rs->setFittedStar(*fs);
         fs.setRefStar(&rs);
     }
@@ -270,7 +270,7 @@ void Associations::selectFittedStars(int minMeasurements) {
     for (auto const &ccdImage : ccdImageList) {
         MeasuredStarList &catalog = ccdImage->getCatalogForFit();
         // Iteration happens internal to the loop, as we may delete measuredStars from catalog.
-        for (MeasuredStarIterator mi = catalog.begin(); mi != catalog.end();) {
+        for (auto mi = catalog.begin(); mi != catalog.end();) {
             MeasuredStar &mstar = **mi;
 
             auto fittedStar = mstar.getFittedStar();
@@ -292,7 +292,7 @@ void Associations::selectFittedStars(int minMeasurements) {
     }      // end loop on catalogs
 
     // now FittedStars with less than minMeasurements should have zero measurementCount.
-    for (FittedStarIterator fi = fittedStarList.begin(); fi != fittedStarList.end();) {
+    for (auto fi = fittedStarList.begin(); fi != fittedStarList.end();) {
         if ((*fi)->getMeasurementCount() == 0) {
             fi = fittedStarList.erase(fi);
         } else {
@@ -363,7 +363,7 @@ void Associations::deprojectFittedStars() {
 
 int Associations::nCcdImagesValidForFit() const {
     return std::count_if(ccdImageList.begin(), ccdImageList.end(), [](std::shared_ptr<CcdImage> const &item) {
-        return item->getCatalogForFit().size() > 0;
+        return !item->getCatalogForFit().empty();
     });
 }
 

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -12,7 +12,7 @@
 namespace lsst {
 namespace jointcal {
 
-Frame applyTransfo(Frame const & inputframe, Gtransfo const & gtransfo, const WhichTransformed which) {
+Frame applyTransfo(Frame const& inputframe, Gtransfo const& gtransfo, const WhichTransformed which) {
     // 2 opposite corners
     double xtmin1, xtmax1, ytmin1, ytmax1;
     gtransfo.apply(inputframe.xMin, inputframe.yMin, xtmin1, ytmin1);

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -12,7 +12,7 @@
 namespace lsst {
 namespace jointcal {
 
-Frame applyTransfo(const Frame& inputframe, const Gtransfo& gtransfo, const WhichTransformed which) {
+Frame applyTransfo(Frame const & inputframe, Gtransfo const & gtransfo, const WhichTransformed which) {
     // 2 opposite corners
     double xtmin1, xtmax1, ytmin1, ytmax1;
     gtransfo.apply(inputframe.xMin, inputframe.yMin, xtmin1, ytmin1);

--- a/src/AstroUtils.cc
+++ b/src/AstroUtils.cc
@@ -1,8 +1,8 @@
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <fstream>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #include "lsst/jointcal/BaseStar.h"
 #include "lsst/jointcal/AstroUtils.h"

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <fstream>
+#include <utility>
 
 #include "Eigen/Sparse"
 
@@ -21,8 +22,8 @@ namespace jointcal {
 
 AstrometryFit::AstrometryFit(std::shared_ptr<Associations> associations,
                              std::shared_ptr<AstrometryModel> astrometryModel, double posError)
-        : FitterBase(associations),
-          _astrometryModel(astrometryModel),
+        : FitterBase(std::move(associations)),
+          _astrometryModel(std::move(astrometryModel)),
           _refractionCoefficient(0),
           _nParDistortions(0),
           _nParPositions(0),
@@ -241,7 +242,7 @@ void AstrometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
     if (!_fittingPos) return;
     /* the other case where the accumulation of derivatives stops
        here is when there are no RefStars */
-    if (_associations->refStarList.size() == 0) return;
+    if (_associations->refStarList.empty()) return;
     Eigen::Matrix2d W(2, 2);
     Eigen::Matrix2d alpha(2, 2);
     Eigen::Matrix2d H(2, 2), halpha(2, 2), HW(2, 2);
@@ -526,8 +527,8 @@ void AstrometryFit::checkStuff() {
 #endif
     const char *what2fit[] = {"Positions", "Distortions", "Positions Distortions"};
     // DEBUG
-    for (unsigned k = 0; k < sizeof(what2fit) / sizeof(what2fit[0]); ++k) {
-        assignIndices(what2fit[k]);
+    for (auto & k : what2fit) {
+        assignIndices(k);
         TripletList tripletList(10000);
         Eigen::VectorXd grad(_nParTot);
         grad.setZero();

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -142,10 +142,11 @@ void AstrometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
         H.setZero();  // we cannot be sure that all entries will be overwritten.
         FatPoint outPos;
         // should *not* fill H if whatToFit excludes mapping parameters.
-        if (_fittingDistortions)
+        if (_fittingDistortions) {
             mapping->computeTransformAndDerivatives(inPos, outPos, H);
-        else
+        } else {
             mapping->transformPosAndErrors(inPos, outPos);
+}
 
         unsigned ipar = npar_mapping;
         double det = outPos.vx * outPos.vy - std::pow(outPos.vxy, 2);
@@ -464,10 +465,11 @@ void AstrometryFit::assignIndices(std::string const &whatToFit) {
 }
 
 void AstrometryFit::offsetParams(Eigen::VectorXd const &delta) {
-    if (delta.size() != _nParTot)
+    if (delta.size() != _nParTot) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "AstrometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");
+}
     if (_fittingDistortions) _astrometryModel->offsetParams(delta);
 
     if (_fittingPos) {

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -146,7 +146,7 @@ void AstrometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
             mapping->computeTransformAndDerivatives(inPos, outPos, H);
         } else {
             mapping->transformPosAndErrors(inPos, outPos);
-}
+        }
 
         unsigned ipar = npar_mapping;
         double det = outPos.vx * outPos.vy - std::pow(outPos.vxy, 2);
@@ -469,7 +469,7 @@ void AstrometryFit::offsetParams(Eigen::VectorXd const &delta) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "AstrometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");
-}
+    }
     if (_fittingDistortions) _astrometryModel->offsetParams(delta);
 
     if (_fittingPos) {
@@ -529,7 +529,7 @@ void AstrometryFit::checkStuff() {
 #endif
     char const *what2fit[] = {"Positions", "Distortions", "Positions Distortions"};
     // DEBUG
-    for (auto & k : what2fit) {
+    for (auto &k : what2fit) {
         assignIndices(k);
         TripletList tripletList(10000);
         Eigen::VectorXd grad(_nParTot);

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -102,7 +102,7 @@ void AstrometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
     if (msList) assert(&(msList->front()->getCcdImage()) == &ccdImage);
 
     // get the Mapping
-    const Mapping *mapping = _astrometryModel->getMapping(ccdImage);
+    Mapping const *mapping = _astrometryModel->getMapping(ccdImage);
     // count parameters
     unsigned npar_mapping = (_fittingDistortions) ? mapping->getNpar() : 0;
     unsigned npar_pos = (_fittingPos) ? 2 : 0;
@@ -120,7 +120,7 @@ void AstrometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
     // refraction stuff
     Point refractionVector = ccdImage.getRefractionVector();
     // transformation from sky to TP
-    const Gtransfo *sky2TP = _astrometryModel->getSky2TP(ccdImage);
+    Gtransfo const *sky2TP = _astrometryModel->getSky2TP(ccdImage);
     // reserve matrices once for all measurements
     GtransfoLin dypdy;
     // the shape of H (et al) is required this way in order to be able to
@@ -131,10 +131,10 @@ void AstrometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
     Eigen::VectorXd grad(npar_tot);
     // current position in the Jacobian
     unsigned kTriplets = tripletList.getNextFreeIndex();
-    const MeasuredStarList &catalog = (msList) ? *msList : ccdImage.getCatalogForFit();
+    MeasuredStarList const &catalog = (msList) ? *msList : ccdImage.getCatalogForFit();
 
     for (auto &i : catalog) {
-        const MeasuredStar &ms = *i;
+        MeasuredStar const &ms = *i;
         if (!ms.isValid()) continue;
         // tweak the measurement errors
         FatPoint inPos = ms;
@@ -258,8 +258,8 @@ void AstrometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
        projection point at every object */
     TanRaDec2Pix proj(GtransfoLin(), Point(0., 0.));
     for (auto const &i : fittedStarList) {
-        const FittedStar &fs = *i;
-        const RefStar *rs = fs.getRefStar();
+        FittedStar const &fs = *i;
+        RefStar const *rs = fs.getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.
@@ -326,13 +326,13 @@ void AstrometryFit::accumulateStatImage(CcdImage const &ccdImage, Chi2Accumulato
     /**********************************************************************/
     /* Setup */
     // 1 : get the Mapping's
-    const Mapping *mapping = _astrometryModel->getMapping(ccdImage);
+    Mapping const *mapping = _astrometryModel->getMapping(ccdImage);
     // proper motion stuff
     double mjd = ccdImage.getMjd() - _JDRef;
     // refraction stuff
     Point refractionVector = ccdImage.getRefractionVector();
     // transformation from sky to TP
-    const Gtransfo *sky2TP = _astrometryModel->getSky2TP(ccdImage);
+    Gtransfo const *sky2TP = _astrometryModel->getSky2TP(ccdImage);
     // reserve matrix once for all measurements
     Eigen::Matrix2Xd transW(2, 2);
 
@@ -384,7 +384,7 @@ void AstrometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
     FittedStarList &fittedStarList = _associations->fittedStarList;
     TanRaDec2Pix proj(GtransfoLin(), Point(0., 0.));
     for (auto const &fs : fittedStarList) {
-        const RefStar *rs = fs->getRefStar();
+        RefStar const *rs = fs->getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(*fs);
         // fs projects to (0,0), no need to compute its transform.
@@ -408,7 +408,7 @@ void AstrometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
 void AstrometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
                                              std::vector<unsigned> &indices) const {
     if (_fittingDistortions) {
-        const Mapping *mapping = _astrometryModel->getMapping(measuredStar.getCcdImage());
+        Mapping const *mapping = _astrometryModel->getMapping(measuredStar.getCcdImage());
         mapping->getMappingIndices(indices);
     }
     std::shared_ptr<FittedStar const> const fs = measuredStar.getFittedStar();
@@ -517,7 +517,7 @@ static void write_vect_in_fits(Eigen::VectorXd const &vectorXd, std::string cons
 
 void AstrometryFit::checkStuff() {
 #if (0)
-    const char *what2fit[] = {"Positions",
+    char const *what2fit[] = {"Positions",
                               "Distortions",
                               "Refrac",
                               "Positions Distortions",
@@ -525,7 +525,7 @@ void AstrometryFit::checkStuff() {
                               "Distortions Refrac",
                               "Positions Distortions Refrac"};
 #endif
-    const char *what2fit[] = {"Positions", "Distortions", "Positions Distortions"};
+    char const *what2fit[] = {"Positions", "Distortions", "Positions Distortions"};
     // DEBUG
     for (auto & k : what2fit) {
         assignIndices(k);
@@ -576,12 +576,12 @@ void AstrometryFit::saveChi2MeasContributions(std::string const &baseName) const
           << separator;
     ofile << "chip id" << separator << "visit id" << std::endl;
 
-    const CcdImageList &ccdImageList = _associations->getCcdImageList();
+    CcdImageList const &ccdImageList = _associations->getCcdImageList();
     for (auto const &ccdImage : ccdImageList) {
-        const MeasuredStarList &cat = ccdImage->getCatalogForFit();
-        const Mapping *mapping = _astrometryModel->getMapping(*ccdImage);
+        MeasuredStarList const &cat = ccdImage->getCatalogForFit();
+        Mapping const *mapping = _astrometryModel->getMapping(*ccdImage);
         const auto readTransfo = ccdImage->readWCS();
-        const Point &refractionVector = ccdImage->getRefractionVector();
+        Point const &refractionVector = ccdImage->getRefractionVector();
         double mjd = ccdImage->getMjd() - _JDRef;
         for (auto const &ms : cat) {
             if (!ms->isValid()) continue;
@@ -589,7 +589,7 @@ void AstrometryFit::saveChi2MeasContributions(std::string const &baseName) const
             FatPoint inPos = *ms;
             tweakAstromMeasurementErrors(inPos, *ms, _posError);
             mapping->transformPosAndErrors(inPos, tpPos);
-            const Gtransfo *sky2TP = _astrometryModel->getSky2TP(*ccdImage);
+            Gtransfo const *sky2TP = _astrometryModel->getSky2TP(*ccdImage);
             const std::unique_ptr<Gtransfo> readPix2TP = gtransfoCompose(sky2TP, readTransfo);
             FatPoint inputTpPos = readPix2TP->apply(inPos);
             std::shared_ptr<FittedStar const> const fs = ms->getFittedStar();
@@ -640,11 +640,11 @@ void AstrometryFit::saveChi2RefContributions(std::string const &baseName) const 
           << "number of measurements of this FittedStar" << std::endl;
 
     // The following loop is heavily inspired from AstrometryFit::computeChi2()
-    const FittedStarList &fittedStarList = _associations->fittedStarList;
+    FittedStarList const &fittedStarList = _associations->fittedStarList;
     TanRaDec2Pix proj(GtransfoLin(), Point(0., 0.));
     for (auto const &i : fittedStarList) {
-        const FittedStar &fs = *i;
-        const RefStar *rs = fs.getRefStar();
+        FittedStar const &fs = *i;
+        RefStar const *rs = fs.getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.

--- a/src/BaseStar.cc
+++ b/src/BaseStar.cc
@@ -1,6 +1,6 @@
-#include <assert.h>
+#include <cassert>
 #include <fstream>
-#include <string.h>  // strstr
+#include <cstring>  // strstr
 
 #include "lsst/jointcal/BaseStar.h"
 #include "lsst/jointcal/StarList.h"

--- a/src/BaseStar.cc
+++ b/src/BaseStar.cc
@@ -23,7 +23,7 @@ bool increasingMag(BaseStar const *star1, BaseStar const *star2) {
 
 int decodeFormat(char const *formatLine, char const *starName) {
     if (!formatLine || !starName) return 0;
-    const char *p = strstr(formatLine, starName);
+    char const *p = strstr(formatLine, starName);
     if (!p) return 0;
     return atoi(p + strlen(starName));
 }

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -86,7 +86,7 @@ void CcdImage::loadCatalog(afw::table::SourceCatalog const &catalog, std::string
 }
 
 CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-                   const std::shared_ptr<lsst::afw::image::VisitInfo> &visitInfo,
+                   std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo,
                    afw::geom::Box2I const &bbox, std::string const &filter,
                    std::shared_ptr<afw::image::PhotoCalib> photoCalib,
                    std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccdId,

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -1,7 +1,8 @@
-#include <assert.h>
+#include <cassert>
 #include <string>
 #include <sstream>
-#include <math.h>
+#include <utility>
+#include <cmath>
 
 #include "lsst/afw/cameraGeom/CameraSys.h"
 #include "lsst/pex/exceptions.h"
@@ -85,11 +86,11 @@ void CcdImage::loadCatalog(afw::table::SourceCatalog const &catalog, std::string
 }
 
 CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-                   std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo, afw::geom::Box2I const &bbox,
+                   const std::shared_ptr<lsst::afw::image::VisitInfo>& visitInfo, afw::geom::Box2I const &bbox,
                    std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
                    std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccdId,
                    std::string const &fluxField)
-        : _ccdId(ccdId), _visit(visit), _photoCalib(photoCalib), _detector(detector), _filter(filter) {
+        : _ccdId(ccdId), _visit(visit), _photoCalib(std::move(photoCalib)), _detector(std::move(detector)), _filter(filter) {
     loadCatalog(catalog, fluxField);
 
     Point lowerLeft(bbox.getMinX(), bbox.getMinY());
@@ -111,7 +112,7 @@ CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw
 
     // lsstSim doesn't manage ERA (and thus Hour Angle) properly, so it's going to be NaN.
     // Because we need the refraction vector later, go with 0 HA to prevent crashes on that NaN.
-    if (std::isnan(_hourAngle) == true) {
+    if (std::isnan(_hourAngle)) {
         _hourAngle = 0;
     }
 

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -86,11 +86,16 @@ void CcdImage::loadCatalog(afw::table::SourceCatalog const &catalog, std::string
 }
 
 CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-                   const std::shared_ptr<lsst::afw::image::VisitInfo>& visitInfo, afw::geom::Box2I const &bbox,
-                   std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
+                   const std::shared_ptr<lsst::afw::image::VisitInfo> &visitInfo,
+                   afw::geom::Box2I const &bbox, std::string const &filter,
+                   std::shared_ptr<afw::image::PhotoCalib> photoCalib,
                    std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccdId,
                    std::string const &fluxField)
-        : _ccdId(ccdId), _visit(visit), _photoCalib(std::move(photoCalib)), _detector(std::move(detector)), _filter(filter) {
+        : _ccdId(ccdId),
+          _visit(visit),
+          _photoCalib(std::move(photoCalib)),
+          _detector(std::move(detector)),
+          _filter(filter) {
     loadCatalog(catalog, fluxField);
 
     Point lowerLeft(bbox.getMinX(), bbox.getMinY());

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -116,9 +116,9 @@ CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw
         _hourAngle = 0;
     }
 
-    if (_airMass == 1)
+    if (_airMass == 1) {
         _sineta = _coseta = _tgz = 0;
-    else {
+    } else {
         double cosz = 1. / _airMass;
         double sinz = sqrt(1 - cosz * cosz);  // astronomers usually observe above the horizon
         _tgz = sinz / cosz;

--- a/src/ConstrainedPhotometryModel.cc
+++ b/src/ConstrainedPhotometryModel.cc
@@ -46,14 +46,12 @@ ConstrainedPhotometryModel::ConstrainedPhotometryModel(CcdImageList const &ccdIm
             // Use the single-frame processing calibration from the PhotoCalib as the default.
             auto chipTransfo =
                     std::make_shared<PhotometryTransfoSpatiallyInvariant>(photoCalib->getCalibrationMean());
-            _chipMap[chip] =
-                    std::make_unique<PhotometryMapping>(std::move(chipTransfo));
+            _chipMap[chip] = std::make_unique<PhotometryMapping>(std::move(chipTransfo));
         }
         // If the visit is not in the map, add it, otherwise continue.
         if (visitPair == _visitMap.end()) {
             auto visitTransfo = std::make_shared<PhotometryTransfoChebyshev>(visitDegree, focalPlaneBBox);
-            _visitMap[visit] =
-                    std::make_unique<PhotometryMapping>(std::move(visitTransfo));
+            _visitMap[visit] = std::make_unique<PhotometryMapping>(std::move(visitTransfo));
         }
     }
 
@@ -66,8 +64,7 @@ ConstrainedPhotometryModel::ConstrainedPhotometryModel(CcdImageList const &ccdIm
         auto visit = ccdImage->getVisit();
         auto chip = ccdImage->getCcdId();
         _myMap.emplace(ccdImage->getHashKey(),
-                       std::make_unique<ChipVisitPhotometryMapping>(
-                               _chipMap[chip], _visitMap[visit]));
+                       std::make_unique<ChipVisitPhotometryMapping>(_chipMap[chip], _visitMap[visit]));
     }
     LOGLS_INFO(_log, "Got " << _chipMap.size() << " chip mappings and " << _visitMap.size()
                             << " visit mappings; holding chip " << constrainedChip << " fixed.");
@@ -142,7 +139,7 @@ void ConstrainedPhotometryModel::computeParameterDerivatives(MeasuredStar const 
 
 namespace {
 // Convert photoTransfo's way of storing Chebyshev coefficients into the format wanted by ChebyMap.
-ndarray::Array<double, 2, 2> toChebyMapCoeffs(const std::shared_ptr<PhotometryTransfoChebyshev>& transfo) {
+ndarray::Array<double, 2, 2> toChebyMapCoeffs(const std::shared_ptr<PhotometryTransfoChebyshev> &transfo) {
     auto coeffs = transfo->getCoefficients();
     // 4 x nPar: ChebyMap wants rows that look like (a_ij, 1, i, j) for out += a_ij*T_i(x)*T_j(y)
     ndarray::Array<double, 2, 2> chebyCoeffs = allocate(ndarray::makeVector(transfo->getNpar(), 4));
@@ -215,7 +212,7 @@ PhotometryMappingBase *ConstrainedPhotometryModel::findMapping(CcdImage const &c
     if (i == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "ConstrainedPhotometryModel cannot find CcdImage " + ccdImage.getName());
-}
+    }
     return i->second.get();
 }
 

--- a/src/ConstrainedPhotometryModel.cc
+++ b/src/ConstrainedPhotometryModel.cc
@@ -139,7 +139,7 @@ void ConstrainedPhotometryModel::computeParameterDerivatives(MeasuredStar const 
 
 namespace {
 // Convert photoTransfo's way of storing Chebyshev coefficients into the format wanted by ChebyMap.
-ndarray::Array<double, 2, 2> toChebyMapCoeffs(const std::shared_ptr<PhotometryTransfoChebyshev> &transfo) {
+ndarray::Array<double, 2, 2> toChebyMapCoeffs(std::shared_ptr<PhotometryTransfoChebyshev> transfo) {
     auto coeffs = transfo->getCoefficients();
     // 4 x nPar: ChebyMap wants rows that look like (a_ij, 1, i, j) for out += a_ij*T_i(x)*T_j(y)
     ndarray::Array<double, 2, 2> chebyCoeffs = allocate(ndarray::makeVector(transfo->getNpar(), 4));

--- a/src/ConstrainedPhotometryModel.cc
+++ b/src/ConstrainedPhotometryModel.cc
@@ -212,9 +212,10 @@ void ConstrainedPhotometryModel::dump(std::ostream &stream) const {
 
 PhotometryMappingBase *ConstrainedPhotometryModel::findMapping(CcdImage const &ccdImage) const {
     auto i = _myMap.find(ccdImage.getHashKey());
-    if (i == _myMap.end())
+    if (i == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "ConstrainedPhotometryModel cannot find CcdImage " + ccdImage.getName());
+}
     return i->second.get();
 }
 

--- a/src/ConstrainedPhotometryModel.cc
+++ b/src/ConstrainedPhotometryModel.cc
@@ -1,5 +1,6 @@
 #include <map>
 #include <limits>
+#include <memory>
 
 #include "lsst/log/Log.h"
 
@@ -46,13 +47,13 @@ ConstrainedPhotometryModel::ConstrainedPhotometryModel(CcdImageList const &ccdIm
             auto chipTransfo =
                     std::make_shared<PhotometryTransfoSpatiallyInvariant>(photoCalib->getCalibrationMean());
             _chipMap[chip] =
-                    std::unique_ptr<PhotometryMapping>(new PhotometryMapping(std::move(chipTransfo)));
+                    std::make_unique<PhotometryMapping>(std::move(chipTransfo));
         }
         // If the visit is not in the map, add it, otherwise continue.
         if (visitPair == _visitMap.end()) {
             auto visitTransfo = std::make_shared<PhotometryTransfoChebyshev>(visitDegree, focalPlaneBBox);
             _visitMap[visit] =
-                    std::unique_ptr<PhotometryMapping>(new PhotometryMapping(std::move(visitTransfo)));
+                    std::make_unique<PhotometryMapping>(std::move(visitTransfo));
         }
     }
 
@@ -65,8 +66,8 @@ ConstrainedPhotometryModel::ConstrainedPhotometryModel(CcdImageList const &ccdIm
         auto visit = ccdImage->getVisit();
         auto chip = ccdImage->getCcdId();
         _myMap.emplace(ccdImage->getHashKey(),
-                       std::unique_ptr<ChipVisitPhotometryMapping>(
-                               new ChipVisitPhotometryMapping(_chipMap[chip], _visitMap[visit])));
+                       std::make_unique<ChipVisitPhotometryMapping>(
+                               _chipMap[chip], _visitMap[visit]));
     }
     LOGLS_INFO(_log, "Got " << _chipMap.size() << " chip mappings and " << _visitMap.size()
                             << " visit mappings; holding chip " << constrainedChip << " fixed.");
@@ -141,7 +142,7 @@ void ConstrainedPhotometryModel::computeParameterDerivatives(MeasuredStar const 
 
 namespace {
 // Convert photoTransfo's way of storing Chebyshev coefficients into the format wanted by ChebyMap.
-ndarray::Array<double, 2, 2> toChebyMapCoeffs(std::shared_ptr<PhotometryTransfoChebyshev> transfo) {
+ndarray::Array<double, 2, 2> toChebyMapCoeffs(const std::shared_ptr<PhotometryTransfoChebyshev>& transfo) {
     auto coeffs = transfo->getCoefficients();
     // 4 x nPar: ChebyMap wants rows that look like (a_ij, 1, i, j) for out += a_ij*T_i(x)*T_j(y)
     ndarray::Array<double, 2, 2> chebyCoeffs = allocate(ndarray::makeVector(transfo->getNpar(), 4));
@@ -165,7 +166,7 @@ std::shared_ptr<afw::image::PhotoCalib> ConstrainedPhotometryModel::toPhotoCalib
     auto oldPhotoCalib = ccdImage.getPhotoCalib();
     auto detector = ccdImage.getDetector();
     auto ccdBBox = detector->getBBox();
-    ChipVisitPhotometryMapping *mapping = dynamic_cast<ChipVisitPhotometryMapping *>(findMapping(ccdImage));
+    auto *mapping = dynamic_cast<ChipVisitPhotometryMapping *>(findMapping(ccdImage));
     // There should be no way in which we can get to this point and not have a ChipVisitMapping,
     // so blow up if we don't.
     assert(mapping != nullptr);

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -109,16 +109,18 @@ unsigned ConstrainedPolyModel::assignIndices(unsigned firstIndex, std::string co
     if ((!_fittingChips) && (!_fittingVisits)) {
         _fittingChips = _fittingVisits = true;
     }
-    if (_fittingChips)
+    if (_fittingChips) {
         for (auto &i : _chipMap) {
             i.second->setIndex(index);
             index += i.second->getNpar();
         }
-    if (_fittingVisits)
+}
+    if (_fittingVisits) {
         for (auto &i : _visitMap) {
             i.second->setIndex(index);
             index += i.second->getNpar();
         }
+}
     // Tell the mappings which derivatives they will have to fill:
     for (auto &i : _mappings) {
         i.second->setWhatToFit(_fittingChips, _fittingVisits);
@@ -127,16 +129,18 @@ unsigned ConstrainedPolyModel::assignIndices(unsigned firstIndex, std::string co
 }
 
 void ConstrainedPolyModel::offsetParams(Eigen::VectorXd const &delta) {
-    if (_fittingChips)
+    if (_fittingChips) {
         for (auto &i : _chipMap) {
             auto mapping = i.second.get();
             mapping->offsetParams(delta.segment(mapping->getIndex(), mapping->getNpar()));
         }
-    if (_fittingVisits)
+}
+    if (_fittingVisits) {
         for (auto &i : _visitMap) {
             auto mapping = i.second.get();
             mapping->offsetParams(delta.segment(mapping->getIndex(), mapping->getNpar()));
         }
+}
 }
 
 void ConstrainedPolyModel::freezeErrorTransform() {

--- a/src/ConstrainedPolyModel.cc
+++ b/src/ConstrainedPolyModel.cc
@@ -42,8 +42,7 @@ ConstrainedPolyModel::ConstrainedPolyModel(CcdImageList const &ccdImageList,
         auto visitp = _visitMap.find(visit);
         if (visitp == _visitMap.end()) {
             if (_visitMap.empty()) {
-                _visitMap[visit] =
-                        std::make_unique<SimpleGtransfoMapping>(GtransfoIdentity());
+                _visitMap[visit] = std::make_unique<SimpleGtransfoMapping>(GtransfoIdentity());
             } else {
                 _visitMap[visit] = std::unique_ptr<SimpleGtransfoMapping>(
                         new SimplePolyMapping(GtransfoLin(), GtransfoPoly(visitDegree)));
@@ -60,8 +59,8 @@ ConstrainedPolyModel::ConstrainedPolyModel(CcdImageList const &ccdImageList,
             }
             GtransfoLin shiftAndNormalize = normalizeCoordinatesTransfo(frame);
 
-            _chipMap[chip] = std::make_unique<SimplePolyMapping>(
-                    shiftAndNormalize, pol * shiftAndNormalize.invert());
+            _chipMap[chip] =
+                    std::make_unique<SimplePolyMapping>(shiftAndNormalize, pol * shiftAndNormalize.invert());
         }
     }
     // now, second loop to set the mappings of the CCdImages
@@ -74,11 +73,9 @@ ConstrainedPolyModel::ConstrainedPolyModel(CcdImageList const &ccdImageList,
         if (_chipMap.find(chip) == _chipMap.end()) {
             LOGLS_WARN(_log, "Chip " << chip << " is missing in the reference exposure, expect troubles.");
             GtransfoLin norm = normalizeCoordinatesTransfo(im.getImageFrame());
-            _chipMap[chip] =
-                    std::make_unique<SimplePolyMapping>(norm, GtransfoPoly(chipDegree));
+            _chipMap[chip] = std::make_unique<SimplePolyMapping>(norm, GtransfoPoly(chipDegree));
         }
-        _mappings[&im] = std::make_unique<TwoTransfoMapping>(
-                _chipMap[chip].get(), _visitMap[visit].get());
+        _mappings[&im] = std::make_unique<TwoTransfoMapping>(_chipMap[chip].get(), _visitMap[visit].get());
     }
     LOGLS_INFO(_log, "Constructor got " << _chipMap.size() << " chip mappings and " << _visitMap.size()
                                         << " visit mappings.");
@@ -114,13 +111,13 @@ unsigned ConstrainedPolyModel::assignIndices(unsigned firstIndex, std::string co
             i.second->setIndex(index);
             index += i.second->getNpar();
         }
-}
+    }
     if (_fittingVisits) {
         for (auto &i : _visitMap) {
             i.second->setIndex(index);
             index += i.second->getNpar();
         }
-}
+    }
     // Tell the mappings which derivatives they will have to fill:
     for (auto &i : _mappings) {
         i.second->setWhatToFit(_fittingChips, _fittingVisits);
@@ -134,18 +131,18 @@ void ConstrainedPolyModel::offsetParams(Eigen::VectorXd const &delta) {
             auto mapping = i.second.get();
             mapping->offsetParams(delta.segment(mapping->getIndex(), mapping->getNpar()));
         }
-}
+    }
     if (_fittingVisits) {
         for (auto &i : _visitMap) {
             auto mapping = i.second.get();
             mapping->offsetParams(delta.segment(mapping->getIndex(), mapping->getNpar()));
         }
-}
+    }
 }
 
 void ConstrainedPolyModel::freezeErrorTransform() {
-    for (auto & i : _visitMap) i.second->freezeErrorTransform();
-    for (auto & i : _chipMap) i.second->freezeErrorTransform();
+    for (auto &i : _visitMap) i.second->freezeErrorTransform();
+    for (auto &i : _chipMap) i.second->freezeErrorTransform();
 }
 
 Gtransfo const &ConstrainedPolyModel::getChipTransfo(CcdIdType const chip) const {
@@ -162,7 +159,7 @@ Gtransfo const &ConstrainedPolyModel::getChipTransfo(CcdIdType const chip) const
 std::vector<VisitIdType> ConstrainedPolyModel::getVisits() const {
     std::vector<VisitIdType> res;
     res.reserve(_visitMap.size());
-    for (auto const & i : _visitMap) res.push_back(i.first);
+    for (auto const &i : _visitMap) res.push_back(i.first);
     return res;
 }
 

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -187,7 +187,7 @@ FastFinder::stars_element Iterator::operator*() const {
 void Iterator::operator++() {
     if (current != pend) {
         current++;
-    } else
+    } else {
         do {
             currentSlice++;
             if (currentSlice >= endSlice) {
@@ -196,6 +196,7 @@ void Iterator::operator++() {
             }
             finder.findRangeInSlice(currentSlice, yStart, yEnd, current, pend);
         } while (current == null_value);
+}
     check();
 }
 

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -113,7 +113,7 @@ FastFinder::pstar FastFinder::locateYStart(pstar begin, pstar end, double yVal) 
     int span = end - begin - 1;
     while (span > 1) {
         int half_span = span / 2;
-        pstar middle = begin + half_span;
+        auto middle = begin + half_span;
         if ((*middle)->y < yVal) {
             begin += half_span;
             span -= half_span;
@@ -131,7 +131,7 @@ FastFinder::pstar FastFinder::locateYEnd(pstar begin, pstar end, double yVal) co
     int span = end - begin - 1;
     while (span > 1) {
         int half_span = span / 2;
-        pstar middle = end - half_span;
+        auto middle = end - half_span;
         if ((*middle)->y > yVal) {
             end -= half_span;
             span -= half_span;

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -11,7 +11,7 @@ LOG_LOGGER _log = LOG_GET("jointcal.FastFinder");
 namespace lsst {
 namespace jointcal {
 
-FastFinder::FastFinder(const BaseStarList &list, const unsigned nXSlice)
+FastFinder::FastFinder(BaseStarList const &list, const unsigned nXSlice)
         : baselist(list), count(list.size()), stars(count), nslice(nXSlice), index(nslice + 1) {
     if (count == 0) return;
 
@@ -57,8 +57,8 @@ void FastFinder::dump() const {
     }
 }
 
-std::shared_ptr<const BaseStar> FastFinder::findClosest(const Point &where, const double maxDist,
-                                                        bool (*SkipIt)(const BaseStar &)) const {
+std::shared_ptr<const BaseStar> FastFinder::findClosest(Point const &where, const double maxDist,
+                                                        bool (*SkipIt)(BaseStar const &)) const {
     if (count == 0) return nullptr;
     FastFinder::Iterator it = beginScan(where, maxDist);
     if (*it == nullptr) return nullptr;
@@ -75,9 +75,9 @@ std::shared_ptr<const BaseStar> FastFinder::findClosest(const Point &where, cons
     return pbest;
 }
 
-std::shared_ptr<const BaseStar> FastFinder::secondClosest(const Point &where, const double maxDist,
+std::shared_ptr<const BaseStar> FastFinder::secondClosest(Point const &where, const double maxDist,
                                                           std::shared_ptr<const BaseStar> &closest,
-                                                          bool (*SkipIt)(const BaseStar &)) const {
+                                                          bool (*SkipIt)(BaseStar const &)) const {
     closest = nullptr;
     if (count == 0) return nullptr;
     FastFinder::Iterator it = beginScan(where, maxDist);
@@ -148,13 +148,13 @@ void FastFinder::findRangeInSlice(const int iSlice, const double yStart, const d
     end = locateYEnd(start, stars.begin() + index[iSlice + 1], yEnd);
 }
 
-FastFinder::Iterator FastFinder::beginScan(const Point &where, double maxDist) const {
+FastFinder::Iterator FastFinder::beginScan(Point const &where, double maxDist) const {
     return FastFinder::Iterator(*this, where, maxDist);
 }
 
 using Iterator = FastFinder::Iterator;
 
-Iterator::Iterator(const FastFinder &F, const Point &where, double maxDist)
+Iterator::Iterator(FastFinder const &F, Point const &where, double maxDist)
         : finder(F), null_value(F.stars.end()) {
     current = pend = null_value;  // does not iterate
     int startSlice = 0;

--- a/src/FastFinder.cc
+++ b/src/FastFinder.cc
@@ -196,7 +196,7 @@ void Iterator::operator++() {
             }
             finder.findRangeInSlice(currentSlice, yStart, yEnd, current, pend);
         } while (current == null_value);
-}
+    }
     check();
 }
 

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -16,7 +16,7 @@ namespace lsst {
 namespace jointcal {
 
 // cannot be in fittedstar.h, because of "crossed includes"
-FittedStar::FittedStar(const MeasuredStar &measuredStar)
+FittedStar::FittedStar(MeasuredStar const &measuredStar)
         : BaseStar(measuredStar),
           _mag(measuredStar.getMag()),
           _gen(-1),
@@ -27,7 +27,7 @@ FittedStar::FittedStar(const MeasuredStar &measuredStar)
     _fluxErr = measuredStar.getInstFluxErr();
 }
 
-void FittedStar::setRefStar(const RefStar *refStar) {
+void FittedStar::setRefStar(RefStar const *refStar) {
     if ((_refStar != nullptr) && (refStar != nullptr)) {
         // TODO: should we raise an Exception in this case?
         LOGLS_WARN(_log,
@@ -49,8 +49,8 @@ BaseStarList &Fitted2Base(FittedStarList &This) { return (BaseStarList &)This; }
 
 BaseStarList *Fitted2Base(FittedStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
-const BaseStarList &Fitted2Base(const FittedStarList &This) { return (const BaseStarList &)This; }
+BaseStarList const &Fitted2Base(FittedStarList const &This) { return (BaseStarList const &)This; }
 
-const BaseStarList *Fitted2Base(const FittedStarList *This) { return (BaseStarList *)This; }
+BaseStarList const *Fitted2Base(FittedStarList const *This) { return (BaseStarList *)This; }
 }  // namespace jointcal
 }  // namespace lsst

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -36,7 +36,7 @@ void FittedStar::setRefStar(RefStar const *refStar) {
         LOGLS_WARN(_log, "new refStar: " << *refStar);
     } else {
         _refStar = refStar;
-}
+    }
 }
 
 void FittedStar::addMagMeasurement(double magValue, double magWeight) {

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -47,7 +47,7 @@ void FittedStar::addMagMeasurement(double magValue, double magWeight) {
 
 BaseStarList &Fitted2Base(FittedStarList &This) { return (BaseStarList &)This; }
 
-BaseStarList *Fitted2Base(FittedStarList *This) { return (BaseStarList *)This; }
+BaseStarList *Fitted2Base(FittedStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
 const BaseStarList &Fitted2Base(const FittedStarList &This) { return (const BaseStarList &)This; }
 

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -34,8 +34,9 @@ void FittedStar::setRefStar(RefStar const *refStar) {
                    "FittedStar: " << *this << " is already matched to another RefStar. Clean up your lists.");
         LOGLS_WARN(_log, "old refStar: " << *_refStar);
         LOGLS_WARN(_log, "new refStar: " << *refStar);
-    } else
+    } else {
         _refStar = refStar;
+}
 }
 
 void FittedStar::addMagMeasurement(double magValue, double magWeight) {

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -199,7 +199,7 @@ void FitterBase::outliersContributions(MeasuredStarList &msOutliers, FittedStarL
     for (auto &outlier : msOutliers) {
         MeasuredStarList tmp;
         tmp.push_back(outlier);
-        const CcdImage &ccdImage = outlier->getCcdImage();
+        CcdImage const &ccdImage = outlier->getCcdImage();
         leastSquareDerivativesMeasurement(ccdImage, tripletList, grad, &tmp);
     }
     leastSquareDerivativesReference(fsOutliers, tripletList, grad);

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -16,7 +16,7 @@ namespace jointcal {
 using namespace std;
 
 /****************** Frame class methods ***********************/
-Frame::Frame(const Point &lowerLeft, const Point &upperRight) {
+Frame::Frame(Point const &lowerLeft, Point const &upperRight) {
     *this = Frame(lowerLeft.x, lowerLeft.y, upperRight.x, upperRight.y);
 }
 
@@ -30,18 +30,18 @@ Frame::Frame(double xmin, double ymin, double xmax, double ymax) {
 Frame::Frame() { xMin = xMax = yMin = yMax = 0; }
 
 /* positive if inside, negative if outside */
-double Frame::minDistToEdges(const Point &point) const {
+double Frame::minDistToEdges(Point const &point) const {
     return min(min(point.x - xMin, xMax - point.x) /* minx */,
                min(point.y - yMin, yMax - point.y) /* miny */);
 }
 
-Frame Frame::operator*(const Frame &right) const {
+Frame Frame::operator*(Frame const &right) const {
     Frame result = *this;
     result *= right;
     return result;
 }
 
-Frame &Frame::operator*=(const Frame &right) {
+Frame &Frame::operator*=(Frame const &right) {
     Frame rightCopy = right;
     // make sure that coordinates are properly ordered
     order();
@@ -55,13 +55,13 @@ Frame &Frame::operator*=(const Frame &right) {
     return *this;
 }
 
-Frame Frame::operator+(const Frame &right) const {
+Frame Frame::operator+(Frame const &right) const {
     Frame result = *this;
     result += right;
     return result;
 }
 
-Frame &Frame::operator+=(const Frame &right) {
+Frame &Frame::operator+=(Frame const &right) {
     Frame rightCopy = right;
     // make sure that coordinates are properly ordered
     order();
@@ -78,7 +78,7 @@ void Frame::order() {
     if (yMin > yMax) swap(yMin, yMax);
 }
 
-bool Frame::operator==(const Frame &right) const {
+bool Frame::operator==(Frame const &right) const {
     return ((xMin == right.xMin) && (xMax == right.xMax) && (yMin == right.yMin) && (yMax == right.yMax));
 }
 

--- a/src/Gtransfo.cc
+++ b/src/Gtransfo.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <iomanip>
 #include <iterator> /* for ostream_iterator */
-#include <cmath>   // for sin and cos and may be others
+#include <cmath>    // for sin and cos and may be others
 #include <fstream>
 #include <cassert>
 #include <memory>
@@ -44,7 +44,7 @@ bool isIntegerShift(Gtransfo const *gtransfo) {
 
     static Point dumb(4000, 4000);
     return fabs(dx - int(floor(dx + 0.5))) < eps && fabs(dy - int(floor(dy + 0.5))) < eps &&
-        fabs(dumb.x + dx - shift->apply(dumb).x) < eps && fabs(dumb.y + dy - shift->apply(dumb).y) < eps;
+           fabs(dumb.x + dx - shift->apply(dumb).x) < eps && fabs(dumb.y + dy - shift->apply(dumb).y) < eps;
 }
 
 /********* Gtransfo ***********************/
@@ -203,7 +203,7 @@ void Gtransfo::write(const std::string &fileName) const {
     if (!ok) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "Gtransfo::write, something went wrong for file " + fileName);
-}
+    }
 }
 
 void Gtransfo::write(ostream &stream) const {
@@ -241,7 +241,9 @@ public:
     std::unique_ptr<Gtransfo> roughInverse(Frame const &) const override { return _direct->clone(); }
 
     //! Inverse transfo: returns the direct one!
-    std::unique_ptr<Gtransfo> inverseTransfo(double, Frame const &) const override { return _direct->clone(); }
+    std::unique_ptr<Gtransfo> inverseTransfo(double, Frame const &) const override {
+        return _direct->clone();
+    }
 
     ~GtransfoInverse() override;
 
@@ -378,9 +380,9 @@ std::unique_ptr<Gtransfo> gtransfoCompose(Gtransfo const *left, Gtransfo const *
        that pipelines "left" and "right" */
     if (composition == nullptr) {
         return std::unique_ptr<Gtransfo>(new GtransfoComposition(left, right));
-}
-    
-        return composition;
+    }
+
+    return composition;
 }
 
 // just a speed up, to avoid useless numerical derivation.
@@ -401,7 +403,7 @@ void GtransfoIdentity::read(istream &stream) {
     if (format != 1) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " GtransfoIdentity::read : format is not 1 ");
-}
+    }
 }
 
 /***************  GtransfoPoly **************************************/
@@ -435,7 +437,7 @@ GtransfoPoly::GtransfoPoly(Gtransfo const *gtransfo, Frame const &frame, unsigne
                all errors (and weights) will be equal : */
             sm.push_back(StarMatch(*pix, *tp, pix, tp));
         }
-}
+    }
     GtransfoPoly ret(degree);
     ret.fit(sm);
     *this = ret;
@@ -669,7 +671,7 @@ double GtransfoPoly::coeffOrZero(const unsigned degX, const unsigned degY, const
     assert(whichCoord < 2);
     if (degX + degY <= _degree) {
         return _coeffs[(degX + degY) * (degX + degY + 1) / 2 + degY + whichCoord * _nterms];
-}
+    }
     return 0;
 }
 
@@ -710,13 +712,13 @@ void GtransfoPoly::dump(ostream &stream) const {
             stream << "newx = ";
         } else {
             stream << "newy = ";
-}
+        }
         for (unsigned p = 0; p <= _degree; ++p) {
             for (unsigned py = 0; py <= p; ++py) {
                 if (p + py != 0) stream << " + ";
                 stream << coeff(p - py, py, ic) << monomialString(p - py, py);
             }
-}
+        }
         stream << endl;
     }
     if (_degree > 0) stream << " Linear determinant = " << determinant() << endl;
@@ -741,7 +743,7 @@ static GtransfoLin shiftAndNormalize(StarMatchList const &starMatchList) {
     double yav = 0;
     double y2 = 0;
     double count = 0;
-    for (auto const & a_match : starMatchList) {
+    for (auto const &a_match : starMatchList) {
         Point const &point1 = a_match.point1;
         xav += point1.x;
         yav += point1.y;
@@ -768,7 +770,7 @@ double GtransfoPoly::computeFit(StarMatchList const &starMatchList, Gtransfo con
     B.setZero();
     double sumr2 = 0;
     double monomials[_nterms];
-    for (auto const & a_match : starMatchList) {
+    for (auto const &a_match : starMatchList) {
         Point tmp = shiftToCenter.apply(a_match.point1);
         FatPoint point1(tmp, a_match.point1.vx, a_match.point1.vy, a_match.point1.vxy);
         FatPoint const &point2 = a_match.point2;
@@ -841,12 +843,12 @@ std::unique_ptr<Gtransfo> GtransfoPoly::reduceCompo(Gtransfo const *right) const
     if (p) {
         if (getDegree() == 1 && p->getDegree() == 1) {
             return std::unique_ptr<Gtransfo>(new GtransfoLin((*this) * (*p)));  // does the composition
-}
-        
-            return std::unique_ptr<Gtransfo>(new GtransfoPoly((*this) * (*p)));  // does the composition
+        }
+
+        return std::unique_ptr<Gtransfo>(new GtransfoPoly((*this) * (*p)));  // does the composition
     } else {
         return std::unique_ptr<Gtransfo>(nullptr);
-}
+    }
 }
 
 /*  PolyXY the class used to perform polynomial algebra (and in
@@ -876,9 +878,9 @@ public:
         for (unsigned px = 0; px <= degree; ++px) {
             for (unsigned py = 0; py <= degree - px; ++py) {
                 coeff(px, py) = gtransfoPoly.coeff(px, py, whichCoord);
-}
+            }
+        }
     }
-}
 
     long double coeff(const unsigned powX, const unsigned powY) const {
         assert(powX + powY <= degree);
@@ -898,7 +900,7 @@ static void operator+=(PolyXY &left, PolyXY const &right) {
     assert(left.getDegree() >= rdeg);
     for (unsigned i = 0; i <= rdeg; ++i) {
         for (unsigned j = 0; j <= rdeg - i; ++j) left.coeff(i, j) += right.coeff(i, j);
-}
+    }
 }
 
 /* multiplication by a scalar */
@@ -908,7 +910,7 @@ static PolyXY operator*(const long double &a, PolyXY const &polyXY) {
     unsigned degree = polyXY.getDegree();
     for (unsigned i = 0; i <= degree; ++i) {
         for (unsigned j = 0; j <= degree - i; ++j) result.coeff(i, j) *= a;
-}
+    }
     return result;
 }
 
@@ -922,10 +924,10 @@ static PolyXY product(PolyXY const &p1, PolyXY const &p2) {
             for (unsigned i2 = 0; i2 <= deg2; ++i2) {
                 for (unsigned j2 = 0; j2 <= deg2 - i2; ++j2) {
                     result.coeff(i1 + i2, j1 + j2) += p1.coeff(i1, j1) * p2.coeff(i2, j2);
-}
-}
-}
-}
+                }
+            }
+        }
+    }
     return result;
 }
 
@@ -948,8 +950,8 @@ static PolyXY composition(PolyXY const &polyXY, PolyXY const &polyX, PolyXY cons
     for (unsigned px = 0; px <= pdeg; ++px) {
         for (unsigned py = 0; py <= pdeg - px; ++py) {
             result += polyXY.coeff(px, py) * product(pXPowers.at(px), pYPowers.at(py));
-}
-}
+        }
+    }
     return result;
 }
 
@@ -975,7 +977,7 @@ GtransfoPoly GtransfoPoly::operator*(GtransfoPoly const &right) const {
             result.coeff(px, py, 0) = rx.coeff(px, py);
             result.coeff(px, py, 1) = ry.coeff(px, py);
         }
-}
+    }
     return result;
 }
 
@@ -987,10 +989,10 @@ GtransfoPoly GtransfoPoly::operator+(GtransfoPoly const &right) const {
                 res.coeff(i, j, 0) += right.coeff(i, j, 0);
                 res.coeff(i, j, 1) += right.coeff(i, j, 1);
             }
-}
+        }
         return res;
-    } 
-        return (right + (*this));
+    }
+    return (right + (*this));
 }
 
 GtransfoPoly GtransfoPoly::operator-(GtransfoPoly const &right) const {
@@ -1000,7 +1002,7 @@ GtransfoPoly GtransfoPoly::operator-(GtransfoPoly const &right) const {
             res.coeff(i, j, 0) = coeffOrZero(i, j, 0) - right.coeffOrZero(i, j, 0);
             res.coeff(i, j, 1) = coeffOrZero(i, j, 1) - right.coeffOrZero(i, j, 1);
         }
-}
+    }
     return res;
 }
 
@@ -1019,14 +1021,14 @@ void GtransfoPoly::read(istream &s) {
     s >> format;
     if (format != 1) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, " GtransfoPoly::read : format is not 1 ");
-}
+    }
 
     string degree;
     s >> degree >> _degree;
     if (degree != "degree") {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " GtransfoPoly::read : expecting \"degree\" and found " + degree);
-}
+    }
     setDegree(_degree);
     for (unsigned k = 0; k < 2 * _nterms; ++k) s >> _coeffs[k];
 }
@@ -1044,7 +1046,7 @@ std::unique_ptr<GtransfoPoly> inversePolyTransfo(Gtransfo const &direct, Frame c
             Point out(direct.apply(in));
             sm.push_back(StarMatch(out, in, nullptr, nullptr));
         }
-}
+    }
     unsigned npairs = sm.size();
     int maxdeg = 9;
     int degree;
@@ -1060,7 +1062,7 @@ std::unique_ptr<GtransfoPoly> inversePolyTransfo(Gtransfo const &direct, Frame c
     if (degree > maxdeg) {
         LOGLS_WARN(_log, "inversePolyTransfo: Reached max degree without reaching requested precision: "
                                  << precision);
-}
+    }
     return poly;
 }
 
@@ -1084,7 +1086,7 @@ GtransfoLin::GtransfoLin(GtransfoPoly const &gtransfoPoly) : GtransfoPoly(1) {
     if (gtransfoPoly.getDegree() != 1) {
         throw pexExcept::InvalidParameterError(
                 "Trying to build a GtransfoLin from a higher order transfo. Aborting. ");
-}
+    }
     (GtransfoPoly &)(*this) = gtransfoPoly;
 }
 
@@ -1307,7 +1309,6 @@ Point BaseTanWcs::getCrPix() const {
 
 BaseTanWcs::~BaseTanWcs() = default;
 
-
 GtransfoSkyWcs::GtransfoSkyWcs(std::shared_ptr<afw::geom::SkyWcs> skyWcs) : _skyWcs(std::move(skyWcs)) {}
 
 void GtransfoSkyWcs::apply(const double xIn, const double yIn, double &xOut, double &yOut) const {
@@ -1316,9 +1317,7 @@ void GtransfoSkyWcs::apply(const double xIn, const double yIn, double &xOut, dou
     yOut = outCoord[1].asDegrees();
 }
 
-void GtransfoSkyWcs::dump(std::ostream &stream) const {
-    stream << "GtransfoSkyWcs(" << *_skyWcs << ")";
-}
+void GtransfoSkyWcs::dump(std::ostream &stream) const { stream << "GtransfoSkyWcs(" << *_skyWcs << ")"; }
 
 double GtransfoSkyWcs::fit(StarMatchList const &starMatchList) {
     throw LSST_EXCEPT(pex::exceptions::LogicError, "Not implemented");
@@ -1364,17 +1363,17 @@ std::unique_ptr<Gtransfo> TanPix2RaDec::roughInverse(Frame const &) const {
 std::unique_ptr<Gtransfo> TanPix2RaDec::inverseTransfo(const double precision, Frame const &region) const {
     if (!corr) {
         return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().invert(), getTangentPoint()));
-}
-    
-        return std::unique_ptr<Gtransfo>(new GtransfoInverse(this, precision, region));
+    }
+
+    return std::unique_ptr<Gtransfo>(new GtransfoInverse(this, precision, region));
 }
 
 GtransfoPoly TanPix2RaDec::getPix2TangentPlane() const {
     if (corr) {
         return (*corr) * linPix2Tan;
-}
-    
-        return linPix2Tan;
+    }
+
+    return linPix2Tan;
 }
 
 void TanPix2RaDec::pix2TP(double xPixel, double yPixel, double &xTangentPlane, double &yTangentPlane) const {
@@ -1441,9 +1440,9 @@ std::unique_ptr<Gtransfo> TanSipPix2RaDec::inverseTransfo(const double precision
 GtransfoPoly TanSipPix2RaDec::getPix2TangentPlane() const {
     if (corr) {
         return GtransfoPoly(linPix2Tan) * (*corr);
-}
-    
-        return linPix2Tan;
+    }
+
+    return linPix2Tan;
 }
 
 void TanSipPix2RaDec::pix2TP(double xPixel, double yPixel, double &xTangentPlane,
@@ -1455,7 +1454,7 @@ void TanSipPix2RaDec::pix2TP(double xPixel, double yPixel, double &xTangentPlane
         linPix2Tan.apply(xtmp, ytmp, xTangentPlane, yTangentPlane);
     } else {
         linPix2Tan.apply(xPixel, yPixel, xTangentPlane, yTangentPlane);
-}
+    }
 }
 
 std::unique_ptr<Gtransfo> TanSipPix2RaDec::clone() const {
@@ -1637,7 +1636,7 @@ std::unique_ptr<Gtransfo> gtransfoRead(const std::string &fileName) {
     ifstream s(fileName.c_str());
     if (!s) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError, " gtransfoRead : cannot open " + fileName);
-}
+    }
     try {
         std::unique_ptr<Gtransfo> res(gtransfoRead(s));
         s.close();
@@ -1654,19 +1653,20 @@ std::unique_ptr<Gtransfo> gtransfoRead(istream &s) {
     if (s.fail()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "gtransfoRead : could not find a Gtransfotype");
-}
+    }
     if (type == "GtransfoIdentity") {
         std::unique_ptr<GtransfoIdentity> res(new GtransfoIdentity());
         res->read(s);
         return std::move(res);
-    } if (type == "GtransfoPoly") {
+    }
+    if (type == "GtransfoPoly") {
         std::unique_ptr<GtransfoPoly> res(new GtransfoPoly());
         res->read(s);
         return std::move(res);
     } else {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " gtransfoRead : No reader for Gtransfo type " + type);
-}
+    }
 }
 }  // namespace jointcal
 }  // namespace lsst

--- a/src/Histo2d.cc
+++ b/src/Histo2d.cc
@@ -1,6 +1,7 @@
 #include <iostream>
-#include <math.h>   /* for floor */
-#include <string.h> /* for memset*/
+#include <memory>
+#include <cmath>   /* for floor */
+#include <cstring> /* for memset*/
 
 #include "lsst/log/Log.h"
 #include "lsst/jointcal/Histo2d.h"
@@ -29,20 +30,20 @@ Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float 
         LOGL_WARN(_log, "Histo2d: maxy = miny requested");
         scaley = 1.0;
     }
-    data.reset(new float[nx * ny]);
+    data = std::make_unique<float[]>(nx * ny);
     memset(data.get(), 0, nx * ny * sizeof(float));
 }
 
 Histo2d::Histo2d(const Histo2d &other) {
     memcpy(this, &other, sizeof(Histo2d));
-    data.reset(new float[nx * ny]);
+    data = std::make_unique<float[]>(nx * ny);
     memcpy((data).get(), other.data.get(), nx * ny * sizeof(float));
 }
 
 bool Histo2d::indices(double x, double y, int &ix, int &iy) const {
-    ix = (int)floor((x - minx) * scalex);
+    ix = static_cast<int>(floor((x - minx) * scalex));
     if (ix < 0 || ix >= nx) return false;
-    iy = (int)floor((y - miny) * scaley);
+    iy = static_cast<int>(floor((y - miny) * scaley));
     return (iy >= 0 && iy < ny);
 }
 
@@ -64,8 +65,8 @@ double Histo2d::maxBin(double &x, double &y) const {
     }
     int ix = imax / ny;
     int iy = imax - ix * ny;
-    x = minx + ((float)ix + 0.5) / scalex;
-    y = miny + ((float)iy + 0.5) / scaley;
+    x = minx + (static_cast<float>(ix) + 0.5) / scalex;
+    y = miny + (static_cast<float>(iy) + 0.5) / scaley;
     return valmax;
 }
 

--- a/src/Histo2d.cc
+++ b/src/Histo2d.cc
@@ -18,15 +18,15 @@ Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float 
     ny = nny;
     minx = mminx;
     miny = mminy;
-    if (mmaxx != mminx)
+    if (mmaxx != mminx) {
         scalex = nx / (mmaxx - mminx);
-    else {
+    } else {
         LOGL_WARN(_log, "Histo2d: minx = maxx requested");
         scalex = 1.0;
     }
-    if (mmaxy != mminy)
+    if (mmaxy != mminy) {
         scaley = ny / (mmaxy - mminy);
-    else {
+    } else {
         LOGL_WARN(_log, "Histo2d: maxy = miny requested");
         scaley = 1.0;
     }

--- a/src/Histo2d.cc
+++ b/src/Histo2d.cc
@@ -34,7 +34,7 @@ Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float 
     memset(data.get(), 0, nx * ny * sizeof(float));
 }
 
-Histo2d::Histo2d(const Histo2d &other) {
+Histo2d::Histo2d(Histo2d const &other) {
     memcpy(this, &other, sizeof(Histo2d));
     data = std::make_unique<float[]>(nx * ny);
     memcpy((data).get(), other.data.get(), nx * ny * sizeof(float));

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -20,8 +20,9 @@ SparseHisto4d::SparseHisto4d(const int n1, double min1, double max1, const int n
                              const int nEntries) {
     double indexMax = n1 * n2 * n3 * n4;
     _data.reset();
-    if (indexMax > double(INT_MAX))
+    if (indexMax > double(INT_MAX)) {
         LOGLS_WARN(_log, "Cannot hold a 4D histo with more than " << INT_MAX << " values.");
+}
     _n[0] = n1;
     _n[1] = n2;
     _n[2] = n3;
@@ -99,10 +100,11 @@ int SparseHisto4d::maxBin(double x[4]) {
     int oldval = _data[0];
     int currentCount = 1;
     for (int i = 1; i < _ndata; ++i) {
-        if (_data[i] == oldval)
+        if (_data[i] == oldval) {
             currentCount++;
-        else
+        } else {
             currentCount = 1;
+}
         if (currentCount > maxCount) {
             maxCount = currentCount;
             maxval = _data[i];
@@ -137,8 +139,9 @@ void SparseHisto4d::binLimits(const double x[4], const int iDim, double &xMin, d
 }
 
 void SparseHisto4d::dump() const {
-    for (int i = 0; i < _ndata; ++i)  // DEBUG
+    for (int i = 0; i < _ndata; ++i) {  // DEBUG
         std::cout << _data[i] << ' ';
+}
     std::cout << std::endl;
 }
 }  // namespace jointcal

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -1,6 +1,6 @@
 #include <iostream>
-#include <cmath>    /* for floor */
-#include <cstring>  /* for memset*/
+#include <cmath>     /* for floor */
+#include <cstring>   /* for memset*/
 #include <algorithm> /* for sort */
 #include <memory>
 #include <climits>
@@ -22,7 +22,7 @@ SparseHisto4d::SparseHisto4d(const int n1, double min1, double max1, const int n
     _data.reset();
     if (indexMax > double(INT_MAX)) {
         LOGLS_WARN(_log, "Cannot hold a 4D histo with more than " << INT_MAX << " values.");
-}
+    }
     _n[0] = n1;
     _n[1] = n2;
     _n[2] = n3;
@@ -104,7 +104,7 @@ int SparseHisto4d::maxBin(double x[4]) {
             currentCount++;
         } else {
             currentCount = 1;
-}
+        }
         if (currentCount > maxCount) {
             maxCount = currentCount;
             maxval = _data[i];
@@ -141,7 +141,7 @@ void SparseHisto4d::binLimits(const double x[4], const int iDim, double &xMin, d
 void SparseHisto4d::dump() const {
     for (int i = 0; i < _ndata; ++i) {  // DEBUG
         std::cout << _data[i] << ' ';
-}
+    }
     std::cout << std::endl;
 }
 }  // namespace jointcal

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -1,8 +1,9 @@
 #include <iostream>
-#include <math.h>    /* for floor */
-#include <string.h>  /* for memset*/
+#include <cmath>    /* for floor */
+#include <cstring>  /* for memset*/
 #include <algorithm> /* for sort */
-#include <limits.h>
+#include <memory>
+#include <climits>
 
 #include "lsst/log/Log.h"
 #include "lsst/jointcal/Histo4d.h"
@@ -35,7 +36,7 @@ SparseHisto4d::SparseHisto4d(const int n1, double min1, double max1, const int n
     _maxVal[3] = max4;
 
     for (int i = 0; i < 4; ++i) _scale[i] = _n[i] / (_maxVal[i] - _minVal[i]);
-    _data.reset(new int[nEntries]);
+    _data = std::make_unique<int[]>(nEntries);
     _dataSize = nEntries;
     _ndata = 0;
     _sorted = false;
@@ -44,7 +45,7 @@ SparseHisto4d::SparseHisto4d(const int n1, double min1, double max1, const int n
 int SparseHisto4d::code_value(const double x[4]) const {
     int index = 0;
     for (int idim = 0; idim < 4; ++idim) {
-        int i = (int)floor((x[idim] - _minVal[idim]) * _scale[idim]);
+        auto i = static_cast<int>(floor((x[idim] - _minVal[idim]) * _scale[idim]));
         if (i < 0 || i >= _n[idim]) return -1;
         index = index * _n[idim] + i;
     }
@@ -55,7 +56,7 @@ void SparseHisto4d::inverse_code(int code, double x[4]) const {
     for (int i = 3; i >= 0; --i) {
         int bin = code % _n[i];
         code /= _n[i];
-        x[i] = _minVal[i] + ((double)bin + 0.5) / _scale[i];
+        x[i] = _minVal[i] + (static_cast<double>(bin) + 0.5) / _scale[i];
     }
 }
 

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -82,7 +82,7 @@ SegmentList::SegmentList(BaseStarList const &list, const int nStars, Gtransfo co
         for (auto si2 = siStop; si2 != si1; --si2) {
             push_back(Segment(*si1, *si2, rank, gtransfo));
         }
-}
+    }
     sort(DecreasingLength); /* allows a break in loops */
 }
 
@@ -103,7 +103,7 @@ static std::unique_ptr<StarMatchList> MatchListExtract(SegmentPairList const &pa
 
     std::unique_ptr<StarMatchList> matchList(new StarMatchList);
 
-    for (auto const & a_pair : pairList) {
+    for (auto const &a_pair : pairList) {
         if (a_pair.first->s1rank != rank1 || a_pair.second->s1rank != rank2) continue;
         /* now we store as star matches both ends of segment pairs ,
            but only once the beginning of segments because they all have the same,
@@ -111,7 +111,7 @@ static std::unique_ptr<StarMatchList> MatchListExtract(SegmentPairList const &pa
         if (matchList->empty()) {
             matchList->push_back(StarMatch(gtransfo.apply(*(a_pair.first->s1)), *(a_pair.second->s1),
                                            a_pair.first->s1, a_pair.second->s1));
-}
+        }
         /* always store the match at end */
         matchList->push_back(StarMatch(gtransfo.apply(*(a_pair.first->s2)), *(a_pair.second->s2),
                                        a_pair.first->s2, a_pair.second->s2));
@@ -124,9 +124,9 @@ static bool DecreasingQuality(const std::unique_ptr<StarMatchList> &first,
     int idiff = first->size() - second->size();
     if (idiff != 0) {
         return (idiff > 0);
-}
-    
-        return (first->getDist2() < second->getDist2());
+    }
+
+    return (first->getDist2() < second->getDist2());
 }
 
 /* many matching solutions (StarMatchList) will be compared. Store them in a SolList : */
@@ -192,7 +192,7 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list
 
         if (conditions.printLevel >= 1) {
             LOGLS_DEBUG(_log, " valMax " << maxContent << " ratio " << ratioMax << " angle " << angleMax);
-}
+        }
 
         minRatio = ratioMax - binr / 2;
         maxRatio = ratioMax + binr / 2;
@@ -212,7 +212,7 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list
                 if (ratio > maxRatio) continue;
                 if (ratio < minRatio) {
                     break; /* use the fact that segment lists are sorted by decresing length */
-}
+                }
                 angle = seg1->relativeAngle(seg2);
                 if (angle > M_PI - angleOffset) angle -= 2. * M_PI;
                 if (angle < minAngle || angle > maxAngle) continue;
@@ -345,12 +345,12 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_New(BaseStarList &list
                 // push in the list the match corresponding to end number 1 of segments
                 if (a_list->empty()) {
                     a_list->push_back(StarMatch(*(seg1->s1), *(seg2->s1), seg1->s1, seg2->s1));
-}
+                }
                 ratio = seg2->r / seg1->r;
                 if (ratio > maxRatio) continue;
                 if (ratio < minRatio) {
                     break; /* use the fact that segment lists are sorted by decresing length */
-}
+                }
                 angle = seg1->relativeAngle(seg2);
                 if (angle > M_PI - angleOffset) angle -= 2. * M_PI;
                 if (angle < minAngle || angle > maxAngle) continue;
@@ -399,9 +399,9 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift(BaseStarList &list1, B
                                                           MatchConditions const &conditions) {
     if (conditions.algorithm == 1) {
         return ListMatchupRotShift_Old(list1, list2, gtransfo, conditions);
-}
-    
-        return ListMatchupRotShift_New(list1, list2, gtransfo, conditions);
+    }
+
+    return ListMatchupRotShift_New(list1, list2, gtransfo, conditions);
 }
 
 std::unique_ptr<StarMatchList> matchSearchRotShift(BaseStarList &list1, BaseStarList &list2,
@@ -433,10 +433,9 @@ std::unique_ptr<StarMatchList> matchSearchRotShiftFlip(BaseStarList &list1, Base
         // (even the flipped one) contains the actual coordinates of stars.
         // MatchListExtract is always called with GtransfoIdentity() as last parameter
         return flipped;
-    } 
-        if (conditions.printLevel >= 1) LOGL_DEBUG(_log, "Keeping unflipped solution.");
-        return unflipped;
-    
+    }
+    if (conditions.printLevel >= 1) LOGL_DEBUG(_log, "Keeping unflipped solution.");
+    return unflipped;
 }
 
 #ifdef STORAGE
@@ -477,11 +476,11 @@ std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseSta
             nx = 100;
         } else {
             nx = static_cast<int>(sqrt(double(ncomb)));
-}
+        }
         if (!ncomb) return std::unique_ptr<GtransfoLin>(nullptr);
     } else {
         nx = int(2 * maxShift / binSize + 0.5);
-}
+    }
 
     Histo2d histo(nx, -maxShift, maxShift, nx, -maxShift, maxShift);
     double binSizeNew = 2 * maxShift / nx;
@@ -549,7 +548,7 @@ std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseS
     std::unique_ptr<StarMatchList> matches(new StarMatchList);
     /****** Collect ***********/
     FastFinder finder(list2);
-    for (auto const & si : list1) {
+    for (auto const &si : list1) {
         auto p1 = si;
         Point p2 = guess->apply(*p1);
         auto neighbour = finder.findClosest(p2, maxDist);
@@ -594,7 +593,7 @@ std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseS
                                                 const double maxDist) {
     std::unique_ptr<StarMatchList> matches(new StarMatchList);
     FastFinder finder(list2);
-    for (auto const & si : list1) {
+    for (auto const &si : list1) {
         auto p1 = si;
         auto neighbour = finder.findClosest(*p1, maxDist);
         if (!neighbour) continue;
@@ -618,7 +617,7 @@ static bool is_transfo_ok(StarMatchList const *match, double pixSizeRatio2, cons
          0.2) &&
         (match->size() > nmin)) {
         return true;
-}
+    }
     LOGL_ERROR(_log, "transfo is not ok!");
     match->dumpTransfo();
     return false;
@@ -630,7 +629,7 @@ static double transfo_diff(BaseStarList const &List, Gtransfo const *T1, Gtransf
     FatPoint tf1;
     Point tf2;
     int count = 0;
-    for (auto const & it : List) {
+    for (auto const &it : List) {
         BaseStar const &s = *it;
         T1->transformPosAndErrors(s, tf1);
         T2->apply(s, tf2);
@@ -650,7 +649,7 @@ static double median_distance(StarMatchList const *match, Gtransfo const *transf
     auto ir = resid.begin();
     for (auto it = match->begin(); it != match->end(); ++it, ++ir) {
         *ir = sqrt(transfo->apply(it->point1).computeDist2(it->point2));
-}
+    }
     sort(resid.begin(), resid.end());
     return (nstars & 1) ? resid[nstars / 2] : (resid[nstars / 2 - 1] + resid[nstars / 2]) * 0.5;
 }
@@ -691,7 +690,7 @@ std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &List1, Base
         }
     } else {
         LOGL_ERROR(_log, "listMatchCombinatorial: failed to find a transfo");
-}
+    }
     return transfo;
 }
 

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -78,10 +78,11 @@ SegmentList::SegmentList(BaseStarList const &list, const int nStars, Gtransfo co
 
     // iterate on star pairs
     int rank = 0;
-    for (auto si1 = list.begin(); si1 != siStop; ++si1, rank++)
+    for (auto si1 = list.begin(); si1 != siStop; ++si1, rank++) {
         for (auto si2 = siStop; si2 != si1; --si2) {
             push_back(Segment(*si1, *si2, rank, gtransfo));
         }
+}
     sort(DecreasingLength); /* allows a break in loops */
 }
 
@@ -107,9 +108,10 @@ static std::unique_ptr<StarMatchList> MatchListExtract(SegmentPairList const &pa
         /* now we store as star matches both ends of segment pairs ,
            but only once the beginning of segments because they all have the same,
            given the selection 3 lines above  */
-        if (matchList->empty())
+        if (matchList->empty()) {
             matchList->push_back(StarMatch(gtransfo.apply(*(a_pair.first->s1)), *(a_pair.second->s1),
                                            a_pair.first->s1, a_pair.second->s1));
+}
         /* always store the match at end */
         matchList->push_back(StarMatch(gtransfo.apply(*(a_pair.first->s2)), *(a_pair.second->s2),
                                        a_pair.first->s2, a_pair.second->s2));
@@ -120,8 +122,9 @@ static std::unique_ptr<StarMatchList> MatchListExtract(SegmentPairList const &pa
 static bool DecreasingQuality(const std::unique_ptr<StarMatchList> &first,
                               const std::unique_ptr<StarMatchList> &second) {
     int idiff = first->size() - second->size();
-    if (idiff != 0)
+    if (idiff != 0) {
         return (idiff > 0);
+}
     
         return (first->getDist2() < second->getDist2());
 }
@@ -187,8 +190,9 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list
         double maxContent = histo.maxBin(ratioMax, angleMax);
         histo.fill(ratioMax, angleMax, -maxContent);
 
-        if (conditions.printLevel >= 1)
+        if (conditions.printLevel >= 1) {
             LOGLS_DEBUG(_log, " valMax " << maxContent << " ratio " << ratioMax << " angle " << angleMax);
+}
 
         minRatio = ratioMax - binr / 2;
         maxRatio = ratioMax + binr / 2;
@@ -206,8 +210,9 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list
                 seg2 = &(*segi2);
                 ratio = seg2->r / seg1->r;
                 if (ratio > maxRatio) continue;
-                if (ratio < minRatio)
+                if (ratio < minRatio) {
                     break; /* use the fact that segment lists are sorted by decresing length */
+}
                 angle = seg1->relativeAngle(seg2);
                 if (angle > M_PI - angleOffset) angle -= 2. * M_PI;
                 if (angle < minAngle || angle > maxAngle) continue;
@@ -338,12 +343,14 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_New(BaseStarList &list
                 seg2 = &(*segi2);
                 if (seg2->s1rank != rank1L2) continue;
                 // push in the list the match corresponding to end number 1 of segments
-                if (a_list->empty())
+                if (a_list->empty()) {
                     a_list->push_back(StarMatch(*(seg1->s1), *(seg2->s1), seg1->s1, seg2->s1));
+}
                 ratio = seg2->r / seg1->r;
                 if (ratio > maxRatio) continue;
-                if (ratio < minRatio)
+                if (ratio < minRatio) {
                     break; /* use the fact that segment lists are sorted by decresing length */
+}
                 angle = seg1->relativeAngle(seg2);
                 if (angle > M_PI - angleOffset) angle -= 2. * M_PI;
                 if (angle < minAngle || angle > maxAngle) continue;
@@ -390,8 +397,9 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_New(BaseStarList &list
 static std::unique_ptr<StarMatchList> ListMatchupRotShift(BaseStarList &list1, BaseStarList &list2,
                                                           Gtransfo const &gtransfo,
                                                           MatchConditions const &conditions) {
-    if (conditions.algorithm == 1)
+    if (conditions.algorithm == 1) {
         return ListMatchupRotShift_Old(list1, list2, gtransfo, conditions);
+}
     
         return ListMatchupRotShift_New(list1, list2, gtransfo, conditions);
 }
@@ -465,13 +473,15 @@ std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseSta
     int nx;
     if (binSize == 0) {
         int ncomb = list1.size() * list2.size();
-        if (ncomb > 10000)
+        if (ncomb > 10000) {
             nx = 100;
-        else
+        } else {
             nx = static_cast<int>(sqrt(double(ncomb)));
+}
         if (!ncomb) return std::unique_ptr<GtransfoLin>(nullptr);
-    } else
+    } else {
         nx = int(2 * maxShift / binSize + 0.5);
+}
 
     Histo2d histo(nx, -maxShift, maxShift, nx, -maxShift, maxShift);
     double binSizeNew = 2 * maxShift / nx;
@@ -606,8 +616,9 @@ static bool is_transfo_ok(StarMatchList const *match, double pixSizeRatio2, cons
               pixSizeRatio2) /
                  pixSizeRatio2 <
          0.2) &&
-        (match->size() > nmin))
+        (match->size() > nmin)) {
         return true;
+}
     LOGL_ERROR(_log, "transfo is not ok!");
     match->dumpTransfo();
     return false;
@@ -637,8 +648,9 @@ static double median_distance(StarMatchList const *match, Gtransfo const *transf
     size_t nstars = match->size();
     std::vector<double> resid(nstars);
     auto ir = resid.begin();
-    for (auto it = match->begin(); it != match->end(); ++it, ++ir)
+    for (auto it = match->begin(); it != match->end(); ++it, ++ir) {
         *ir = sqrt(transfo->apply(it->point1).computeDist2(it->point2));
+}
     sort(resid.begin(), resid.end());
     return (nstars & 1) ? resid[nstars / 2] : (resid[nstars / 2 - 1] + resid[nstars / 2]) * 0.5;
 }
@@ -659,14 +671,14 @@ std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &List1, Base
             std::min(size_t(10), size_t(std::min(List1.size(), List2.size()) * conditions.minMatchRatio));
 
     std::unique_ptr<Gtransfo> transfo;
-    if (is_transfo_ok(match.get(), pixSizeRatio2, nmin))
+    if (is_transfo_ok(match.get(), pixSizeRatio2, nmin)) {
         transfo = match->getTransfo()->clone();
-    else {
+    } else {
         LOGL_ERROR(_log, "listMatchCombinatorial: direct transfo failed, trying reverse");
         match = matchSearchRotShiftFlip(list2, list1, conditions);
-        if (is_transfo_ok(match.get(), pixSizeRatio2, nmin))
+        if (is_transfo_ok(match.get(), pixSizeRatio2, nmin)) {
             transfo = match->inverseTransfo();
-        else {
+        } else {
             LOGL_FATAL(_log, "FAILED");
         }
     }
@@ -677,8 +689,9 @@ std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &List1, Base
             LOGL_DEBUG(_log, " listMatchCombinatorial: found the following transfo.");
             LOGLS_DEBUG(_log, *transfo);
         }
-    } else
+    } else {
         LOGL_ERROR(_log, "listMatchCombinatorial: failed to find a transfo");
+}
     return transfo;
 }
 

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -35,7 +35,7 @@ struct Segment {
 
     /* constructor (could set last argument to identity by default)  */
     Segment(std::shared_ptr<const BaseStar> star1, std::shared_ptr<const BaseStar> star2, const int star1Rank,
-            const Gtransfo &gtransfo) {
+            Gtransfo const &gtransfo) {
         s1rank = star1Rank;
         s1 = std::move(star1);
         s2 = std::move(star2);
@@ -51,7 +51,7 @@ struct Segment {
         return atan2(other->dx * dy - dx * other->dy, dx * other->dx + dy * other->dy);
     }
 
-    friend std::ostream &operator<<(std::ostream &stream, const Segment &segment) {
+    friend std::ostream &operator<<(std::ostream &stream, Segment const &segment) {
         stream << " dx " << segment.dx << " dy " << segment.dy << " r " << segment.r << std::endl;
         return stream;
     }
@@ -59,16 +59,16 @@ struct Segment {
 
 class SegmentList : public std::list<Segment> {
 public:
-    //  SegmentList(const BaseStarList &list, const int nStar);
-    SegmentList(const BaseStarList &list, int nStar, const Gtransfo &gtransfo = GtransfoIdentity());
+    //  SegmentList(BaseStarList const &list, const int nStar);
+    SegmentList(BaseStarList const &list, int nStar, Gtransfo const &gtransfo = GtransfoIdentity());
 };
 
 using SegmentIterator = std::list<Segment>::iterator;
 using SegmentCIterator = std::list<Segment>::const_iterator;
 
-static bool DecreasingLength(const Segment &first, const Segment &second) { return (first.r > second.r); }
+static bool DecreasingLength(Segment const &first, Segment const &second) { return (first.r > second.r); }
 
-SegmentList::SegmentList(const BaseStarList &list, const int nStars, const Gtransfo &gtransfo) {
+SegmentList::SegmentList(BaseStarList const &list, const int nStars, Gtransfo const &gtransfo) {
     BaseStarCIterator siStop;
 
     /* find the fence */
@@ -95,14 +95,14 @@ using SegmentPairList = std::list<SegmentPair>;
 using SegmentPairListIterator = SegmentPairList::iterator;
 using SegmentPairListCIterator = SegmentPairList::const_iterator;
 
-static std::unique_ptr<StarMatchList> MatchListExtract(const SegmentPairList &pairList, int rank1, int rank2,
-                                                       const Gtransfo &gtransfo) {
+static std::unique_ptr<StarMatchList> MatchListExtract(SegmentPairList const &pairList, int rank1, int rank2,
+                                                       Gtransfo const &gtransfo) {
     /* first Select in the segment pairs list the ones which make use of star rank1 in segment1
   and star s2 in segment2 */
 
     std::unique_ptr<StarMatchList> matchList(new StarMatchList);
 
-    for (const auto & a_pair : pairList) {
+    for (auto const & a_pair : pairList) {
         if (a_pair.first->s1rank != rank1 || a_pair.second->s1rank != rank2) continue;
         /* now we store as star matches both ends of segment pairs ,
            but only once the beginning of segments because they all have the same,
@@ -134,8 +134,8 @@ using SolList = std::list<std::unique_ptr<StarMatchList>>;
 of star pairs ( Segment's) built from the 2 lists */
 
 static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list1, BaseStarList &list2,
-                                                              const Gtransfo &gtransfo,
-                                                              const MatchConditions &conditions) {
+                                                              Gtransfo const &gtransfo,
+                                                              MatchConditions const &conditions) {
     SegmentList sList1(list1, conditions.nStarsList1, gtransfo);
     SegmentList sList2(list2, conditions.nStarsList2, GtransfoIdentity());
 
@@ -248,8 +248,8 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_Old(BaseStarList &list
 */
 
 static std::unique_ptr<StarMatchList> ListMatchupRotShift_New(BaseStarList &list1, BaseStarList &list2,
-                                                              const Gtransfo &gtransfo,
-                                                              const MatchConditions &conditions) {
+                                                              Gtransfo const &gtransfo,
+                                                              MatchConditions const &conditions) {
     if (list1.size() <= 4 || list2.size() <= 4) {
         LOGL_FATAL(_log, "ListMatchupRotShift_New : (at least) one of the lists is too short.");
         return nullptr;
@@ -388,8 +388,8 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift_New(BaseStarList &list
 }
 
 static std::unique_ptr<StarMatchList> ListMatchupRotShift(BaseStarList &list1, BaseStarList &list2,
-                                                          const Gtransfo &gtransfo,
-                                                          const MatchConditions &conditions) {
+                                                          Gtransfo const &gtransfo,
+                                                          MatchConditions const &conditions) {
     if (conditions.algorithm == 1)
         return ListMatchupRotShift_Old(list1, list2, gtransfo, conditions);
     
@@ -397,7 +397,7 @@ static std::unique_ptr<StarMatchList> ListMatchupRotShift(BaseStarList &list1, B
 }
 
 std::unique_ptr<StarMatchList> matchSearchRotShift(BaseStarList &list1, BaseStarList &list2,
-                                                   const MatchConditions &conditions) {
+                                                   MatchConditions const &conditions) {
     list1.fluxSort();
     list2.fluxSort();
 
@@ -405,7 +405,7 @@ std::unique_ptr<StarMatchList> matchSearchRotShift(BaseStarList &list1, BaseStar
 }
 
 std::unique_ptr<StarMatchList> matchSearchRotShiftFlip(BaseStarList &list1, BaseStarList &list2,
-                                                       const MatchConditions &conditions) {
+                                                       MatchConditions const &conditions) {
     list1.fluxSort();
     list2.fluxSort();
 
@@ -433,8 +433,8 @@ std::unique_ptr<StarMatchList> matchSearchRotShiftFlip(BaseStarList &list1, Base
 
 #ifdef STORAGE
 // timing : 2.5 s for l1 of 1862 objects  and l2 of 2617 objects
-std::unique_ptr<GtransfoLin> listMatchupShift(const BaseStarList &list1, const BaseStarList &list2,
-                                              const Gtransfo &gtransfo, double maxShift) {
+std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseStarList const &list2,
+                                              Gtransfo const &gtransfo, double maxShift) {
     int ncomb = list1.size() * list2.size();
     if (!ncomb) return nullptr;
     int nx;
@@ -460,8 +460,8 @@ std::unique_ptr<GtransfoLin> listMatchupShift(const BaseStarList &list1, const B
 #endif /*STORAGE*/
 
 // timing : 140 ms for l1 of 1862 objects  and l2 of 2617 objects (450 MHz, "-O4") maxShift = 200.
-std::unique_ptr<GtransfoLin> listMatchupShift(const BaseStarList &list1, const BaseStarList &list2,
-                                              const Gtransfo &gtransfo, double maxShift, double binSize) {
+std::unique_ptr<GtransfoLin> listMatchupShift(BaseStarList const &list1, BaseStarList const &list2,
+                                              Gtransfo const &gtransfo, double maxShift, double binSize) {
     int nx;
     if (binSize == 0) {
         int ncomb = list1.size() * list2.size();
@@ -512,14 +512,14 @@ std::unique_ptr<GtransfoLin> listMatchupShift(const BaseStarList &list1, const B
 
 // this is the old fashioned way...
 
-std::unique_ptr<StarMatchList> listMatchCollect_Slow(const BaseStarList &list1, const BaseStarList &list2,
-                                                     const Gtransfo *guess, const double maxDist) {
+std::unique_ptr<StarMatchList> listMatchCollect_Slow(BaseStarList const &list1, BaseStarList const &list2,
+                                                     Gtransfo const *guess, const double maxDist) {
     std::unique_ptr<StarMatchList> matches(new StarMatchList);
     /****** Collect ***********/
     for (BaseStarCIterator si = list1.begin(); si != list1.end(); ++si) {
-        const Point *p1 = (*si);
+        Point const *p1 = (*si);
         const Point p2 = guess->apply(*p1);
-        const BaseStar *neighbour = list2.findClosest(p2);
+        BaseStar const *neighbour = list2.findClosest(p2);
         if (!neighbour) continue;
         double distance = p2.Distance(*neighbour);
         if (distance < maxDist) {
@@ -534,12 +534,12 @@ std::unique_ptr<StarMatchList> listMatchCollect_Slow(const BaseStarList &list1, 
 
 // here is the real active routine:
 
-std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const BaseStarList &list2,
-                                                const Gtransfo *guess, const double maxDist) {
+std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseStarList const &list2,
+                                                Gtransfo const *guess, const double maxDist) {
     std::unique_ptr<StarMatchList> matches(new StarMatchList);
     /****** Collect ***********/
     FastFinder finder(list2);
-    for (const auto & si : list1) {
+    for (auto const & si : list1) {
         auto p1 = si;
         Point p2 = guess->apply(*p1);
         auto neighbour = finder.findClosest(p2, maxDist);
@@ -559,9 +559,9 @@ std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const
 #ifdef STORAGE
 // unused
 //! iteratively collect and fits, with the same transfo kind, until the residual increases
-std::unique_ptr<StarMatchList> CollectAndFit(const BaseStarList &list1, const BaseStarList &list2,
-                                             const Gtransfo *guess, const double maxDist) {
-    const Gtransfo *bestTransfo = guess;
+std::unique_ptr<StarMatchList> CollectAndFit(BaseStarList const &list1, BaseStarList const &list2,
+                                             Gtransfo const *guess, const double maxDist) {
+    Gtransfo const *bestTransfo = guess;
     std::unique_ptr<StarMatchList> prevMatch;
     while (true) {
         auto m = listMatchCollect(list1, list2, bestTransfo, maxDist);
@@ -580,11 +580,11 @@ std::unique_ptr<StarMatchList> CollectAndFit(const BaseStarList &list1, const Ba
 }
 #endif
 
-std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const BaseStarList &list2,
+std::unique_ptr<StarMatchList> listMatchCollect(BaseStarList const &list1, BaseStarList const &list2,
                                                 const double maxDist) {
     std::unique_ptr<StarMatchList> matches(new StarMatchList);
     FastFinder finder(list2);
-    for (const auto & si : list1) {
+    for (auto const & si : list1) {
         auto p1 = si;
         auto neighbour = finder.findClosest(*p1, maxDist);
         if (!neighbour) continue;
@@ -601,7 +601,7 @@ std::unique_ptr<StarMatchList> listMatchCollect(const BaseStarList &list1, const
     return matches;
 }
 
-static bool is_transfo_ok(const StarMatchList *match, double pixSizeRatio2, const size_t nmin) {
+static bool is_transfo_ok(StarMatchList const *match, double pixSizeRatio2, const size_t nmin) {
     if ((fabs(fabs(std::dynamic_pointer_cast<const GtransfoLin>(match->getTransfo())->determinant()) -
               pixSizeRatio2) /
                  pixSizeRatio2 <
@@ -614,13 +614,13 @@ static bool is_transfo_ok(const StarMatchList *match, double pixSizeRatio2, cons
 }
 
 // utility to check current transfo difference
-static double transfo_diff(const BaseStarList &List, const Gtransfo *T1, const Gtransfo *T2) {
+static double transfo_diff(BaseStarList const &List, Gtransfo const *T1, Gtransfo const *T2) {
     double diff2 = 0;
     FatPoint tf1;
     Point tf2;
     int count = 0;
-    for (const auto & it : List) {
-        const BaseStar &s = *it;
+    for (auto const & it : List) {
+        BaseStar const &s = *it;
         T1->transformPosAndErrors(s, tf1);
         T2->apply(s, tf2);
         double dx = tf1.x - tf2.x;
@@ -633,7 +633,7 @@ static double transfo_diff(const BaseStarList &List, const Gtransfo *T1, const G
     return 0;
 }
 
-static double median_distance(const StarMatchList *match, const Gtransfo *transfo) {
+static double median_distance(StarMatchList const *match, Gtransfo const *transfo) {
     size_t nstars = match->size();
     std::vector<double> resid(nstars);
     auto ir = resid.begin();
@@ -643,8 +643,8 @@ static double median_distance(const StarMatchList *match, const Gtransfo *transf
     return (nstars & 1) ? resid[nstars / 2] : (resid[nstars / 2 - 1] + resid[nstars / 2]) * 0.5;
 }
 
-std::unique_ptr<Gtransfo> listMatchCombinatorial(const BaseStarList &List1, const BaseStarList &List2,
-                                                 const MatchConditions &conditions) {
+std::unique_ptr<Gtransfo> listMatchCombinatorial(BaseStarList const &List1, BaseStarList const &List2,
+                                                 MatchConditions const &conditions) {
     BaseStarList list1, list2;
     List1.copyTo(list1);
     list1.fluxSort();
@@ -682,7 +682,7 @@ std::unique_ptr<Gtransfo> listMatchCombinatorial(const BaseStarList &List1, cons
     return transfo;
 }
 
-std::unique_ptr<Gtransfo> listMatchRefine(const BaseStarList &List1, const BaseStarList &List2,
+std::unique_ptr<Gtransfo> listMatchRefine(BaseStarList const &List1, BaseStarList const &List2,
                                           std::unique_ptr<Gtransfo> transfo, const int maxOrder) {
     if (!transfo) {
         return std::unique_ptr<Gtransfo>(nullptr);

--- a/src/ListMatch.cc
+++ b/src/ListMatch.cc
@@ -60,7 +60,7 @@ struct Segment {
 class SegmentList : public std::list<Segment> {
 public:
     //  SegmentList(BaseStarList const &list, const int nStar);
-    SegmentList(BaseStarList const &list, int nStar, Gtransfo const &gtransfo = GtransfoIdentity());
+    SegmentList(BaseStarList const &list, int nStars, Gtransfo const &gtransfo = GtransfoIdentity());
 };
 
 using SegmentIterator = std::list<Segment>::iterator;

--- a/src/MeasuredStar.cc
+++ b/src/MeasuredStar.cc
@@ -36,13 +36,13 @@ BaseStarList &Measured2Base(MeasuredStarList &This) { return (BaseStarList &)Thi
 
 BaseStarList *Measured2Base(MeasuredStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
-const BaseStarList &Measured2Base(const MeasuredStarList &This) { return (const BaseStarList &)This; }
+BaseStarList const &Measured2Base(MeasuredStarList const &This) { return (BaseStarList const &)This; }
 
-const BaseStarList *Measured2Base(const MeasuredStarList *This) { return (BaseStarList *)This; }
+BaseStarList const *Measured2Base(MeasuredStarList const *This) { return (BaseStarList *)This; }
 
 /******* MeasuredStarList *********/
 
-void MeasuredStarList::setCcdImage(const CcdImage *ccdImage) {
+void MeasuredStarList::setCcdImage(CcdImage const *ccdImage) {
     for (auto &i : *this) i->setCcdImage(ccdImage);
 }
 }  // namespace jointcal

--- a/src/MeasuredStar.cc
+++ b/src/MeasuredStar.cc
@@ -8,7 +8,7 @@
 
 //#include "preferences.h"
 //#include "ccdimage.h"
-#include "assert.h"  // for assert
+#include <cassert>  // for assert
 
 namespace lsst {
 namespace jointcal {
@@ -34,7 +34,7 @@ for fluxes, we might use :
 
 BaseStarList &Measured2Base(MeasuredStarList &This) { return (BaseStarList &)This; }
 
-BaseStarList *Measured2Base(MeasuredStarList *This) { return (BaseStarList *)This; }
+BaseStarList *Measured2Base(MeasuredStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
 const BaseStarList &Measured2Base(const MeasuredStarList &This) { return (const BaseStarList &)This; }
 

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -86,7 +86,7 @@ void PhotometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
     // Derivatives of terms involving fitted and refstars only contribute if we are fitting fluxes.
     if (!_fittingFluxes) return;
     // Can't compute anything if there are no refStars.
-    if (_associations->refStarList.size() == 0) return;
+    if (_associations->refStarList.empty()) return;
 
     unsigned kTriplets = tripletList.getNextFreeIndex();
 

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -39,7 +39,7 @@ void PhotometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
     Eigen::VectorXd H(nparTotal);  // derivative matrix
     // current position in the Jacobian
     unsigned kTriplets = tripletList.getNextFreeIndex();
-    const MeasuredStarList &catalog = (measuredStarList) ? *measuredStarList : ccdImage.getCatalogForFit();
+    MeasuredStarList const &catalog = (measuredStarList) ? *measuredStarList : ccdImage.getCatalogForFit();
 
     for (auto const &measuredStar : catalog) {
         if (!measuredStar->isValid()) continue;
@@ -241,9 +241,9 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &baseName) const
           << separator;
     ofile << "chip id" << separator << "visit id" << std::endl;
 
-    const CcdImageList &ccdImageList = _associations->getCcdImageList();
+    CcdImageList const &ccdImageList = _associations->getCcdImageList();
     for (auto const &ccdImage : ccdImageList) {
-        const MeasuredStarList &cat = ccdImage->getCatalogForFit();
+        MeasuredStarList const &cat = ccdImage->getCatalogForFit();
         for (auto const &measuredStar : cat) {
             if (!measuredStar->isValid()) continue;
             double sigma = _photometryModel->transformError(*ccdImage, *measuredStar,
@@ -293,9 +293,9 @@ void PhotometryFit::saveChi2RefContributions(std::string const &baseName) const 
           << separator << "number of measurements of this FittedStar" << std::endl;
 
     // The following loop is heavily inspired from PhotometryFit::computeChi2()
-    const FittedStarList &fittedStarList = _associations->fittedStarList;
+    FittedStarList const &fittedStarList = _associations->fittedStarList;
     for (auto const &fittedStar : fittedStarList) {
-        const RefStar *refStar = fittedStar->getRefStar();
+        RefStar const *refStar = fittedStar->getRefStar();
         if (refStar == nullptr) continue;
 
         double chi2 = std::pow(((fittedStar->getFlux() - refStar->getFlux()) / refStar->getFluxErr()), 2);

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -195,10 +195,11 @@ void PhotometryFit::assignIndices(std::string const &whatToFit) {
 }
 
 void PhotometryFit::offsetParams(Eigen::VectorXd const &delta) {
-    if (delta.size() != _nParTot)
+    if (delta.size() != _nParTot) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "PhotometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");
+}
     if (_fittingModel) _photometryModel->offsetParams(delta);
 
     if (_fittingFluxes) {

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -199,7 +199,7 @@ void PhotometryFit::offsetParams(Eigen::VectorXd const &delta) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "PhotometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");
-}
+    }
     if (_fittingModel) _photometryModel->offsetParams(delta);
 
     if (_fittingFluxes) {

--- a/src/PhotometryTransfo.cc
+++ b/src/PhotometryTransfo.cc
@@ -100,7 +100,7 @@ namespace {
 double integrateTn(int n) {
     if (n % 2 == 1)
         return 0;
-    else
+    
         return 2.0 / (1.0 - static_cast<double>(n * n));
 }
 }  // namespace

--- a/src/PhotometryTransfo.cc
+++ b/src/PhotometryTransfo.cc
@@ -98,8 +98,9 @@ namespace {
 // The integral of T_n(x) over [-1,1]:
 // https://en.wikipedia.org/wiki/Chebyshev_polynomials#Differentiation_and_integration
 double integrateTn(int n) {
-    if (n % 2 == 1)
+    if (n % 2 == 1) {
         return 0;
+}
     
         return 2.0 / (1.0 - static_cast<double>(n * n));
 }

--- a/src/PhotometryTransfo.cc
+++ b/src/PhotometryTransfo.cc
@@ -100,9 +100,9 @@ namespace {
 double integrateTn(int n) {
     if (n % 2 == 1) {
         return 0;
-}
-    
-        return 2.0 / (1.0 - static_cast<double>(n * n));
+    }
+
+    return 2.0 / (1.0 - static_cast<double>(n * n));
 }
 }  // namespace
 

--- a/src/Projectionhandler.cc
+++ b/src/Projectionhandler.cc
@@ -9,14 +9,14 @@ class Mapping;
 
 /**********   Stuff for providing Sk22TP gtransfos to a AstrometryModel ***/
 
-OneTPPerVisitHandler::OneTPPerVisitHandler(const CcdImageList &ccdImageList) {
+OneTPPerVisitHandler::OneTPPerVisitHandler(CcdImageList const &ccdImageList) {
     for (auto const &i : ccdImageList) {
-        const CcdImage &im = *i;
+        CcdImage const &im = *i;
         if (tMap.find(im.getVisit()) == tMap.end()) tMap[im.getVisit()] = im.getSky2TP()->clone();
     }
 }
 
-const Gtransfo *OneTPPerVisitHandler::getSky2TP(const CcdImage &ccdImage) const {
+Gtransfo const *OneTPPerVisitHandler::getSky2TP(CcdImage const &ccdImage) const {
     auto it = tMap.find(ccdImage.getVisit());
     if (it == tMap.end()) return nullptr;
     return &*(it->second);

--- a/src/RefStar.cc
+++ b/src/RefStar.cc
@@ -12,8 +12,8 @@ BaseStarList &Ref2Base(RefStarList &This) { return (BaseStarList &)This; }
 
 BaseStarList *Ref2Base(RefStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
-const BaseStarList &Ref2Base(const RefStarList &This) { return (const BaseStarList &)This; }
+BaseStarList const &Ref2Base(RefStarList const &This) { return (BaseStarList const &)This; }
 
-const BaseStarList *Ref2Base(const RefStarList *This) { return (BaseStarList *)This; }
+BaseStarList const *Ref2Base(RefStarList const *This) { return (BaseStarList *)This; }
 }  // namespace jointcal
 }  // namespace lsst

--- a/src/RefStar.cc
+++ b/src/RefStar.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <iomanip>
 
 #include "lsst/jointcal/RefStar.h"
@@ -10,7 +10,7 @@ namespace jointcal {
 
 BaseStarList &Ref2Base(RefStarList &This) { return (BaseStarList &)This; }
 
-BaseStarList *Ref2Base(RefStarList *This) { return (BaseStarList *)This; }
+BaseStarList *Ref2Base(RefStarList *This) { return reinterpret_cast<BaseStarList *>(This); }
 
 const BaseStarList &Ref2Base(const RefStarList &This) { return (const BaseStarList &)This; }
 

--- a/src/SimplePhotometryModel.cc
+++ b/src/SimplePhotometryModel.cc
@@ -94,9 +94,10 @@ void SimplePhotometryModel::dump(std::ostream &stream) const {
 
 PhotometryMappingBase *SimplePhotometryModel::findMapping(CcdImage const &ccdImage) const {
     auto i = _myMap.find(ccdImage.getHashKey());
-    if (i == _myMap.end())
+    if (i == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePhotometryModel cannot find CcdImage " + ccdImage.getName());
+}
     return i->second.get();
 }
 

--- a/src/SimplePhotometryModel.cc
+++ b/src/SimplePhotometryModel.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <memory>
 
 #include "lsst/log/Log.h"
 #include "lsst/jointcal/PhotometryMapping.h"
@@ -22,7 +23,7 @@ SimplePhotometryModel::SimplePhotometryModel(CcdImageList const &ccdImageList) {
         auto transfo =
                 std::make_shared<PhotometryTransfoSpatiallyInvariant>(photoCalib->getCalibrationMean());
         _myMap.emplace(ccdImage->getHashKey(),
-                       std::unique_ptr<PhotometryMapping>(new PhotometryMapping(transfo)));
+                       std::make_unique<PhotometryMapping>(transfo));
     }
     LOGLS_INFO(_log, "SimplePhotometryModel got " << _myMap.size() << " ccdImage mappings.");
 }
@@ -79,8 +80,8 @@ void SimplePhotometryModel::computeParameterDerivatives(MeasuredStar const &meas
 std::shared_ptr<afw::image::PhotoCalib> SimplePhotometryModel::toPhotoCalib(CcdImage const &ccdImage) const {
     double calibration = (findMapping(ccdImage)->getParameters()[0]);
     auto oldPhotoCalib = ccdImage.getPhotoCalib();
-    return std::unique_ptr<afw::image::PhotoCalib>(
-            new afw::image::PhotoCalib(calibration, oldPhotoCalib->getCalibrationErr()));
+    return std::make_unique<afw::image::PhotoCalib>(
+            calibration, oldPhotoCalib->getCalibrationErr());
 }
 
 void SimplePhotometryModel::dump(std::ostream &stream) const {

--- a/src/SimplePhotometryModel.cc
+++ b/src/SimplePhotometryModel.cc
@@ -22,8 +22,7 @@ SimplePhotometryModel::SimplePhotometryModel(CcdImageList const &ccdImageList) {
         // Use the single-frame processing calibration from the PhotoCalib as the default.
         auto transfo =
                 std::make_shared<PhotometryTransfoSpatiallyInvariant>(photoCalib->getCalibrationMean());
-        _myMap.emplace(ccdImage->getHashKey(),
-                       std::make_unique<PhotometryMapping>(transfo));
+        _myMap.emplace(ccdImage->getHashKey(), std::make_unique<PhotometryMapping>(transfo));
     }
     LOGLS_INFO(_log, "SimplePhotometryModel got " << _myMap.size() << " ccdImage mappings.");
 }
@@ -80,8 +79,7 @@ void SimplePhotometryModel::computeParameterDerivatives(MeasuredStar const &meas
 std::shared_ptr<afw::image::PhotoCalib> SimplePhotometryModel::toPhotoCalib(CcdImage const &ccdImage) const {
     double calibration = (findMapping(ccdImage)->getParameters()[0]);
     auto oldPhotoCalib = ccdImage.getPhotoCalib();
-    return std::make_unique<afw::image::PhotoCalib>(
-            calibration, oldPhotoCalib->getCalibrationErr());
+    return std::make_unique<afw::image::PhotoCalib>(calibration, oldPhotoCalib->getCalibrationErr());
 }
 
 void SimplePhotometryModel::dump(std::ostream &stream) const {
@@ -97,7 +95,7 @@ PhotometryMappingBase *SimplePhotometryModel::findMapping(CcdImage const &ccdIma
     if (i == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePhotometryModel cannot find CcdImage " + ccdImage.getName());
-}
+    }
     return i->second.get();
 }
 

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -29,7 +29,7 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
     unsigned count = 0;
 
     for (auto i = ccdImageList.cbegin(); i != ccdImageList.cend(); ++i, ++count) {
-        const CcdImage &im = **i;
+        CcdImage const &im = **i;
         if (count < nNotFit) {
             std::unique_ptr<SimpleGtransfoMapping> id(new SimpleGtransfoMapping(GtransfoIdentity()));
             id->setIndex(-1);  // non sense, because it has no parameters
@@ -56,7 +56,7 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
                fitted transformation is returned, so that the trick
                remains hidden
              */
-            const Frame &frame = im.getImageFrame();
+            Frame const &frame = im.getImageFrame();
             GtransfoLin shiftAndNormalize = normalizeCoordinatesTransfo(frame);
             if (initFromWcs) {
                 pol = GtransfoPoly(im.getPix2TangentPlane(), frame, degree);
@@ -68,7 +68,7 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
     }
 }
 
-const Mapping *SimplePolyModel::getMapping(CcdImage const &ccdImage) const {
+Mapping const *SimplePolyModel::getMapping(CcdImage const &ccdImage) const {
     auto i = _myMap.find(&ccdImage);
     if (i == _myMap.cend())
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
@@ -102,7 +102,7 @@ void SimplePolyModel::freezeErrorTransform() {
     for (auto & i : _myMap) i.second->freezeErrorTransform();
 }
 
-const Gtransfo &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
+Gtransfo const &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
     // return GetMapping(ccdImage)->Transfo(); // cannot do that
     auto p = _myMap.find(&ccdImage);
     if (p == _myMap.end())
@@ -112,11 +112,11 @@ const Gtransfo &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
 }
 
 std::shared_ptr<TanSipPix2RaDec> SimplePolyModel::produceSipWcs(CcdImage const &ccdImage) const {
-    const auto &pix2Tp = dynamic_cast<const GtransfoPoly &>(getTransfo(ccdImage));
-    const auto *proj = dynamic_cast<const TanRaDec2Pix *>(getSky2TP(ccdImage));
+    auto const &pix2Tp = dynamic_cast<GtransfoPoly const &>(getTransfo(ccdImage));
+    auto const *proj = dynamic_cast<TanRaDec2Pix const *>(getSky2TP(ccdImage));
     if (!proj) return nullptr;
 
-    const GtransfoLin &projLinPart = proj->getLinPart();  // should be the identity, but who knows? So, let us
+    GtransfoLin const &projLinPart = proj->getLinPart();  // should be the identity, but who knows? So, let us
                                                           // incorporate it into the pix2TP part.
     GtransfoPoly wcsPix2Tp = GtransfoPoly(projLinPart.invert()) * pix2Tp;
 

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -69,7 +69,7 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
 }
 
 const Mapping *SimplePolyModel::getMapping(CcdImage const &ccdImage) const {
-    mapType::const_iterator i = _myMap.find(&ccdImage);
+    auto i = _myMap.find(&ccdImage);
     if (i == _myMap.cend())
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePolyModel::GetMapping, never heard of CcdImage " + ccdImage.getName());
@@ -82,8 +82,8 @@ unsigned SimplePolyModel::assignIndices(unsigned firstIndex, std::string const &
         return 0;
     }
     unsigned index = firstIndex;
-    for (auto i = _myMap.begin(); i != _myMap.end(); ++i) {
-        SimplePolyMapping *p = dynamic_cast<SimplePolyMapping *>(&*(i->second));
+    for (auto & i : _myMap) {
+        auto *p = dynamic_cast<SimplePolyMapping *>(&*(i.second));
         if (!p) continue;  // it should be GtransfoIdentity
         p->setIndex(index);
         index += p->getNpar();
@@ -99,7 +99,7 @@ void SimplePolyModel::offsetParams(Eigen::VectorXd const &delta) {
 }
 
 void SimplePolyModel::freezeErrorTransform() {
-    for (auto i = _myMap.begin(); i != _myMap.end(); ++i) i->second->freezeErrorTransform();
+    for (auto & i : _myMap) i.second->freezeErrorTransform();
 }
 
 const Gtransfo &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
@@ -112,8 +112,8 @@ const Gtransfo &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
 }
 
 std::shared_ptr<TanSipPix2RaDec> SimplePolyModel::produceSipWcs(CcdImage const &ccdImage) const {
-    const GtransfoPoly &pix2Tp = dynamic_cast<const GtransfoPoly &>(getTransfo(ccdImage));
-    const TanRaDec2Pix *proj = dynamic_cast<const TanRaDec2Pix *>(getSky2TP(ccdImage));
+    const auto &pix2Tp = dynamic_cast<const GtransfoPoly &>(getTransfo(ccdImage));
+    const auto *proj = dynamic_cast<const TanRaDec2Pix *>(getSky2TP(ccdImage));
     if (!proj) return nullptr;
 
     const GtransfoLin &projLinPart = proj->getLinPart();  // should be the identity, but who knows? So, let us

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -48,7 +48,7 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
             GtransfoPoly pol(degree);
             if (pol.getDegree() > 0) {  // if not, it cannot be decreased
                 while (unsigned(pol.getNpar()) > 2 * nObj) pol.setDegree(pol.getDegree() - 1);
-}
+            }
             /* We have to center and normalize the coordinates so that
                the fit matrix is not too ill-conditionned. Basically, x
                and y in pixels are mapped to [-1,1]. When the
@@ -74,7 +74,7 @@ Mapping const *SimplePolyModel::getMapping(CcdImage const &ccdImage) const {
     if (i == _myMap.cend()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePolyModel::GetMapping, never heard of CcdImage " + ccdImage.getName());
-}
+    }
     return (i->second.get());
 }
 
@@ -84,7 +84,7 @@ unsigned SimplePolyModel::assignIndices(unsigned firstIndex, std::string const &
         return 0;
     }
     unsigned index = firstIndex;
-    for (auto & i : _myMap) {
+    for (auto &i : _myMap) {
         auto *p = dynamic_cast<SimplePolyMapping *>(&*(i.second));
         if (!p) continue;  // it should be GtransfoIdentity
         p->setIndex(index);
@@ -101,7 +101,7 @@ void SimplePolyModel::offsetParams(Eigen::VectorXd const &delta) {
 }
 
 void SimplePolyModel::freezeErrorTransform() {
-    for (auto & i : _myMap) i.second->freezeErrorTransform();
+    for (auto &i : _myMap) i.second->freezeErrorTransform();
 }
 
 Gtransfo const &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
@@ -110,7 +110,7 @@ Gtransfo const &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
     if (p == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePolyModel::getTransfo, never heard of CcdImage " + ccdImage.getName());
-}
+    }
     return p->second->getTransfo();
 }
 

--- a/src/SimplePolyModel.cc
+++ b/src/SimplePolyModel.cc
@@ -46,8 +46,9 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
                 continue;
             }
             GtransfoPoly pol(degree);
-            if (pol.getDegree() > 0)  // if not, it cannot be decreased
+            if (pol.getDegree() > 0) {  // if not, it cannot be decreased
                 while (unsigned(pol.getNpar()) > 2 * nObj) pol.setDegree(pol.getDegree() - 1);
+}
             /* We have to center and normalize the coordinates so that
                the fit matrix is not too ill-conditionned. Basically, x
                and y in pixels are mapped to [-1,1]. When the
@@ -70,9 +71,10 @@ SimplePolyModel::SimplePolyModel(CcdImageList const &ccdImageList, ProjectionHan
 
 Mapping const *SimplePolyModel::getMapping(CcdImage const &ccdImage) const {
     auto i = _myMap.find(&ccdImage);
-    if (i == _myMap.cend())
+    if (i == _myMap.cend()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePolyModel::GetMapping, never heard of CcdImage " + ccdImage.getName());
+}
     return (i->second.get());
 }
 
@@ -105,9 +107,10 @@ void SimplePolyModel::freezeErrorTransform() {
 Gtransfo const &SimplePolyModel::getTransfo(CcdImage const &ccdImage) const {
     // return GetMapping(ccdImage)->Transfo(); // cannot do that
     auto p = _myMap.find(&ccdImage);
-    if (p == _myMap.end())
+    if (p == _myMap.end()) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "SimplePolyModel::getTransfo, never heard of CcdImage " + ccdImage.getName());
+}
     return p->second->getTransfo();
 }
 

--- a/src/SipToGtransfo.cc
+++ b/src/SipToGtransfo.cc
@@ -22,7 +22,7 @@ using GtPoly_Ptr = std::shared_ptr<jointcal::GtransfoPoly>;
 /* The inverse transformation i.e. convert from the fit result to the SIP
    convention. */
 std::shared_ptr<afw::geom::SkyWcs> gtransfoToTanWcs(const jointcal::TanSipPix2RaDec& wcsTransfo,
-                                                    const jointcal::Frame &ccdFrame,
+                                                    const jointcal::Frame& ccdFrame,
                                                     const bool noLowOrderSipTerms) {
     GtransfoLin linPart = wcsTransfo.getLinPart();
     afwGeom::Point2D crpix_lsst;  // in LSST "frame"

--- a/src/SipToGtransfo.cc
+++ b/src/SipToGtransfo.cc
@@ -17,11 +17,11 @@ namespace afwGeom = lsst::afw::geom;
 namespace lsst {
 namespace jointcal {
 
-typedef std::shared_ptr<jointcal::GtransfoPoly> GtPoly_Ptr;
+using GtPoly_Ptr = std::shared_ptr<jointcal::GtransfoPoly>;
 
 /* The inverse transformation i.e. convert from the fit result to the SIP
    convention. */
-std::shared_ptr<afw::geom::SkyWcs> gtransfoToTanWcs(const jointcal::TanSipPix2RaDec wcsTransfo,
+std::shared_ptr<afw::geom::SkyWcs> gtransfoToTanWcs(const jointcal::TanSipPix2RaDec& wcsTransfo,
                                                     const jointcal::Frame &ccdFrame,
                                                     const bool noLowOrderSipTerms) {
     GtransfoLin linPart = wcsTransfo.getLinPart();

--- a/src/StarList.cc
+++ b/src/StarList.cc
@@ -24,8 +24,9 @@ template <class Star>
 void StarList<Star>::cutTail(const int nKeep) {
     int count = 0;
     auto si = this->begin();
-    for (; si != this->end() && count < nKeep; ++count, ++si)
+    for (; si != this->end() && count < nKeep; ++count, ++si) {
         ;
+}
     while (si != this->end()) {
         si = this->erase(si);
     }

--- a/src/StarList.cc
+++ b/src/StarList.cc
@@ -17,7 +17,7 @@ namespace jointcal {
 template <class Star>
 void StarList<Star>::fluxSort() {
     using E = StarList<Star>::Element;
-    this->sort([](const E &e1, const E &e2) { return (e1->getFlux() > e2->getFlux()); });
+    this->sort([](E const &e1, E const &e2) { return (e1->getFlux() > e2->getFlux()); });
 }
 
 template <class Star>
@@ -32,7 +32,7 @@ void StarList<Star>::cutTail(const int nKeep) {
 }
 
 template <class Star>
-void StarList<Star>::extractInFrame(StarList<Star> &out, const Frame &frame) const {
+void StarList<Star>::extractInFrame(StarList<Star> &out, Frame const &frame) const {
     for (auto const &star : *this) {
         if (frame.inFrame(*star)) {
             out.push_back(std::make_shared<Star>(*star));

--- a/src/StarList.cc
+++ b/src/StarList.cc
@@ -16,7 +16,7 @@ namespace jointcal {
 
 template <class Star>
 void StarList<Star>::fluxSort() {
-    typedef StarList<Star>::Element E;
+    using E = StarList<Star>::Element;
     this->sort([](const E &e1, const E &e2) { return (e1->getFlux() > e2->getFlux()); });
 }
 

--- a/src/StarList.cc
+++ b/src/StarList.cc
@@ -26,7 +26,7 @@ void StarList<Star>::cutTail(const int nKeep) {
     auto si = this->begin();
     for (; si != this->end() && count < nKeep; ++count, ++si) {
         ;
-}
+    }
     while (si != this->end()) {
         si = this->erase(si);
     }

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -17,7 +17,7 @@ namespace jointcal {
 
 static double sq(double x) { return x * x; }
 
-double StarMatch::computeChi2(const Gtransfo &gtransfo) const {
+double StarMatch::computeChi2(Gtransfo const &gtransfo) const {
     FatPoint tr;
     gtransfo.transformPosAndErrors(point1, tr);
     double vxx = tr.vx + point2.vx;
@@ -29,19 +29,19 @@ double StarMatch::computeChi2(const Gtransfo &gtransfo) const {
            det;
 }
 
-std::ostream &operator<<(std::ostream &stream, const StarMatch &match) {
+std::ostream &operator<<(std::ostream &stream, StarMatch const &match) {
     stream << match.point1.x << ' ' << match.point1.y << ' ' << match.point2.x << ' ' << match.point2.y << ' '
            << match.distance << std::endl;
     return stream;
 }
 
-std::ostream &operator<<(std::ostream &stream, const StarMatchList &starMatchList) {
+std::ostream &operator<<(std::ostream &stream, StarMatchList const &starMatchList) {
     stream << " number of elements " << starMatchList.size() << std::endl;
     copy(starMatchList.begin(), starMatchList.end(), std::ostream_iterator<StarMatch>(stream));
     return stream;
 }
 
-static std::unique_ptr<double[]> chi2_array(const StarMatchList &starMatchList, const Gtransfo &gtransfo) {
+static std::unique_ptr<double[]> chi2_array(StarMatchList const &starMatchList, Gtransfo const &gtransfo) {
     unsigned s = starMatchList.size();
     auto res = std::unique_ptr<double[]>(new double[s]);
     unsigned count = 0;
@@ -49,7 +49,7 @@ static std::unique_ptr<double[]> chi2_array(const StarMatchList &starMatchList, 
     return res;
 }
 
-static unsigned chi2_cleanup(StarMatchList &starMatchList, const double chi2Cut, const Gtransfo &gtransfo) {
+static unsigned chi2_cleanup(StarMatchList &starMatchList, const double chi2Cut, Gtransfo const &gtransfo) {
     unsigned erased = starMatchList.removeAmbiguities(gtransfo);
     for (auto smi = starMatchList.begin(); smi != starMatchList.end();) {
         if (smi->chi2 > chi2Cut) {
@@ -111,11 +111,11 @@ double StarMatchList::computeResidual() const {
     return (deno > 0) ? sqrt(_dist2 / deno) : -1;  // is -1 a good idea?
 }
 
-void StarMatchList::setDistance(const Gtransfo &gtransfo) {
+void StarMatchList::setDistance(Gtransfo const &gtransfo) {
     for (auto &smi : *this) smi.setDistance(gtransfo);  // c'est compact
 }
 
-unsigned StarMatchList::removeAmbiguities(const Gtransfo &gtransfo, int which) {
+unsigned StarMatchList::removeAmbiguities(Gtransfo const &gtransfo, int which) {
     if (!which) return 0;
     setDistance(gtransfo);
     int initial_count = size();
@@ -184,12 +184,12 @@ int StarMatchList::recoveredNumber(double mindist) const {
     return (n);
 }
 
-void StarMatchList::applyTransfo(StarMatchList &transformed, const Gtransfo *priorTransfo,
-                                 const Gtransfo *posteriorTransfo) const {
+void StarMatchList::applyTransfo(StarMatchList &transformed, Gtransfo const *priorTransfo,
+                                 Gtransfo const *posteriorTransfo) const {
     transformed.clear();
     GtransfoIdentity id;
-    const Gtransfo &T1 = (priorTransfo) ? *priorTransfo : id;
-    const Gtransfo &T2 = (posteriorTransfo) ? *posteriorTransfo : id;
+    Gtransfo const &T1 = (priorTransfo) ? *priorTransfo : id;
+    Gtransfo const &T2 = (posteriorTransfo) ? *posteriorTransfo : id;
 
     for (auto const &starMatch : *this) {
         FatPoint p1;
@@ -209,14 +209,14 @@ void StarMatchList::dumpTransfo(std::ostream &stream) const {
            << " ================================================================" << std::endl;
 }
 
-double computeDist2(const StarMatchList &starMatchList, const Gtransfo &gtransfo) {
+double computeDist2(StarMatchList const &starMatchList, Gtransfo const &gtransfo) {
     double dist2 = 0;
     for (auto const &starMatch : starMatchList)
         dist2 += gtransfo.apply(starMatch.point1).computeDist2(starMatch.point2);
     return dist2;
 }
 
-double computeChi2(const StarMatchList &starMatchList, const Gtransfo &gtransfo) {
+double computeChi2(StarMatchList const &starMatchList, Gtransfo const &gtransfo) {
     unsigned s = starMatchList.size();
     std::unique_ptr<double[]> chi2s(chi2_array(starMatchList, gtransfo));
     double chi2 = 0;

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -57,7 +57,7 @@ static unsigned chi2_cleanup(StarMatchList &starMatchList, const double chi2Cut,
             erased++;
         } else {
             ++smi;
-}
+        }
     }
     return erased;
 }
@@ -138,7 +138,7 @@ void StarMatchList::setTransfoOrder(int order) {
         setTransfo(std::make_shared<GtransfoLin>());
     } else {
         setTransfo(GtransfoPoly(order));
-}
+    }
     // might consider throwing if order does not make sense (e.g. >10)
     _order = order;
 }
@@ -168,7 +168,7 @@ void StarMatchList::cutTail(int nKeep) {
     int count = 0;
     for (si = begin(); si != end() && count < nKeep; ++count, ++si) {
         ;
-}
+    }
     erase(si, end());
 }
 
@@ -216,7 +216,7 @@ double computeDist2(StarMatchList const &starMatchList, Gtransfo const &gtransfo
     double dist2 = 0;
     for (auto const &starMatch : starMatchList) {
         dist2 += gtransfo.apply(starMatch.point1).computeDist2(starMatch.point2);
-}
+    }
     return dist2;
 }
 

--- a/src/StarMatch.cc
+++ b/src/StarMatch.cc
@@ -55,8 +55,9 @@ static unsigned chi2_cleanup(StarMatchList &starMatchList, const double chi2Cut,
         if (smi->chi2 > chi2Cut) {
             smi = starMatchList.erase(smi);
             erased++;
-        } else
+        } else {
             ++smi;
+}
     }
     return erased;
 }
@@ -131,12 +132,13 @@ unsigned StarMatchList::removeAmbiguities(Gtransfo const &gtransfo, int which) {
 }
 
 void StarMatchList::setTransfoOrder(int order) {
-    if (order == 0)
+    if (order == 0) {
         setTransfo(std::make_shared<GtransfoLinShift>());
-    else if (order == 1)
+    } else if (order == 1) {
         setTransfo(std::make_shared<GtransfoLin>());
-    else
+    } else {
         setTransfo(GtransfoPoly(order));
+}
     // might consider throwing if order does not make sense (e.g. >10)
     _order = order;
 }
@@ -164,8 +166,9 @@ std::unique_ptr<Gtransfo> StarMatchList::inverseTransfo() {
 void StarMatchList::cutTail(int nKeep) {
     iterator si;
     int count = 0;
-    for (si = begin(); si != end() && count < nKeep; ++count, ++si)
+    for (si = begin(); si != end() && count < nKeep; ++count, ++si) {
         ;
+}
     erase(si, end());
 }
 
@@ -211,8 +214,9 @@ void StarMatchList::dumpTransfo(std::ostream &stream) const {
 
 double computeDist2(StarMatchList const &starMatchList, Gtransfo const &gtransfo) {
     double dist2 = 0;
-    for (auto const &starMatch : starMatchList)
+    for (auto const &starMatch : starMatchList) {
         dist2 += gtransfo.apply(starMatch.point1).computeDist2(starMatch.point2);
+}
     return dist2;
 }
 

--- a/src/TwoTransfoMapping.cc
+++ b/src/TwoTransfoMapping.cc
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "lsst/jointcal/TwoTransfoMapping.h"
 #include "lsst/pex/exceptions.h"
 
@@ -11,7 +13,7 @@ TwoTransfoMapping::TwoTransfoMapping(SimpleGtransfoMapping *mapping1, SimpleGtra
     /* Allocate the record of temporary variables, so that they are not
        allocated at every call. This is hidden behind a pointer in order
        to be allowed to alter them in a const routine. */
-    tmp = std::unique_ptr<tmpVars>(new tmpVars);
+    tmp = std::make_unique<tmpVars>();
     setWhatToFit(true, true);
 }
 

--- a/src/TwoTransfoMapping.cc
+++ b/src/TwoTransfoMapping.cc
@@ -51,13 +51,13 @@ void TwoTransfoMapping::computeTransformAndDerivatives(FatPoint const &where, Fa
         H.block(0, 0, _nPar1, 2) = tmp->h1 * tmp->dt2dx;
     } else {
         _m1->transformPosAndErrors(where, pMid);
-}
+    }
     if (_nPar2) {
         _m2->computeTransformAndDerivatives(pMid, outPoint, tmp->h2);
         H.block(_nPar1, 0, _nPar2, 2) = tmp->h2;
     } else {
         _m2->transformPosAndErrors(pMid, outPoint);
-}
+    }
 }
 
 /*! Sets the _nPar{1,2} and allocates H matrices accordingly, to
@@ -70,13 +70,13 @@ void TwoTransfoMapping::setWhatToFit(const bool fittingT1, const bool fittingT2)
         tmp->h1 = Eigen::MatrixX2d(_nPar1, 2);
     } else {
         _nPar1 = 0;
-}
+    }
     if (fittingT2) {
         _nPar2 = _m2->getNpar();
         tmp->h2 = Eigen::MatrixX2d(_nPar2, 2);
     } else {
         _nPar2 = 0;
-}
+    }
 }
 
 void TwoTransfoMapping::transformPosAndErrors(FatPoint const &where, FatPoint &outPoint) const {

--- a/src/TwoTransfoMapping.cc
+++ b/src/TwoTransfoMapping.cc
@@ -75,7 +75,7 @@ void TwoTransfoMapping::setWhatToFit(const bool fittingT1, const bool fittingT2)
         _nPar2 = 0;
 }
 
-void TwoTransfoMapping::transformPosAndErrors(const FatPoint &where, FatPoint &outPoint) const {
+void TwoTransfoMapping::transformPosAndErrors(FatPoint const &where, FatPoint &outPoint) const {
     FatPoint pMid;
     _m1->transformPosAndErrors(where, pMid);
     _m2->transformPosAndErrors(pMid, outPoint);

--- a/src/TwoTransfoMapping.cc
+++ b/src/TwoTransfoMapping.cc
@@ -23,9 +23,9 @@ void TwoTransfoMapping::getMappingIndices(std::vector<unsigned> &indices) const 
     unsigned npar = getNpar();
     if (indices.size() < npar) indices.resize(npar);
     // in case we are only fitting one of the two transfos
-    if (_nPar1)
+    if (_nPar1) {
         _m1->getMappingIndices(indices);
-    else if (_nPar2) {
+    } else if (_nPar2) {
         _m2->getMappingIndices(indices);
         return;
     }
@@ -49,13 +49,15 @@ void TwoTransfoMapping::computeTransformAndDerivatives(FatPoint const &where, Fa
         // the last argument is epsilon and is not used for polynomials
         _m2->positionDerivative(pMid, tmp->dt2dx, 1e-4);
         H.block(0, 0, _nPar1, 2) = tmp->h1 * tmp->dt2dx;
-    } else
+    } else {
         _m1->transformPosAndErrors(where, pMid);
+}
     if (_nPar2) {
         _m2->computeTransformAndDerivatives(pMid, outPoint, tmp->h2);
         H.block(_nPar1, 0, _nPar2, 2) = tmp->h2;
-    } else
+    } else {
         _m2->transformPosAndErrors(pMid, outPoint);
+}
 }
 
 /*! Sets the _nPar{1,2} and allocates H matrices accordingly, to
@@ -66,13 +68,15 @@ void TwoTransfoMapping::setWhatToFit(const bool fittingT1, const bool fittingT2)
     if (fittingT1) {
         _nPar1 = _m1->getNpar();
         tmp->h1 = Eigen::MatrixX2d(_nPar1, 2);
-    } else
+    } else {
         _nPar1 = 0;
+}
     if (fittingT2) {
         _nPar2 = _m2->getNpar();
         tmp->h2 = Eigen::MatrixX2d(_nPar2, 2);
-    } else
+    } else {
         _nPar2 = 0;
+}
 }
 
 void TwoTransfoMapping::transformPosAndErrors(FatPoint const &where, FatPoint &outPoint) const {

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -2,7 +2,7 @@
 
 #define BOOST_TEST_MODULE test_trans
 
-//The boost unit test header
+// The boost unit test header
 #include "boost/test/unit_test.hpp"
 
 #include "lsst/jointcal/StarMatch.h"
@@ -24,10 +24,9 @@
 #define _GNU_SOURCE 1
 #define __USE_GNU
 #include <fenv.h>
-static void __attribute__ ((constructor)) trapfpe ()
-{
-   // Enable some exceptions.  At startup all exceptions are masked.
-  feenableexcept (FE_INVALID|FE_DIVBYZERO|FE_OVERFLOW);
+static void __attribute__((constructor)) trapfpe() {
+    // Enable some exceptions.  At startup all exceptions are masked.
+    feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
 }
 #endif
 
@@ -38,64 +37,57 @@ namespace afwImg = lsst::afw::image;
 
 BOOST_AUTO_TEST_SUITE(test_transfos)
 
-BOOST_AUTO_TEST_CASE(test_wcs)
-{
+BOOST_AUTO_TEST_CASE(test_wcs) {
+    std::string fileName = "tests/header_only.fits";
 
-  std::string fileName = "tests/header_only.fits";
+    lsst::afw::fits::Fits file(fileName, "r", 0);
+    auto propSet = lsst::afw::fits::readMetadata(fileName);
+    auto skyWcs = lsst::afw::geom::makeSkyWcs(*propSet);
+    jointcal::GtransfoSkyWcs gtransfoWcs(skyWcs);
 
-  lsst::afw::fits::Fits file(fileName, "r",0);
-  auto propSet = lsst::afw::fits::readMetadata(fileName);
-  auto skyWcs = lsst::afw::geom::makeSkyWcs(*propSet);
-  jointcal::GtransfoSkyWcs gtransfoWcs(skyWcs);
+    jointcal::Point where(100., 200.);
+    jointcal::Point outPol = gtransfoWcs.apply(where);
+    std::cout << std::setprecision(12) << "Poloka : " << outPol.x << ' ' << outPol.y << std::endl;
 
-  jointcal::Point where(100.,200.);
-  jointcal::Point outPol = gtransfoWcs.apply(where);
-  std::cout << std::setprecision(12) << "Poloka : " << outPol.x << ' ' << outPol.y << std::endl;
+    lsst::afw::geom::Point2D whereSame(100., 200.);
+    auto skyPos = skyWcs->pixelToSky(whereSame);
+    lsst::afw::geom::Point2D outDeg = skyPos.getPosition(lsst::afw::geom::degrees);
+    std::cout << "Stack : " << outDeg[0] << ' ' << outDeg[1] << std::endl;
 
-  lsst::afw::geom::Point2D whereSame(100.,200.);
-  auto skyPos = skyWcs->pixelToSky(whereSame);
-  lsst::afw::geom::Point2D outDeg = skyPos.getPosition(lsst::afw::geom::degrees);
-  std::cout << "Stack : " << outDeg[0] << ' ' << outDeg[1] << std::endl;
-
-  BOOST_CHECK_CLOSE(outPol.x, outDeg[0], .000001);
-  BOOST_CHECK_CLOSE(outPol.y, outDeg[1], .000001);
+    BOOST_CHECK_CLOSE(outPol.x, outDeg[0], .000001);
+    BOOST_CHECK_CLOSE(outPol.y, outDeg[1], .000001);
 }
-
-
 
 /* test the GtransfoPoly::fit routine */
 
-BOOST_AUTO_TEST_CASE(test_polyfit)
-{
-  std::string fileName = "tests/header_only.fits";
+BOOST_AUTO_TEST_CASE(test_polyfit) {
+    std::string fileName = "tests/header_only.fits";
 
-  lsst::afw::fits::Fits file(fileName, "r",0);
-  auto propSet = lsst::afw::fits::readMetadata(fileName);
-  auto skyWcs = lsst::afw::geom::makeSkyWcs(*propSet);
-  jointcal::GtransfoSkyWcs gtransfoWcs(skyWcs);
+    lsst::afw::fits::Fits file(fileName, "r", 0);
+    auto propSet = lsst::afw::fits::readMetadata(fileName);
+    auto skyWcs = lsst::afw::geom::makeSkyWcs(*propSet);
+    jointcal::GtransfoSkyWcs gtransfoWcs(skyWcs);
 
-  jointcal::StarMatchList sml;
-  jointcal::BaseStarList bsl1, bsl2;
+    jointcal::StarMatchList sml;
+    jointcal::BaseStarList bsl1, bsl2;
 
-  for (double x=10; x<2000; x+= 120)
-    for (double y=20; y<4000; y+=160)
-      {
-	auto s1 = std::make_shared<jointcal::BaseStar>(x,y,1,0.01);
-	s1->vx = 0.1;
-	s1->vy = 0.2;
-	s1->vxy = 0.05;
-	auto s2 = std::make_shared<jointcal::BaseStar>();
-	gtransfoWcs.transformPosAndErrors(*s1, *s2);
-	bsl1.push_back(s1);
-	bsl2.push_back(s2);
-	sml.push_back(jointcal::StarMatch(*s1,*s2,s1,s2));
-      }
-  jointcal::GtransfoPoly pol(3);
-  double chi2 = pol.fit(sml);
-  std::cout << " chi2/ndf " << chi2 << '/' << sml.size()-pol.getNpar() << std::endl;
-  // since there is no noise, the chi2 should be very very small:
-  BOOST_CHECK( fabs(chi2)<1e-8);
+    for (double x = 10; x < 2000; x += 120)
+        for (double y = 20; y < 4000; y += 160) {
+            auto s1 = std::make_shared<jointcal::BaseStar>(x, y, 1, 0.01);
+            s1->vx = 0.1;
+            s1->vy = 0.2;
+            s1->vxy = 0.05;
+            auto s2 = std::make_shared<jointcal::BaseStar>();
+            gtransfoWcs.transformPosAndErrors(*s1, *s2);
+            bsl1.push_back(s1);
+            bsl2.push_back(s2);
+            sml.push_back(jointcal::StarMatch(*s1, *s2, s1, s2));
+        }
+    jointcal::GtransfoPoly pol(3);
+    double chi2 = pol.fit(sml);
+    std::cout << " chi2/ndf " << chi2 << '/' << sml.size() - pol.getNpar() << std::endl;
+    // since there is no noise, the chi2 should be very very small:
+    BOOST_CHECK(fabs(chi2) < 1e-8);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Enabled checks:
    google-build-explicit-make-pair
    google-build-namespaces
    google-build-using-namespace
    google-default-arguments
    google-explicit-constructor
    google-global-names-in-headers
    google-readability-casting
    google-readability-function-size
    google-readability-namespace-comments
    google-readability-redundant-smartptr-get
    google-runtime-int
    google-runtime-member-string-references
    google-runtime-operator
    google-runtime-references
    modernize-avoid-bind
    modernize-deprecated-headers
    modernize-loop-convert
    modernize-make-shared
    modernize-make-unique
    modernize-raw-string-literal
    modernize-redundant-void-arg
    modernize-replace-auto-ptr
    modernize-replace-random-shuffle
    modernize-shrink-to-fit
    modernize-unary-static-assert
    modernize-use-auto
    modernize-use-bool-literals
    modernize-use-emplace
    modernize-use-equals-default
    modernize-use-equals-delete
    modernize-use-noexcept
    modernize-use-nullptr
    modernize-use-override
    modernize-use-transparent-functors
    modernize-use-using
    performance-faster-string-find
    performance-for-range-copy
    performance-implicit-cast-in-loop
    performance-inefficient-string-concatenation
    performance-inefficient-vector-operation
    performance-type-promotion-in-math-fn
    performance-unnecessary-copy-initialization
    performance-unnecessary-value-param
    readability-avoid-const-params-in-decls
    readability-container-size-empty
    readability-delete-null-pointer
    readability-deleted-default
    readability-else-after-return
    readability-function-size
    readability-misleading-indentation
    readability-misplaced-array-index
    readability-non-const-parameter
    readability-redundant-control-flow
    readability-redundant-declaration
    readability-redundant-function-ptr-dereference
    readability-redundant-smartptr-get
    readability-redundant-string-cstr
    readability-redundant-string-init
    readability-simplify-boolean-expr
    readability-static-definition-in-anonymous-namespace
    readability-uniqueptr-delete-release