### PR TITLE
DM-15139: Rename invert() and getInverse() to inverted()

### DIFF
--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -33,8 +33,8 @@ class GtransfoLin;
     transformation". If a transfo has an analytical inverse, then
     providing inverseTransfo is obviously a very good idea. Before
     resorting to inverseTransfo, consider using
-    StarMatchList::inverseTransfo().  GtransfoLin::invert() and
-    TanPix2RaDec::invert() exist.
+    StarMatchList::inverseTransfo().  GtransfoLin::inverted() and
+    TanPix2RaDec::inverted() exist.
     The classes also provide derivation and linear approximation.
 
 */
@@ -401,8 +401,8 @@ public:
     //!  enables to combine linear tranformations: T1=T2*T3 is legal.
     GtransfoLin operator*(GtransfoLin const &right) const;
 
-    //! returns the inverse: T1 = T2.invert();
-    GtransfoLin invert() const;
+    //! returns the inverse: T1 = T2.inverted();
+    GtransfoLin inverted() const;
 
     // useful?    double jacobian(const double x, const double y) const { return determinant();}
 
@@ -598,7 +598,7 @@ public:
     std::unique_ptr<Gtransfo> composeAndReduce(GtransfoLin const &right) const;
 
     //! approximate inverse : it ignores corrections;
-    TanRaDec2Pix invert() const;
+    TanRaDec2Pix inverted() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
     std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
@@ -676,7 +676,7 @@ public:
     void transformPosAndErrors(const FatPoint &in, FatPoint &out) const;
 
     //! exact typed inverse:
-    TanPix2RaDec invert() const;
+    TanPix2RaDec inverted() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
     std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;

--- a/include/lsst/jointcal/SimpleAstrometryMapping.h
+++ b/include/lsst/jointcal/SimpleAstrometryMapping.h
@@ -128,7 +128,7 @@ public:
     SimplePolyMapping(GtransfoLin const &CenterAndScale, GtransfoPoly const &gtransfo)
             : SimpleGtransfoMapping(gtransfo), _centerAndScale(CenterAndScale) {
         // We assume that the initialization was done properly, for example that
-        // gtransfo = pix2TP*CenterAndScale.invert(), so we do not touch transfo.
+        // gtransfo = pix2TP*CenterAndScale.inverted(), so we do not touch transfo.
         /* store the (spatial) derivative of _centerAndScale. For the extra
            diagonal terms, just copied the ones in positionDerivatives */
         preDer(0, 0) = _centerAndScale.coeff(1, 0, 0);

--- a/src/ConstrainedAstrometryModel.cc
+++ b/src/ConstrainedAstrometryModel.cc
@@ -72,8 +72,8 @@ ConstrainedAstrometryModel::ConstrainedAstrometryModel(
             // construct the chip gtransfo by approximating the pixel->Focal afw::geom::Transform.
             GtransfoPoly pol = GtransfoPoly(pixelsToFocal, frame, chipOrder);
             GtransfoLin shiftAndNormalize = normalizeCoordinatesTransfo(frame);
-            _chipMap[chip] =
-                    std::make_shared<SimplePolyMapping>(shiftAndNormalize, pol * shiftAndNormalize.invert());
+            _chipMap[chip] = std::make_shared<SimplePolyMapping>(shiftAndNormalize,
+                                                                 pol * shiftAndNormalize.inverted());
         }
     }
 

--- a/src/Gtransfo.cc
+++ b/src/Gtransfo.cc
@@ -169,7 +169,7 @@ std::unique_ptr<Gtransfo> Gtransfo::roughInverse(const Frame &region) const {
     Point centerIn = apply(centerOut);
     GtransfoLin der;
     computeDerivative(centerOut, der, std::sqrt(region.getArea()) / 5.);
-    der = der.invert();
+    der = der.inverted();
     der = GtransfoLinShift(centerOut.x, centerOut.y) * der * GtransfoLinShift(-centerIn.x, -centerIn.y);
     return std::unique_ptr<Gtransfo>(new GtransfoLin(der));
 }
