### PR TITLE
DM-13270: Cleanup ccdImage and gtransfo APIs

### DIFF
--- a/include/lsst/jointcal/AstrometryModel.h
+++ b/include/lsst/jointcal/AstrometryModel.h
@@ -66,7 +66,7 @@ public:
     //! The transformation used to project the positions of FittedStars.
     /*! This defines the coordinate system into which the Mapping of
         this Ccdimage maps the pixel coordinates. */
-    virtual const std::shared_ptr<Gtransfo const> getSky2TP(CcdImage const &ccdImage) const = 0;
+    virtual const std::shared_ptr<Gtransfo const> getSkyToTangentPlane(CcdImage const &ccdImage) const = 0;
 
     /**
      * Make a SkyWcs that contains this model.

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -123,22 +123,23 @@ public:
      *
      * @return     The common tangent point of all ccdImages (decimal degrees).
      */
-    Point const &getCommonTangentPoint() const { return _commonTangentPoint; }
+    jointcal::Point const &getCommonTangentPoint() const { return _commonTangentPoint; }
 
-    //!
-    Gtransfo const *getPix2CommonTangentPlane() const { return _pix2CommonTangentPlane.get(); }
+    std::shared_ptr<Gtransfo> const getPixelToCommonTangentPlane() const {
+        return _pixelToCommonTangentPlane;
+    }
 
-    //!
-    Gtransfo const *getCommonTangentPlane2TP() const { return _CTP2TP.get(); }
+    std::shared_ptr<Gtransfo> const getCommonTangentPlaneToTangentPlane() const {
+        return _commonTangentPlaneToTangentPlane;
+    }
 
-    //!
-    Gtransfo const *getTP2CommonTangentPlane() const { return _TP2CTP.get(); }
+    std::shared_ptr<Gtransfo> const getTangentPlaneToCommonTangentPlane() const {
+        return _tangentPlaneToCommonTangentPlane;
+    }
 
-    //!
-    Gtransfo const *getPix2TangentPlane() const { return _pix2TP.get(); }
+    std::shared_ptr<Gtransfo> const getPixelToTangentPlane() const { return _pixelToTangentPlane; }
 
-    //!
-    Gtransfo const *getSky2TP() const { return _sky2TP.get(); }
+    std::shared_ptr<Gtransfo> const getSkyToTangentPlane() const { return _skyToTangentPlane; }
 
     //! returns ccd ID
     CcdIdType getCcdId() const { return _ccdId; }
@@ -164,26 +165,27 @@ public:
      */
     lsst::afw::geom::SpherePoint getBoresightRaDec() const { return _boresightRaDec; }
 
-    //!
     double getHourAngle() const { return _hourAngle; }
 
-    //! Parallactic angle
-    double getSinEta() const { return _sineta; }
+    double getLstObs() const { return _lstObs; }
 
     //! Parallactic angle
-    double getCosEta() const { return _coseta; }
+    double getSinEta() const { return _sinEta; }
 
     //! Parallactic angle
-    double getTanZ() const { return _tgz; }
+    double getCosEta() const { return _cosEta; }
+
+    //! Parallactic angle
+    double getTanZ() const { return _tanZ; }
 
     //!
-    Point getRefractionVector() const { return Point(_tgz * _coseta, _tgz * _sineta); }
+    Point getRefractionVector() const { return Point(_tanZ * _cosEta, _tanZ * _sinEta); }
 
     //! return the CcdImage filter name
     std::string getFilter() const { return _filter; }
 
     //! the wcs read in the header. NOT updated when fitting.
-    Gtransfo const *readWCS() const { return _readWcs.get(); }
+    std::shared_ptr<Gtransfo> const getReadWcs() const { return _readWcs; }
 
     //! Frame in pixels
     Frame const &getImageFrame() const { return _imageFrame; }
@@ -192,7 +194,7 @@ private:
     void loadCatalog(lsst::afw::table::SortedCatalogT<lsst::afw::table::SourceRecord> const &Cat,
                      std::string const &fluxField);
 
-    Frame _imageFrame;  // in pixels
+    jointcal::Frame _imageFrame;  // in pixels
 
     MeasuredStarList _wholeCatalog;  // the catalog of measured objets
     MeasuredStarList _catalogForFit;
