### PR TITLE
DM-15513 Fix bug in caller naming to prevent race condition

### DIFF
--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -129,7 +129,7 @@ class JointcalTestBase:
         """
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[1].function
 
         result = self._runJointcalTask(nCatalogs, caller, metrics=metrics)
 

--- a/tests/test_jointcal_cfht_minimal.py
+++ b/tests/test_jointcal_cfht_minimal.py
@@ -63,7 +63,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
                    }
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[0].function
         self._runJointcalTask(2, caller, metrics=metrics)
 
         # Check that the Hessian/gradient files were written.
@@ -95,7 +95,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
                    }
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[0].function
         self._runJointcalTask(2, caller, metrics=metrics)
 
     def test_jointcalTask_fails_raise(self):
@@ -107,7 +107,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.doAstrometry = False
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])
         output_dir = os.path.join('.test', self.__class__.__name__, caller)
@@ -128,7 +128,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.doAstrometry = False
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])
         output_dir = os.path.join('.test', self.__class__.__name__, caller)
@@ -149,7 +149,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.doAstrometry = False
 
         # the calling method is one step back on the stack: use it to specify the output repo.
-        caller = inspect.stack()[1][3]  # NOTE: could be inspect.stack()[1].function in py3.5
+        caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])
         output_dir = os.path.join('.test', self.__class__.__name__, caller)

--- a/tests/test_jointcal_cfht_minimal.py
+++ b/tests/test_jointcal_cfht_minimal.py
@@ -62,7 +62,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
                    'photometry_final_ndof': 1
                    }
 
-        # the calling method is one step back on the stack: use it to specify the output repo.
+        # The output repo is named after this method.
         caller = inspect.stack()[0].function
         self._runJointcalTask(2, caller, metrics=metrics)
 
@@ -94,7 +94,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
                    'photometry_final_ndof': 1
                    }
 
-        # the calling method is one step back on the stack: use it to specify the output repo.
+        # The output repo is named after this method.
         caller = inspect.stack()[0].function
         self._runJointcalTask(2, caller, metrics=metrics)
 
@@ -106,7 +106,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.sourceSelector['astrometry'].minSnr = 10000
         self.config.doAstrometry = False
 
-        # the calling method is one step back on the stack: use it to specify the output repo.
+        # The output repo is named after this method.
         caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])
@@ -127,7 +127,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.sourceSelector['astrometry'].minSnr = 10000
         self.config.doAstrometry = False
 
-        # the calling method is one step back on the stack: use it to specify the output repo.
+        # The output repo is named after this method.
         caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])
@@ -148,7 +148,7 @@ class JointcalTestCFHTMinimal(jointcalTestBase.JointcalTestBase, lsst.utils.test
         self.config.sourceSelector['astrometry'].minSnr = 10000
         self.config.doAstrometry = False
 
-        # the calling method is one step back on the stack: use it to specify the output repo.
+        # The output repo is named after this method.
         caller = inspect.stack()[0].function
         nCatalogs = 2
         visits = '^'.join(str(v) for v in self.all_visits[:nCatalogs])

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -151,7 +151,7 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
-        caller = inspect.stack()[0][3]  # NOTE: could be inspect.stack()[0].function in py3.5
+        caller = inspect.stack()[0].function
         result = self._runJointcalTask(2, caller, metrics=metrics)
         data_refs = result.resultList[0].result.dataRefs
         oldWcsList = result.resultList[0].result.oldWcsList

--- a/tests/test_jointcal_lsstSim.py
+++ b/tests/test_jointcal_lsstSim.py
@@ -148,7 +148,7 @@ class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Te
         self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_astrometry = False
 
-        caller = inspect.stack()[0][3]  # NOTE: could be inspect.stack()[0].function in py3.5
+        caller = inspect.stack()[0].function
         result = self._runJointcalTask(2, caller, metrics=metrics)
 
         data_refs = result.resultList[0].result.dataRefs
@@ -184,7 +184,7 @@ class JointcalTestLSSTSim(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Te
         self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
-        caller = inspect.stack()[0][3]  # NOTE: could be inspect.stack()[0].function in py3.5
+        caller = inspect.stack()[0].function
         result = self._runJointcalTask(2, caller, metrics=metrics)
         data_refs = result.resultList[0].result.dataRefs
         oldWcsList = result.resultList[0].result.oldWcsList


### PR DESCRIPTION
All of the cfht_minimal tests were using `JointcalTestCFHTMinimal/run` for
their output directories, which occasionally caused a race (though exactly
why I'm not certain). This fixes them to use the correct, named-after-method
directories.