@@ -300,7 +300,7 @@ void GtransfoInverse::apply(const double xIn, const double yIn, double &xOut, do
         loop++;
         Point inGuess = _direct->apply(outGuess);
         _direct->computeDerivative(outGuess, directDer);
-        reverseDer = directDer.invert();
+        reverseDer = directDer.inverted();
         double xShift, yShift;
         reverseDer.apply(xIn - inGuess.x, yIn - inGuess.y, xShift, yShift);
         outGuess.x += xShift;
@@ -1175,7 +1175,7 @@ void GtransfoLin::computeDerivative(Point const &, GtransfoLin &derivative, cons
 
 GtransfoLin GtransfoLin::linearApproximation(Point const &, const double) const { return *this; }
 
-GtransfoLin GtransfoLin::invert() const {
+GtransfoLin GtransfoLin::inverted() const {
     //
     //   (T1,M1) * (T2,M2) = 1 i.e (0,1) implies
     //   T1 = -M1 * T2
@@ -1202,7 +1202,7 @@ GtransfoLin GtransfoLin::invert() const {
 }
 
 std::unique_ptr<Gtransfo> GtransfoLin::inverseTransfo(const double, const Frame &) const {
-    return std::unique_ptr<Gtransfo>(new GtransfoLin(invert()));
+    return std::unique_ptr<Gtransfo>(new GtransfoLin(inverted()));
 }
 
 double GtransfoLinRot::fit(StarMatchList const &) {
@@ -1364,7 +1364,7 @@ Point BaseTanWcs::getCrPix() const {
 
        so that CrPix is the point which transforms to (0,0)
     */
-    const GtransfoLin inverse = linPix2Tan.invert();
+    const GtransfoLin inverse = linPix2Tan.inverted();
     return Point(inverse.Dx(), inverse.Dy());
 }
 
@@ -1411,21 +1411,21 @@ TanPix2RaDec TanPix2RaDec::operator*(GtransfoLin const &right) const {
     return result;
 }
 
-TanRaDec2Pix TanPix2RaDec::invert() const {
+TanRaDec2Pix TanPix2RaDec::inverted() const {
     if (corr != nullptr) {
         LOGL_WARN(_log, "You are inverting a TanPix2RaDec with corrections.");
         LOGL_WARN(_log, "The inverse you get ignores the corrections!");
     }
-    return TanRaDec2Pix(getLinPart().invert(), getTangentPoint());
+    return TanRaDec2Pix(getLinPart().inverted(), getTangentPoint());
 }
 
 std::unique_ptr<Gtransfo> TanPix2RaDec::roughInverse(const Frame &) const {
-    return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().invert(), getTangentPoint()));
+    return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().inverted(), getTangentPoint()));
 }
 
 std::unique_ptr<Gtransfo> TanPix2RaDec::inverseTransfo(const double precision, const Frame &region) const {
     if (!corr)
-        return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().invert(), getTangentPoint()));
+        return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().inverted(), getTangentPoint()));
     else
         return std::unique_ptr<Gtransfo>(new GtransfoInverse(this, precision, region));
 }
@@ -1489,7 +1489,7 @@ TanSipPix2RaDec::TanSipPix2RaDec() : BaseTanWcs(GtransfoLin(), Point(0, 0), null
 std::unique_ptr<Gtransfo> TanPix2RaDec::roughInverse(const Frame &region) const
 {
   if (&region) {}
-  return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().invert(),getTangentPoint()));
+  return std::unique_ptr<Gtransfo>(new TanRaDec2Pix(getLinPart().inverted(),getTangentPoint()));
 }
 #endif
 
@@ -1640,7 +1640,9 @@ void TanRaDec2Pix::apply(const double xIn, const double yIn, double &xOut, doubl
     linTan2Pix.apply(l, m, xOut, yOut);
 }
 
-TanPix2RaDec TanRaDec2Pix::invert() const { return TanPix2RaDec(getLinPart().invert(), getTangentPoint()); }
+TanPix2RaDec TanRaDec2Pix::inverted() const {
+    return TanPix2RaDec(getLinPart().inverted(), getTangentPoint());
+}
 
 void TanRaDec2Pix::dump(ostream &stream) const {
     Point tp = getTangentPoint();
@@ -1648,11 +1650,11 @@ void TanRaDec2Pix::dump(ostream &stream) const {
 }
 
 std::unique_ptr<Gtransfo> TanRaDec2Pix::roughInverse(const Frame &) const {
-    return std::unique_ptr<Gtransfo>(new TanPix2RaDec(getLinPart().invert(), getTangentPoint()));
+    return std::unique_ptr<Gtransfo>(new TanPix2RaDec(getLinPart().inverted(), getTangentPoint()));
 }
 
 std::unique_ptr<Gtransfo> TanRaDec2Pix::inverseTransfo(const double, const Frame &) const {
-    return std::unique_ptr<Gtransfo>(new TanPix2RaDec(getLinPart().invert(), getTangentPoint()));
+    return std::unique_ptr<Gtransfo>(new TanPix2RaDec(getLinPart().inverted(), getTangentPoint()));
 }
 
 std::unique_ptr<Gtransfo> TanRaDec2Pix::clone() const {

--- a/src/SimpleAstrometryModel.cc
+++ b/src/SimpleAstrometryModel.cc
@@ -64,7 +64,7 @@ SimpleAstrometryModel::SimpleAstrometryModel(CcdImageList const &ccdImageList,
             GtransfoLin shiftAndNormalize = normalizeCoordinatesTransfo(frame);
             if (initFromWcs) {
                 pol = GtransfoPoly(im.getPix2TangentPlane(), frame, order);
-                pol = pol * shiftAndNormalize.invert();
+                pol = pol * shiftAndNormalize.inverted();
             }
             _myMap[im.getHashKey()] =
                     std::unique_ptr<SimpleGtransfoMapping>(new SimplePolyMapping(shiftAndNormalize, pol));


### PR DESCRIPTION
for objects that have it, e.g. GtransfoLin and TanRaDec2Pix.
Also use invert() instead of deprecated inverted() for objects
from other packages.