@@ -200,12 +202,13 @@ private:
     std::shared_ptr<GtransfoSkyWcs> _readWcs;  // apply goes from pix to sky
 
     // The following ones should probably be mostly removed.
-    std::shared_ptr<Gtransfo> _CTP2TP;                  // go from CommonTangentPlane to this tangent plane.
-    std::shared_ptr<Gtransfo> _TP2CTP;                  // reverse one
-    std::shared_ptr<Gtransfo> _pix2CommonTangentPlane;  // pixels -> CTP
-    std::shared_ptr<Gtransfo> _pix2TP;
+    // go from CommonTangentPlane to this tangent plane.
+    std::shared_ptr<Gtransfo> _commonTangentPlaneToTangentPlane;
+    std::shared_ptr<Gtransfo> _tangentPlaneToCommonTangentPlane;  // reverse one
+    std::shared_ptr<Gtransfo> _pixelToCommonTangentPlane;         // pixels -> CTP
+    std::shared_ptr<Gtransfo> _pixelToTangentPlane;
 
-    std::shared_ptr<Gtransfo> _sky2TP;
+    std::shared_ptr<Gtransfo> _skyToTangentPlane;
 
     std::string _name;
     CcdIdType _ccdId;
@@ -218,13 +221,13 @@ private:
     std::shared_ptr<afw::cameraGeom::Detector> _detector;
     // refraction
     // eta : parallactic angle, z: zenithal angle (X = 1/cos(z))
-    double _sineta, _coseta, _tgz;
+    double _sinEta, _cosEta, _tanZ;
     // Local Sidereal Time and hour angle of observation
     double _lstObs, _hourAngle;
 
     std::string _filter;
 
-    Point _commonTangentPoint;
+    jointcal::Point _commonTangentPoint;
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/ConstrainedAstrometryModel.h
+++ b/include/lsst/jointcal/ConstrainedAstrometryModel.h
@@ -102,8 +102,8 @@ public:
      * stars are reported) onto the Tangent plane (into which the pixel coordinates
      * are transformed).
      */
-    const std::shared_ptr<Gtransfo const> getSky2TP(CcdImage const &ccdImage) const override {
-        return _sky2TP->getSky2TP(ccdImage);
+    const std::shared_ptr<Gtransfo const> getSkyToTangentPlane(CcdImage const &ccdImage) const override {
+        return _skyToTangentPlane->getSkyToTangentPlane(ccdImage);
     }
 
     /// @copydoc AstrometryModel::makeSkyWcs
@@ -113,7 +113,7 @@ private:
     std::unordered_map<CcdImageKey, std::unique_ptr<TwoTransfoMapping>> _mappings;
     std::map<CcdIdType, std::shared_ptr<SimpleGtransfoMapping>> _chipMap;
     std::map<VisitIdType, std::shared_ptr<SimpleGtransfoMapping>> _visitMap;
-    const std::shared_ptr<ProjectionHandler const> _sky2TP;
+    const std::shared_ptr<ProjectionHandler const> _skyToTangentPlane;
     bool _fittingChips, _fittingVisits;
 
     /// @copydoc AstrometryModel::findMapping

--- a/include/lsst/jointcal/Gtransfo.h
+++ b/include/lsst/jointcal/Gtransfo.h
@@ -57,7 +57,7 @@ class GtransfoLin;
     providing inverseTransfo is obviously a very good idea. Before
     resorting to inverseTransfo, consider using
     StarMatchList::inverseTransfo().  GtransfoLin::inverted() and
-    TanPix2RaDec::inverted() exist.
+    TanPixelToRaDec::inverted() exist.
     The classes also provide derivation and linear approximation.
 
 */
@@ -552,7 +552,7 @@ class BaseTanWcs : public Gtransfo {
 public:
     using Gtransfo::apply;  // to unhide apply(const Point&)
 
-    BaseTanWcs(GtransfoLin const &pix2Tan, Point const &tangentPoint,
+    BaseTanWcs(GtransfoLin const &pixToTan, Point const &tangentPoint,
                const GtransfoPoly *corrections = nullptr);
 
     BaseTanWcs(const BaseTanWcs &original);
@@ -579,55 +579,57 @@ public:
 
     //! Get a transform from pixels to tangent plane (degrees)
     //! This is a linear transform plus the effects of the correction
-    virtual GtransfoPoly getPix2TangentPlane() const = 0;
+    virtual GtransfoPoly getPixelToTangentPlane() const = 0;
 
     //! Transform from pixels to tangent plane (degrees)
-    virtual void pix2TP(double xPixel, double yPixel, double &xTangentPlane, double &yTangentPlane) const = 0;
+    virtual void pixToTangentPlane(double xPixel, double yPixel, double &xTangentPlane,
+                                   double &yTangentPlane) const = 0;
 
     ~BaseTanWcs();
 
 protected:
-    GtransfoLin linPix2Tan;  // transform from pixels to tangent plane (degrees)
-                             // a linear approximation centered at the pixel and sky origins
+    GtransfoLin linPixelToTan;  // transform from pixels to tangent plane (degrees)
+                                // a linear approximation centered at the pixel and sky origins
     std::unique_ptr<GtransfoPoly> corr;
     double ra0, dec0;   // sky origin (radians)
     double cos0, sin0;  // cos(dec0), sin(dec0)
 };
 
-class TanRaDec2Pix;  // the inverse of TanPix2RaDec.
+class TanRaDecToPixel;  // the inverse of TanPixelToRaDec.
 
 //! the transformation that handles pix to sideral transfos (Gnomonic, possibly with polynomial distortions).
-class TanPix2RaDec : public BaseTanWcs {
+class TanPixelToRaDec : public BaseTanWcs {
 public:
     using Gtransfo::apply;  // to unhide apply(const Point&)
-    //! pix2Tan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
+    //! pixToTan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
     //! Corrections are applied between Lin and deprojection parts (as in Swarp).
-    TanPix2RaDec(GtransfoLin const &pix2Tan, Point const &tangentPoint,
-                 const GtransfoPoly *corrections = nullptr);
+    TanPixelToRaDec(GtransfoLin const &pixToTan, Point const &tangentPoint,
+                    const GtransfoPoly *corrections = nullptr);
 
     //! the transformation from pixels to tangent plane (degrees)
-    GtransfoPoly getPix2TangentPlane() const;
+    GtransfoPoly getPixelToTangentPlane() const;
 
     //! transforms from pixel space to tangent plane (degrees)
-    virtual void pix2TP(double xPixel, double yPixel, double &xTangentPlane, double &yTangentPlane) const;
+    virtual void pixToTangentPlane(double xPixel, double yPixel, double &xTangentPlane,
+                                   double &yTangentPlane) const;
 
-    TanPix2RaDec();
+    TanPixelToRaDec();
 
     //! composition with GtransfoLin
-    TanPix2RaDec operator*(GtransfoLin const &right) const;
+    TanPixelToRaDec operator*(GtransfoLin const &right) const;
 
     using Gtransfo::composeAndReduce;  // to unhide Gtransfo::composeAndReduce(Gtransfo const &)
     /// @copydoc Gtransfo::composeAndReduce
     std::unique_ptr<Gtransfo> composeAndReduce(GtransfoLin const &right) const;
 
     //! approximate inverse : it ignores corrections;
-    TanRaDec2Pix inverted() const;
+    TanRaDecToPixel inverted() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
     std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
 
-    //! Inverse transfo: returns a TanRaDec2Pix if there are no corrections, or the iterative solver if there
-    //! are.
+    //! Inverse transfo: returns a TanRaDecToPixel if there are no corrections, or the iterative solver if
+    //! there are.
     std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
 
     std::unique_ptr<Gtransfo> clone() const;
@@ -639,23 +641,24 @@ public:
 };
 
 //! Implements the (forward) SIP distorsion scheme
-class TanSipPix2RaDec : public BaseTanWcs {
+class TanSipPixelToRaDec : public BaseTanWcs {
 public:
-    //! pix2Tan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
+    //! pixToTan describes the transfo from pix to tangent plane (degrees). TangentPoint in degrees.
     //! Corrections are applied before Lin.
-    TanSipPix2RaDec(GtransfoLin const &pix2Tan, Point const &tangentPoint,
-                    const GtransfoPoly *corrections = nullptr);
+    TanSipPixelToRaDec(GtransfoLin const &pixToTan, Point const &tangentPoint,
+                       const GtransfoPoly *corrections = nullptr);
 
     //! the transformation from pixels to tangent plane (degrees)
-    GtransfoPoly getPix2TangentPlane() const;
+    GtransfoPoly getPixelToTangentPlane() const;
 
     //! transforms from pixel space to tangent plane (degrees)
-    virtual void pix2TP(double xPixel, double yPixel, double &xTangentPlane, double &yTangentPlane) const;
+    virtual void pixToTangentPlane(double xPixel, double yPixel, double &xTangentPlane,
+                                   double &yTangentPlane) const;
 
-    TanSipPix2RaDec();
+    TanSipPixelToRaDec();
 
-    //! Inverse transfo: returns a TanRaDec2Pix if there are no corrections, or the iterative solver if there
-    //! are.
+    //! Inverse transfo: returns a TanRaDecToPixel if there are no corrections, or the iterative solver if
+    //! there are.
     std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
 
     std::unique_ptr<Gtransfo> clone() const;
@@ -670,18 +673,18 @@ public:
 /*! this transfo does not implement corrections, since
    they are defined the other way around (from pixels to sky),
    and not invertible analytically. The inversion of tangent
-   point WCS (TanPix2RaDec) is obtained via inverseTransfo().
+   point WCS (TanPixelToRaDec) is obtained via inverseTransfo().
 */
 
-class TanRaDec2Pix : public Gtransfo {
+class TanRaDecToPixel : public Gtransfo {
 public:
     using Gtransfo::apply;  // to unhide apply(const Point&)
 
     //! assume degrees everywhere.
-    TanRaDec2Pix(GtransfoLin const &tan2Pix, Point const &tangentPoint);
+    TanRaDecToPixel(GtransfoLin const &tan2Pix, Point const &tangentPoint);
 
     //!
-    TanRaDec2Pix();
+    TanRaDecToPixel();
 
     //! The Linear part (corresponding to CD's and CRPIX's)
     GtransfoLin getLinPart() const;
@@ -699,12 +702,12 @@ public:
     void transformPosAndErrors(const FatPoint &in, FatPoint &out) const;
 
     //! exact typed inverse:
-    TanPix2RaDec inverted() const;
+    TanPixelToRaDec inverted() const;
 
     //! Overload the "generic routine" (available for all Gtransfo types
     std::unique_ptr<Gtransfo> roughInverse(const Frame &region) const;
 
-    //! Inverse transfo: returns a TanPix2RaDec.
+    //! Inverse transfo: returns a TanPixelToRaDec.
     std::unique_ptr<Gtransfo> inverseTransfo(const double precision, const Frame &region) const;
 
     void dump(std::ostream &stream) const;

--- a/include/lsst/jointcal/ProjectionHandler.h
+++ b/include/lsst/jointcal/ProjectionHandler.h
@@ -41,7 +41,7 @@ class CcdImage;
  * (where they are compared to transformed measurements)
  */
 struct ProjectionHandler {
-    virtual const std::shared_ptr<const Gtransfo> getSky2TP(const CcdImage &ccdImage) const = 0;
+    virtual const std::shared_ptr<const Gtransfo> getSkyToTangentPlane(const CcdImage &ccdImage) const = 0;
 
     virtual ~ProjectionHandler(){};
 };
@@ -55,7 +55,7 @@ class IdentityProjectionHandler : public ProjectionHandler {
     std::shared_ptr<GtransfoIdentity> id;
 
 public:
-    const std::shared_ptr<const Gtransfo> getSky2TP(const CcdImage &ccdImage) const { return id; };
+    const std::shared_ptr<const Gtransfo> getSkyToTangentPlane(const CcdImage &ccdImage) const { return id; };
 };
 
 /**
@@ -72,7 +72,7 @@ class OneTPPerVisitHandler : public ProjectionHandler {
 public:
     OneTPPerVisitHandler(const CcdImageList &ccdImageList);
 
-    const std::shared_ptr<const Gtransfo> getSky2TP(const CcdImage &ccdImage) const;
+    const std::shared_ptr<const Gtransfo> getSkyToTangentPlane(const CcdImage &ccdImage) const;
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/SimpleAstrometryMapping.h
+++ b/include/lsst/jointcal/SimpleAstrometryMapping.h
@@ -151,7 +151,7 @@ public:
     SimplePolyMapping(GtransfoLin const &CenterAndScale, GtransfoPoly const &gtransfo)
             : SimpleGtransfoMapping(gtransfo), _centerAndScale(CenterAndScale) {
         // We assume that the initialization was done properly, for example that
-        // gtransfo = pix2TP*CenterAndScale.inverted(), so we do not touch transfo.
+        // gtransfo = pixToTangentPlane*CenterAndScale.inverted(), so we do not touch transfo.
         /* store the (spatial) derivative of _centerAndScale. For the extra
            diagonal terms, just copied the ones in positionDerivatives */
         preDer(0, 0) = _centerAndScale.coeff(1, 0, 0);

--- a/include/lsst/jointcal/SimpleAstrometryModel.h
+++ b/include/lsst/jointcal/SimpleAstrometryModel.h
@@ -75,8 +75,8 @@ public:
     /*! the mapping of sky coordinates (i.e. the coordinate system
     in which fitted stars are reported) onto the Tangent plane
     (into which the pixel coordinates are transformed) */
-    const std::shared_ptr<Gtransfo const> getSky2TP(CcdImage const &ccdImage) const override {
-        return _sky2TP->getSky2TP(ccdImage);
+    const std::shared_ptr<Gtransfo const> getSkyToTangentPlane(CcdImage const &ccdImage) const override {
+        return _skyToTangentPlane->getSkyToTangentPlane(ccdImage);
     }
 
     //!
@@ -95,7 +95,7 @@ public:
 
 private:
     std::unordered_map<CcdImageKey, std::unique_ptr<SimpleGtransfoMapping>> _myMap;
-    const std::shared_ptr<ProjectionHandler const> _sky2TP;
+    const std::shared_ptr<ProjectionHandler const> _skyToTangentPlane;
 
     /// @copydoc AstrometryModel::findMapping
     AstrometryMapping *findMapping(CcdImage const &ccdImage) const override;

--- a/python/lsst/jointcal/astrometryModels.cc
+++ b/python/lsst/jointcal/astrometryModels.cc
@@ -49,7 +49,7 @@ void declareAstrometryModel(py::module &mod) {
     cls.def("getMapping", &AstrometryModel::getMapping, py::return_value_policy::reference_internal);
     cls.def("assignIndices", &AstrometryModel::assignIndices);
     cls.def("offsetParams", &AstrometryModel::offsetParams);
-    cls.def("getSky2TP", &AstrometryModel::getSky2TP);
+    cls.def("getSkyToTangentPlane", &AstrometryModel::getSkyToTangentPlane);
     cls.def("makeSkyWcs", &AstrometryModel::makeSkyWcs);
     cls.def("getTotalParameters", &AstrometryModel::getTotalParameters);
     cls.def("validate", &AstrometryModel::validate);

--- a/python/lsst/jointcal/ccdImage.cc
+++ b/python/lsst/jointcal/ccdImage.cc
@@ -74,8 +74,9 @@ void declareCcdImage(py::module &mod) {
     cls.def_property("commonTangentPoint", &CcdImage::getCommonTangentPoint, &CcdImage::setCommonTangentPoint,
                      py::return_value_policy::reference_internal);
 
-    cls.def("getSky2TP", &CcdImage::getSky2TP, py::return_value_policy::reference_internal);
-    cls.def("readWCS", &CcdImage::readWCS, py::return_value_policy::reference_internal);
+    cls.def("getSkyToTangentPlane", &CcdImage::getSkyToTangentPlane,
+            py::return_value_policy::reference_internal);
+    cls.def("getReadWcs", &CcdImage::getReadWcs, py::return_value_policy::reference_internal);
 }
 
 PYBIND11_MODULE(ccdImage, mod) { declareCcdImage(mod); }

--- a/python/lsst/jointcal/gtransfo.cc
+++ b/python/lsst/jointcal/gtransfo.cc
@@ -111,16 +111,17 @@ void declareBaseTanWcs(py::module &mod) {
     py::class_<BaseTanWcs, std::shared_ptr<BaseTanWcs>, Gtransfo> cls(mod, "BaseTanWcs");
 }
 
-void declareTanPix2RaDec(py::module &mod) {
-    py::class_<TanPix2RaDec, std::shared_ptr<TanPix2RaDec>, Gtransfo> cls(mod, "TanPix2RaDec");
+void declareTanPixelToRaDec(py::module &mod) {
+    py::class_<TanPixelToRaDec, std::shared_ptr<TanPixelToRaDec>, Gtransfo> cls(mod, "TanPixelToRaDec");
 }
 
-void declareTanRaDec2Pix(py::module &mod) {
-    py::class_<TanRaDec2Pix, std::shared_ptr<TanRaDec2Pix>, Gtransfo> cls(mod, "TanRaDec2Pix");
+void declareTanRaDecToPixel(py::module &mod) {
+    py::class_<TanRaDecToPixel, std::shared_ptr<TanRaDecToPixel>, Gtransfo> cls(mod, "TanRaDecToPixel");
 }
 
-void declareTanSipPix2RaDec(py::module &mod) {
-    py::class_<TanSipPix2RaDec, std::shared_ptr<TanSipPix2RaDec>, BaseTanWcs> cls(mod, "TanSipPix2RaDec");
+void declareTanSipPixelToRaDec(py::module &mod) {
+    py::class_<TanSipPixelToRaDec, std::shared_ptr<TanSipPixelToRaDec>, BaseTanWcs> cls(mod,
+                                                                                        "TanSipPixelToRaDec");
 }
 
 PYBIND11_MODULE(gtransfo, mod) {
@@ -136,9 +137,9 @@ PYBIND11_MODULE(gtransfo, mod) {
     declareGtransfoLinScale(mod);
     declareGtransfoSkyWcs(mod);
     declareBaseTanWcs(mod);
-    declareTanPix2RaDec(mod);
-    declareTanRaDec2Pix(mod);
-    declareTanSipPix2RaDec(mod);
+    declareTanPixelToRaDec(mod);
+    declareTanRaDecToPixel(mod);
+    declareTanSipPixelToRaDec(mod);
 
     // utility functions
     mod.def("inversePolyTransfo", &inversePolyTransfo, "forward"_a, "domain"_a, "precision"_a,

--- a/src/ConstrainedAstrometryModel.cc
+++ b/src/ConstrainedAstrometryModel.cc
@@ -67,7 +67,7 @@ namespace jointcal {
 ConstrainedAstrometryModel::ConstrainedAstrometryModel(
         CcdImageList const &ccdImageList, std::shared_ptr<ProjectionHandler const> projectionHandler,
         int chipOrder, int visitOrder)
-        : _sky2TP(projectionHandler) {
+        : _skyToTangentPlane(projectionHandler) {
     // keep track of which chip we want to hold fixed (the one closest to the middle of the focal plane)
     double minRadius2 = std::numeric_limits<double>::infinity();
     CcdIdType constrainedChip = -1;
@@ -228,7 +228,7 @@ int ConstrainedAstrometryModel::getTotalParameters() const {
 }
 
 std::shared_ptr<afw::geom::SkyWcs> ConstrainedAstrometryModel::makeSkyWcs(CcdImage const &ccdImage) const {
-    auto proj = std::dynamic_pointer_cast<const TanRaDec2Pix>(getSky2TP(ccdImage));
+    auto proj = std::dynamic_pointer_cast<const TanRaDecToPixel>(getSkyToTangentPlane(ccdImage));
     jointcal::Point tangentPoint(proj->getTangentPoint());
 
     auto imageFrame = ccdImage.getImageFrame();

--- a/src/Projectionhandler.cc
+++ b/src/Projectionhandler.cc
@@ -36,11 +36,12 @@ class Mapping;
 OneTPPerVisitHandler::OneTPPerVisitHandler(const CcdImageList &ccdImageList) {
     for (auto const &i : ccdImageList) {
         const CcdImage &im = *i;
-        if (tMap.find(im.getVisit()) == tMap.end()) tMap[im.getVisit()] = im.getSky2TP()->clone();
+        if (tMap.find(im.getVisit()) == tMap.end()) tMap[im.getVisit()] = im.getSkyToTangentPlane()->clone();
     }
 }
 
-const std::shared_ptr<const Gtransfo> OneTPPerVisitHandler::getSky2TP(const CcdImage &ccdImage) const {
+const std::shared_ptr<const Gtransfo> OneTPPerVisitHandler::getSkyToTangentPlane(
+        const CcdImage &ccdImage) const {
     auto it = tMap.find(ccdImage.getVisit());
     if (it == tMap.end()) return nullptr;
     return it->second;

--- a/src/SimpleAstrometryModel.cc
+++ b/src/SimpleAstrometryModel.cc
@@ -45,7 +45,7 @@ namespace jointcal {
 SimpleAstrometryModel::SimpleAstrometryModel(CcdImageList const &ccdImageList,
                                              const std::shared_ptr<ProjectionHandler const> projectionHandler,
                                              bool initFromWcs, unsigned nNotFit, unsigned order)
-        : _sky2TP(projectionHandler)
+        : _skyToTangentPlane(projectionHandler)
 
 {
     unsigned count = 0;
@@ -87,7 +87,7 @@ SimpleAstrometryModel::SimpleAstrometryModel(CcdImageList const &ccdImageList,
             const Frame &frame = im.getImageFrame();
             GtransfoLin shiftAndNormalize = normalizeCoordinatesTransfo(frame);
             if (initFromWcs) {
-                pol = GtransfoPoly(im.getPix2TangentPlane(), frame, order);
+                pol = GtransfoPoly(im.getPixelToTangentPlane().get(), frame, order);
                 pol = pol * shiftAndNormalize.inverted();
             }
             _myMap[im.getHashKey()] =
@@ -139,7 +139,7 @@ const Gtransfo &SimpleAstrometryModel::getTransfo(CcdImage const &ccdImage) cons
 }
 
 std::shared_ptr<afw::geom::SkyWcs> SimpleAstrometryModel::makeSkyWcs(CcdImage const &ccdImage) const {
-    auto proj = std::dynamic_pointer_cast<const TanRaDec2Pix>(getSky2TP(ccdImage));
+    auto proj = std::dynamic_pointer_cast<const TanRaDecToPixel>(getSkyToTangentPlane(ccdImage));
     jointcal::Point tangentPoint(proj->getTangentPoint());
 
     auto polyMap = getTransfo(ccdImage).toAstMap(ccdImage.getImageFrame());

--- a/tests/test_astrometryModel.py
+++ b/tests/test_astrometryModel.py
@@ -205,7 +205,7 @@ class AstrometryModelTestBase:
             See `lsst.afw.geom.utils.assertPairsAlmostEqual`.
         """
         skyWcs = model.makeSkyWcs(ccdImage)
-        skyToTangentPlane = model.getSky2TP(ccdImage)
+        skyToTangentPlane = model.getSkyToTangentPlane(ccdImage)
         mapping = model.getMapping(ccdImage)
 
         bbox = ccdImage.getDetector().getBBox()

--- a/tests/test_ccdImage.py
+++ b/tests/test_ccdImage.py
@@ -83,7 +83,7 @@ class CcdImageTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(refStars, 0)
 
         # Make a fake reference catalog; will match the catalog one-to-one.
-        skyWcs = ccdImage.readWCS().getSkyWcs()
+        skyWcs = ccdImage.getReadWcs().getSkyWcs()
         self.refCat = testUtils.createFakeCatalog(nStars, self.bbox, "refFlux", skyWcs=skyWcs, refCat=True)
         # associate the reference stars
         self.associations.collectRefStars(self.refCat, matchCut, 'refFlux_instFlux')

--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -58,7 +58,7 @@ static void __attribute__((constructor)) trapfpe() {
 namespace jointcal = lsst::jointcal;
 namespace afwImg = lsst::afw::image;
 
-/* Test jointcal::TanSipPix2RaDec::apply against afwImg::Wcs::pixelToSky */
+/* Test jointcal::TanSipPixelToRaDec::apply against afwImg::Wcs::pixelToSky */
 
 BOOST_AUTO_TEST_SUITE(test_transfos)
 


### PR DESCRIPTION
* Rename sky2TP->skyToTangentPlane
* Rename other ccdImage tangent plane/pixel methods and members: `X2Y`->`XToY`
  and cleanup TP->TangentPlane, CTP->CommonTangentPlane, etc.

Rename gtransfo subclasses:
 * TanPix2RaDec->TanPixelToRaDec
 * TanRaDec2Pix->TanRaDecToPixel
 * TanSipPix2RaDec->TanSipPixelToRaDec