### PR TITLE
DM-18895: use bigger index types

### DIFF
--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -138,13 +138,13 @@ private:
     std::shared_ptr<AstrometryModel> _astrometryModel;
     double _referenceColor, _sigCol;  // average and r.m.s color
     double _refractionCoefficient;    // fit parameter
-    unsigned int _refracPosInMatrix;  // where it stands
+    Eigen::Index _refracPosInMatrix;  // where it stands
     double _JDRef;                    // average Julian date
 
     // counts in parameter subsets.
-    unsigned int _nParDistortions;
-    unsigned int _nParPositions;
-    unsigned int _nParRefrac;
+    std::size_t _nParDistortions;
+    std::size_t _nParPositions;
+    std::size_t _nParRefrac;
 
     double _posError;  // constant term on error on position (in pixel unit)
 
@@ -160,7 +160,7 @@ private:
     void accumulateStatRefStars(Chi2Accumulator &accum) const override;
 
     void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                  std::vector<unsigned> &indices) const override;
+                                  IndexVector &indices) const override;
 
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const &sky2TP,
                               Point const &refractionVector, double refractionCoeff, double mjd) const;

--- a/include/lsst/jointcal/AstrometryMapping.h
+++ b/include/lsst/jointcal/AstrometryMapping.h
@@ -38,11 +38,11 @@ class Point;
 class AstrometryMapping {
 public:
     //! Number of parameters in total
-    virtual unsigned getNpar() const = 0;
+    virtual std::size_t getNpar() const = 0;
 
     /// Sets how this set of parameters (of length Npar()) map into the "grand" fit
     /// Expects that indices has enough space reserved.
-    virtual void getMappingIndices(std::vector<unsigned> &indices) const = 0;
+    virtual void getMappingIndices(IndexVector &indices) const = 0;
 
     //! Actually applies the AstrometryMapping and evaluates the derivatives w.r.t the fitted parameters.
     /*! This is grouped into a single call because for most models,

--- a/include/lsst/jointcal/AstrometryModel.h
+++ b/include/lsst/jointcal/AstrometryModel.h
@@ -51,14 +51,14 @@ public:
     AstrometryModel(LOG_LOGGER log) : _log(log) {}
 
     /// Return the number of parameters in the mapping of CcdImage
-    int getNpar(CcdImage const &ccdImage) const { return findMapping(ccdImage)->getNpar(); }
+    std::size_t getNpar(CcdImage const &ccdImage) const { return findMapping(ccdImage)->getNpar(); }
 
     //! Mapping associated to a given CcdImage
     virtual const AstrometryMapping *getMapping(CcdImage const &) const = 0;
 
     //! Assign indices to parameters involved in mappings, starting at firstIndex. Returns the highest
     //! assigned index.
-    virtual unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) = 0;
+    virtual Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) = 0;
 
     /**
      * Offset the parameters by the provided amounts (by -delta).
@@ -88,7 +88,7 @@ public:
     virtual void freezeErrorTransform() = 0;
 
     /// Return the total number of parameters in this model.
-    virtual int getTotalParameters() const = 0;
+    virtual std::size_t getTotalParameters() const = 0;
 
     virtual ~AstrometryModel(){};
 

--- a/include/lsst/jointcal/AstrometryTransform.h
+++ b/include/lsst/jointcal/AstrometryTransform.h
@@ -162,10 +162,10 @@ public:
     void offsetParams(Eigen::VectorXd const &delta);
 
     //!
-    virtual double paramRef(const int i) const;
+    virtual double paramRef(Eigen::Index const i) const;
 
     //!
-    virtual double &paramRef(const int i);
+    virtual double &paramRef(Eigen::Index const i);
 
     //! Derivative w.r.t parameters. Derivatives should be al least 2*NPar long. first Npar, for x, last Npar
     //! for y.
@@ -177,7 +177,7 @@ public:
     virtual std::unique_ptr<AstrometryTransform> roughInverse(const Frame &region) const;
 
     //! returns the number of parameters (to compute chi2's)
-    virtual int getNpar() const { return 0; }
+    virtual std::size_t getNpar() const { return 0; }
 
     /**
      * Create an equivalent AST mapping for this transformation, including an analytic inverse if possible.
@@ -240,7 +240,7 @@ public:
 
     void dump(std::ostream &stream = std::cout) const override { stream << "x' = x\ny' = y" << std::endl; }
 
-    int getNpar() const override { return 0; }
+    std::size_t getNpar() const override { return 0; }
 
     std::unique_ptr<AstrometryTransform> clone() const override {
         return std::unique_ptr<AstrometryTransform>(new AstrometryTransformIdentity);
@@ -285,11 +285,11 @@ public:
      *
      * @param order The highest total power (x+y) of monomials of this polynomial.
      */
-    AstrometryTransformPolynomial(const unsigned order = 1);
+    AstrometryTransformPolynomial(std::size_t order = 1);
 
     //! Constructs a "polynomial image" from an existing transform, over a specified domain
-    AstrometryTransformPolynomial(const AstrometryTransform *transform, const Frame &frame, unsigned order,
-                                  unsigned nPoint = 1000);
+    AstrometryTransformPolynomial(const AstrometryTransform *transform, const Frame &frame,
+                                  std::size_t order, std::size_t nPoint = 1000);
 
     /**
      * Constructs a polynomial approximation to an afw::geom::TransformPoint2ToPoint2.
@@ -300,13 +300,13 @@ public:
      * @param[in] nSteps The number of sample points per axis (nSteps^2 total points).
      */
     AstrometryTransformPolynomial(std::shared_ptr<afw::geom::TransformPoint2ToPoint2> transform,
-                                  jointcal::Frame const &domain, unsigned const order,
-                                  unsigned const nSteps = 50);
+                                  jointcal::Frame const &domain, std::size_t order,
+                                  std::size_t nSteps = 50);
 
     /// Sets the polynomial order (the highest sum of exponents of the largest monomial).
-    void setOrder(const unsigned order);
+    void setOrder(std::size_t order);
     /// Returns the polynomial order.
-    unsigned getOrder() const { return _order; }
+    std::size_t getOrder() const { return _order; }
 
     using AstrometryTransform::apply;  // to unhide AstrometryTransform::apply(Point const &)
 
@@ -320,7 +320,7 @@ public:
     virtual void transformPosAndErrors(const FatPoint &in, FatPoint &out) const override;
 
     //! total number of parameters
-    int getNpar() const override { return 2 * _nterms; }
+    std::size_t getNpar() const override { return 2 * _nterms; }
 
     //! print out of coefficients in a readable form.
     void dump(std::ostream &stream = std::cout) const override;
@@ -348,21 +348,21 @@ public:
     }
 
     //! access to coefficients (read only)
-    double coeff(const unsigned powX, const unsigned powY, const unsigned whichCoord) const;
+    double coeff(std::size_t powX, std::size_t powY, std::size_t whichCoord) const;
 
     //! write access
-    double &coeff(const unsigned powX, const unsigned powY, const unsigned whichCoord);
+    double &coeff(std::size_t powX, std::size_t powY, std::size_t whichCoord);
 
     //! read access, zero if beyond order
-    double coeffOrZero(const unsigned powX, const unsigned powY, const unsigned whichCoord) const;
+    double coeffOrZero(std::size_t powX, std::size_t powY, std::size_t whichCoord) const;
 
     double determinant() const;
 
     //!
-    double paramRef(const int i) const override;
+    double paramRef(Eigen::Index const i) const override;
 
     //!
-    double &paramRef(const int i) override;
+    double &paramRef(Eigen::Index const i) override;
 
     //! Derivative w.r.t parameters. Derivatives should be al least 2*NPar long. first Npar, for x, last Npar
     //! for y.
@@ -378,8 +378,8 @@ private:
     double computeFit(StarMatchList const &starMatchList, AstrometryTransform const &shiftToCenter,
                       const bool useErrors);
 
-    unsigned _order;              // The highest sum of exponents of the largest monomial.
-    unsigned _nterms;             // number of parameters per coordinate
+    std::size_t _order;              // The highest sum of exponents of the largest monomial.
+    std::size_t _nterms;             // number of parameters per coordinate
     std::vector<double> _coeffs;  // the actual coefficients
                                   // both polynomials in a single vector to speed up allocation and copies
 
@@ -416,8 +416,8 @@ private:
 std::shared_ptr<AstrometryTransformPolynomial> inversePolyTransform(AstrometryTransform const &forward,
                                                                     Frame const &domain,
                                                                     double const precision,
-                                                                    int const maxOrder = 9,
-                                                                    unsigned const nSteps = 50);
+                                                                    std::size_t maxOrder = 9,
+                                                                    std::size_t nSteps = 50);
 
 AstrometryTransformLinear normalizeCoordinatesTransform(const Frame &frame);
 
@@ -484,7 +484,7 @@ protected:
     friend class AstrometryTransformPolynomial;  // // for AstrometryTransform::Derivative
 
 private:
-    void setOrder(const unsigned order);  // to hide AstrometryTransformPolynomial::setOrder
+    void setOrder(std::size_t order);  // to hide AstrometryTransformPolynomial::setOrder
 };
 
 /*=============================================================*/
@@ -500,7 +500,7 @@ public:
             : AstrometryTransformLinear(point.x, point.y, 1., 0., 0., 1.){};
     double fit(StarMatchList const &starMatchList);
 
-    int getNpar() const { return 2; }
+    std::size_t getNpar() const { return 2; }
 };
 
 /*=============================================================*/
@@ -514,7 +514,7 @@ public:
                                  const double scaleFactor = 1.0);
     double fit(StarMatchList const &starMatchList);
 
-    int getNpar() const { return 4; }
+    std::size_t getNpar() const { return 4; }
 };
 
 /*=============================================================*/
@@ -530,7 +530,7 @@ public:
     AstrometryTransformLinearScale(const double scaleX, const double scaleY)
             : AstrometryTransformLinear(0.0, 0.0, scaleX, 0., 0., scaleY){};
 
-    int getNpar() const { return 2; }
+    std::size_t getNpar() const { return 2; }
 };
 
 /**

--- a/include/lsst/jointcal/Chi2.h
+++ b/include/lsst/jointcal/Chi2.h
@@ -43,7 +43,7 @@ namespace jointcal {
  */
 class Chi2Accumulator {
 public:
-    virtual void addEntry(double inc, unsigned dof, std::shared_ptr<BaseStar> star) = 0;
+    virtual void addEntry(double inc, std::size_t dof, std::shared_ptr<BaseStar> star) = 0;
 
     virtual ~Chi2Accumulator(){};
 };
@@ -52,7 +52,7 @@ public:
 class Chi2Statistic : public Chi2Accumulator {
 public:
     double chi2;
-    unsigned ndof;
+    std::size_t ndof;
 
     Chi2Statistic() : chi2(0), ndof(0){};
 
@@ -62,7 +62,7 @@ public:
     }
 
     // Addentry has an ignored third argument in order to make it compatible with Chi2List.
-    void addEntry(double inc, unsigned dof, std::shared_ptr<BaseStar>) override {
+    void addEntry(double inc, std::size_t dof, std::shared_ptr<BaseStar>) override {
         chi2 += inc;
         ndof += dof;
     }
@@ -99,7 +99,7 @@ struct Chi2Star {
 /// Structure to accumulate the chi2 contributions per each star (to help find outliers).
 class Chi2List : public Chi2Accumulator, public std::vector<Chi2Star> {
 public:
-    void addEntry(double chi2, unsigned ndof, std::shared_ptr<BaseStar> star) override {
+    void addEntry(double chi2, std::size_t ndof, std::shared_ptr<BaseStar> star) override {
         push_back(Chi2Star(chi2, std::move(star)));
     }
 

--- a/include/lsst/jointcal/ChipVisitAstrometryMapping.h
+++ b/include/lsst/jointcal/ChipVisitAstrometryMapping.h
@@ -48,9 +48,9 @@ public:
     ChipVisitAstrometryMapping &operator=(ChipVisitAstrometryMapping &&) = delete;
 
     //!
-    unsigned getNpar() const;
+    std::size_t getNpar() const;
 
-    void getMappingIndices(std::vector<unsigned> &indices) const;
+    void getMappingIndices(IndexVector &indices) const;
 
     //!
     void computeTransformAndDerivatives(FatPoint const &where, FatPoint &outPoint, Eigen::MatrixX2d &H) const;
@@ -86,7 +86,7 @@ private:
     void setWhatToFit(const bool fittingT1, const bool fittingT2);
 
     std::shared_ptr<SimpleAstrometryMapping> _m1, _m2;
-    unsigned _nPar1, _nPar2;
+    Eigen::Index _nPar1, _nPar2;
     struct tmpVars  // just there to get around constness issues
     {
         Eigen::MatrixX2d h1, h2;

--- a/include/lsst/jointcal/ConstrainedAstrometryModel.h
+++ b/include/lsst/jointcal/ConstrainedAstrometryModel.h
@@ -79,7 +79,7 @@ public:
      * Positions the various parameter sets into the parameter vector, starting at
      * firstIndex.
      */
-    unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) override;
+    Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) override;
 
     /**
      * Dispaches the offsets after a fit step into the actual locations of
@@ -94,7 +94,7 @@ public:
     void freezeErrorTransform() override;
 
     /// @copydoc AstrometryModel::getTotalParameters
-    int getTotalParameters() const override;
+    std::size_t getTotalParameters() const override;
 
     //! Access to mappings
     AstrometryTransform const &getChipTransform(CcdIdType const chip) const;

--- a/include/lsst/jointcal/ConstrainedPhotometryModel.h
+++ b/include/lsst/jointcal/ConstrainedPhotometryModel.h
@@ -71,7 +71,7 @@ public:
     ConstrainedPhotometryModel &operator=(ConstrainedPhotometryModel &&) = delete;
 
     /// @copydoc PhotometryModel::assignIndices
-    unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) override;
+    Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) override;
 
     /// @copydoc PhotometryModel::offsetParams
     void offsetParams(Eigen::VectorXd const &delta) override;
@@ -80,10 +80,10 @@ public:
     void freezeErrorTransform() override;
 
     /// @copydoc PhotometryModel::getMappingIndices
-    void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const override;
+    void getMappingIndices(CcdImage const &ccdImage, IndexVector &indices) const override;
 
     /// @copydoc PhotometryModel::getTotalParameters
-    int getTotalParameters() const override;
+    std::size_t getTotalParameters() const override;
 
     /// @copydoc PhotometryModel::computeParameterDerivatives
     void computeParameterDerivatives(MeasuredStar const &measuredStar, CcdImage const &ccdImage,

--- a/include/lsst/jointcal/Eigenstuff.h
+++ b/include/lsst/jointcal/Eigenstuff.h
@@ -32,7 +32,10 @@
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, 2> MatrixX2d;
 
-typedef Eigen::SparseMatrix<double> SparseMatrixD;
+typedef Eigen::SparseMatrix<double, 0, Eigen::Index> SparseMatrixD;
+
+// To make our indices and triplets conform to Eigen's desire for taking a signed type
+typedef std::vector<std::ptrdiff_t> IndexVector;
 
 /* Cholesky factorization class using cholmod, with the small-rank update capability.
  *
@@ -71,12 +74,13 @@ public:
         cholmod_sparse C_cs = viewAsCholmod(H);
         /* We have to apply the magic permutation to the update matrix,
         read page 117 of Cholmod UserGuide.pdf */
+        // Using cholmod_l_* functions instead of cholmod_* because index is Eigen::Index instead of int.
         cholmod_sparse *C_cs_perm =
-                cholmod_submatrix(&C_cs, (int *)Base::m_cholmodFactor->Perm, Base::m_cholmodFactor->n,
-                                  nullptr, -1, true, true, &this->cholmod());
+                cholmod_l_submatrix(&C_cs, (Eigen::Index*)Base::m_cholmodFactor->Perm,
+                                  Base::m_cholmodFactor->n, nullptr, -1, true, true, &this->cholmod());
         assert(C_cs_perm);
-        int isOk = cholmod_updown(UpOrDown, C_cs_perm, Base::m_cholmodFactor, &this->cholmod());
-        cholmod_free_sparse(&C_cs_perm, &this->cholmod());
+        int isOk = cholmod_l_updown(UpOrDown, C_cs_perm, Base::m_cholmodFactor, &this->cholmod());
+        cholmod_l_free_sparse(&C_cs_perm, &this->cholmod());
         if (!isOk) {
             throw(LSST_EXCEPT(lsst::pex::exceptions::RuntimeError, "cholmod_update failed!"));
         }

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <fstream>
 
+#include "Eigen/Core"
 #include "lsst/jointcal/BaseStar.h"
 #include "lsst/jointcal/StarList.h"
 
@@ -99,10 +100,10 @@ public:
     void addMagMeasurement(double magValue, double magWeight);
 
     //! index is a value that a fit can set and reread....
-    void setIndexInMatrix(const unsigned& index) { _indexInMatrix = index; };
+    void setIndexInMatrix(Eigen::Index const index) { _indexInMatrix = index; };
 
     //!
-    int getIndexInMatrix() const { return _indexInMatrix; }
+    Eigen::Index getIndexInMatrix() const { return _indexInMatrix; }
 
     //! Set the astrometric reference star associated with this star.
     void setRefStar(const RefStar* _refStar);
@@ -111,7 +112,7 @@ public:
     const RefStar* getRefStar() const { return _refStar; };
 
 private:
-    unsigned _indexInMatrix;
+    Eigen::Index _indexInMatrix;
     int _measurementCount;
     const RefStar* _refStar;
 };

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -153,9 +153,9 @@ protected:
     std::shared_ptr<Associations> _associations;
     std::string _whatToFit;
 
-    int _lastNTrip;  // last triplet count, used to speed up allocation
-    unsigned int _nParTot;
-    unsigned _nMeasuredStars;
+    Eigen::Index _lastNTrip;  // last triplet count, used to speed up allocation
+    Eigen::Index _nParTot;
+    Eigen::Index _nMeasuredStars;
 
     // lsst.logging instance, to be created by subclass so that messages have consistent name while fitting.
     LOG_LOGGER _log;
@@ -182,7 +182,8 @@ protected:
      *
      * @return     Total number of outliers that were removed.
      */
-    unsigned findOutliers(double nSigmaCut, MeasuredStarList &msOutliers, FittedStarList &fsOutliers) const;
+    std::size_t findOutliers(double nSigmaCut, MeasuredStarList &msOutliers,
+                             FittedStarList &fsOutliers) const;
 
     /**
      * Contributions to derivatives from (presumably) outlier terms. No
@@ -199,7 +200,7 @@ protected:
 
     /// Set the indices of a measured star from the full matrix, for outlier removal.
     virtual void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                          std::vector<unsigned> &indices) const = 0;
+                                          IndexVector &indices) const = 0;
 
     /// Compute the chi2 (per star or total, depending on which Chi2Accumulator is used) for measurements.
     virtual void accumulateStatImageList(CcdImageList const &ccdImageList, Chi2Accumulator &accum) const = 0;

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -99,15 +99,15 @@ private:
     std::shared_ptr<PhotometryModel> _photometryModel;
 
     // counts in parameter subsets.
-    unsigned int _nParModel;
-    unsigned int _nParFluxes;
+    std::size_t _nParModel;
+    std::size_t _nParFluxes;
 
     void accumulateStatImageList(CcdImageList const &ccdImageList, Chi2Accumulator &accum) const override;
 
     void accumulateStatRefStars(Chi2Accumulator &accum) const override;
 
     void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                  std::vector<unsigned> &indices) const override;
+                                  IndexVector &indices) const override;
 
     void leastSquareDerivativesMeasurement(CcdImage const &ccdImage, TripletList &tripletList,
                                            Eigen::VectorXd &grad,

--- a/include/lsst/jointcal/PhotometryMapping.h
+++ b/include/lsst/jointcal/PhotometryMapping.h
@@ -53,7 +53,7 @@ public:
     PhotometryMappingBase &operator=(PhotometryMappingBase &&) = delete;
 
     /// Number of total parameters in this mapping
-    virtual unsigned getNpar() const = 0;
+    virtual std::size_t getNpar() const = 0;
 
     /**
      * Return the on-sky transformed flux for measuredStar on ccdImage.
@@ -106,20 +106,20 @@ public:
      * Gets how this set of parameters (of length getNpar()) map into the "grand" fit.
      * Expects that indices has enough space reserved.
      */
-    virtual void getMappingIndices(std::vector<unsigned> &indices) const = 0;
+    virtual void getMappingIndices(IndexVector &indices) const = 0;
 
     /// Dump the contents of the transforms, for debugging.
     virtual void dump(std::ostream &stream = std::cout) const = 0;
 
     /// Get the index of this mapping in the grand fit.
-    unsigned getIndex() { return index; }
+    Eigen::Index getIndex() { return index; }
 
     /// Set the index of this mapping in the grand fit.
-    void setIndex(unsigned i) { index = i; }
+    void setIndex(Eigen::Index i) { index = i; }
 
 protected:
     // Start index of this mapping in the "grand" fit
-    unsigned index;
+    Eigen::Index index;
     // Should this mapping be varied during fitting?
     bool fixed;
 };
@@ -138,7 +138,7 @@ public:
             : PhotometryMappingBase(), _transform(std::move(transform)), _transformErrors(_transform) {}
 
     /// @copydoc PhotometryMappingBase::getNpar
-    unsigned getNpar() const override {
+    std::size_t getNpar() const override {
         if (fixed) {
             return 0;
         } else {
@@ -183,9 +183,9 @@ public:
     Eigen::VectorXd getParameters() override { return _transform->getParameters(); }
 
     /// @copydoc PhotometryMappingBase::getMappingIndices
-    void getMappingIndices(std::vector<unsigned> &indices) const override {
+    void getMappingIndices(IndexVector &indices) const override {
         if (indices.size() < getNpar()) indices.resize(getNpar());
-        for (unsigned k = 0; k < getNpar(); ++k) {
+        for (std::size_t k = 0; k < getNpar(); ++k) {
             indices[k] = index + k;
         }
     }
@@ -221,7 +221,7 @@ public:
               _visitMapping(std::move(visitMapping)) {}
 
     /// @copydoc PhotometryMappingBase::getNpar
-    unsigned getNpar() const override { return _nParChip + _nParVisit; }
+    std::size_t getNpar() const override { return _nParChip + _nParVisit; }
 
     /// @copydoc PhotometryMappingBase::transform
     double transform(MeasuredStar const &measuredStar, double value) const override {
@@ -244,7 +244,7 @@ public:
     }
 
     /// @copydoc PhotometryMappingBase::getMappingIndices
-    void getMappingIndices(std::vector<unsigned> &indices) const override;
+    void getMappingIndices(IndexVector &indices) const override;
 
     /**
      * Set whether to fit chips or visits.
@@ -268,12 +268,12 @@ public:
     std::shared_ptr<PhotometryMapping> getChipMapping() const { return _chipMapping; }
     std::shared_ptr<PhotometryMapping> getVisitMapping() const { return _visitMapping; }
 
-    unsigned getNParChip() const { return _nParChip; }
-    unsigned getNParVisit() const { return _nParVisit; }
+    std::size_t getNParChip() const { return _nParChip; }
+    std::size_t getNParVisit() const { return _nParVisit; }
 
 protected:
     // These are either transform.getNpar() or 0, depending on whether we are fitting that component or not.
-    unsigned _nParChip, _nParVisit;
+    std::size_t _nParChip, _nParVisit;
 
     // the actual transformation to be fit
     std::shared_ptr<PhotometryMapping> _chipMapping;

--- a/include/lsst/jointcal/PhotometryModel.h
+++ b/include/lsst/jointcal/PhotometryModel.h
@@ -57,7 +57,7 @@ public:
      *
      * @return     The highest assigned index.
      */
-    virtual unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) = 0;
+    virtual Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) = 0;
 
     /**
      * Offset the parameters by the provided amounts (by -delta).
@@ -126,7 +126,7 @@ public:
      * @param[in]  ccdImage  The ccdImage to look up.
      * @param[out] indices   The indices of the mapping associated with ccdImage.
      */
-    virtual void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const = 0;
+    virtual void getMappingIndices(CcdImage const &ccdImage, IndexVector &indices) const = 0;
 
     /**
      * Compute the parametric derivatives of this model.
@@ -150,7 +150,7 @@ public:
     virtual std::shared_ptr<afw::image::PhotoCalib> toPhotoCalib(CcdImage const &ccdImage) const = 0;
 
     /// Return the number of parameters in the mapping of CcdImage
-    unsigned getNpar(CcdImage const &ccdImage) const { return findMapping(ccdImage)->getNpar(); }
+    std::size_t getNpar(CcdImage const &ccdImage) const { return findMapping(ccdImage)->getNpar(); }
 
     /// Get the mapping associated with ccdImage.
     PhotometryMappingBase const &getMapping(CcdImage const &ccdImage) const {
@@ -158,7 +158,7 @@ public:
     }
 
     /// Return the total number of parameters in this model.
-    virtual int getTotalParameters() const = 0;
+    virtual std::size_t getTotalParameters() const = 0;
 
     /// Dump the contents of the transforms, for debugging.
     virtual void dump(std::ostream &stream = std::cout) const = 0;

--- a/include/lsst/jointcal/PhotometryTransform.h
+++ b/include/lsst/jointcal/PhotometryTransform.h
@@ -74,7 +74,7 @@ public:
     }
 
     /// Return the number of parameters (used to compute chisq)
-    virtual int getNpar() const = 0;
+    virtual std::size_t getNpar() const = 0;
 
     /**
      * Offset the parameters by some (negative) amount during fitting.
@@ -115,7 +115,7 @@ public:
     void dump(std::ostream &stream = std::cout) const override { stream << std::setprecision(10) << _value; }
 
     /// @copydoc PhotometryTransform::getNpar
-    int getNpar() const override { return 1; }
+    std::size_t getNpar() const override { return 1; }
 
     /// @copydoc PhotometryTransform::offsetParams
     void offsetParams(Eigen::VectorXd const &delta) override { _value -= delta[0]; };
@@ -245,7 +245,7 @@ public:
     void dump(std::ostream &stream = std::cout) const override { stream << _coefficients; }
 
     /// @copydoc PhotometryTransform::getNpar
-    int getNpar() const override { return _nParameters; }
+    std::size_t getNpar() const override { return _nParameters; }
 
     /// @copydoc PhotometryTransform::offsetParams
     void offsetParams(Eigen::VectorXd const &delta) override;

--- a/include/lsst/jointcal/SimpleAstrometryMapping.h
+++ b/include/lsst/jointcal/SimpleAstrometryMapping.h
@@ -66,7 +66,7 @@ public:
     // interface Mapping functions:
 
     //!
-    unsigned getNpar() const {
+    std::size_t getNpar() const {
         if (toBeFit)
             return transform->getNpar();
         else
@@ -74,9 +74,9 @@ public:
     }
 
     //!
-    void getMappingIndices(std::vector<unsigned> &indices) const {
+    void getMappingIndices(IndexVector &indices) const {
         if (indices.size() < getNpar()) indices.resize(getNpar());
-        for (unsigned k = 0; k < getNpar(); ++k) indices[k] = index + k;
+        for (std::size_t k = 0; k < getNpar(); ++k) indices[k] = index + k;
     }
 
     //!
@@ -110,10 +110,10 @@ public:
     }
 
     //! position of the parameters within the grand fitting scheme
-    unsigned getIndex() const { return index; }
+    Eigen::Index getIndex() const { return index; }
 
     //!
-    void setIndex(unsigned i) { index = i; }
+    void setIndex(Eigen::Index i) { index = i; }
 
     virtual void computeTransformAndDerivatives(FatPoint const &where, FatPoint &outPoint,
                                                 Eigen::MatrixX2d &H) const {
@@ -132,7 +132,7 @@ public:
 protected:
     // Whether this Mapping is fit as part of a Model.
     bool toBeFit;
-    unsigned index;
+    Eigen::Index index;
     /* inheritance may also work. Perhaps with some trouble because
        some routines in Mapping and AstrometryTransform have the same name */
     std::shared_ptr<AstrometryTransform> transform;

--- a/include/lsst/jointcal/SimpleAstrometryModel.h
+++ b/include/lsst/jointcal/SimpleAstrometryModel.h
@@ -76,7 +76,7 @@ public:
     const AstrometryMapping *getMapping(CcdImage const &) const override;
 
     //! Positions the various parameter sets into the parameter vector, starting at firstIndex
-    unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) override;
+    Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) override;
 
     // dispaches the offsets after a fit step into the actual locations of parameters
     void offsetParams(Eigen::VectorXd const &delta) override;
@@ -93,7 +93,7 @@ public:
     void freezeErrorTransform() override;
 
     /// @copydoc AstrometryModel::getTotalParameters
-    int getTotalParameters() const override;
+    std::size_t getTotalParameters() const override;
 
     //! Access to mappings
     AstrometryTransform const &getTransform(CcdImage const &ccdImage) const;

--- a/include/lsst/jointcal/SimplePhotometryModel.h
+++ b/include/lsst/jointcal/SimplePhotometryModel.h
@@ -54,7 +54,7 @@ public:
     SimplePhotometryModel &operator=(SimplePhotometryModel &&) = delete;
 
     /// @copydoc PhotometryModel::assignIndices
-    unsigned assignIndices(std::string const &whatToFit, unsigned firstIndex) override;
+    Eigen::Index assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) override;
 
     /// @copydoc PhotometryModel::offsetParams
     void offsetParams(Eigen::VectorXd const &delta) override;
@@ -63,10 +63,10 @@ public:
     void freezeErrorTransform() override;
 
     /// @copydoc PhotometryModel::getMappingIndices
-    void getMappingIndices(CcdImage const &ccdImage, std::vector<unsigned> &indices) const override;
+    void getMappingIndices(CcdImage const &ccdImage, IndexVector &indices) const override;
 
     /// @copydoc PhotometryModel::getTotalParameters
-    int getTotalParameters() const override;
+    std::size_t getTotalParameters() const override;
 
     /// @copydoc PhotometryModel::computeParameterDerivatives
     void computeParameterDerivatives(MeasuredStar const &measuredStar, CcdImage const &ccdImage,

--- a/include/lsst/jointcal/Tripletlist.h
+++ b/include/lsst/jointcal/Tripletlist.h
@@ -40,14 +40,16 @@ class TripletList : public std::vector<Trip> {
 public:
     TripletList(int count) : _nextFreeIndex(0) { reserve(count); };
 
-    void addTriplet(const unsigned i, const unsigned j, double val) { push_back(Trip(i, j, val)); }
+    void addTriplet(Eigen::Index i, Eigen::Index j, double val) {
+        push_back(Trip(i, j, val));
+    }
 
-    unsigned getNextFreeIndex() const { return _nextFreeIndex; }
+    Eigen::Index getNextFreeIndex() const { return _nextFreeIndex; }
 
-    void setNextFreeIndex(unsigned index) { _nextFreeIndex = index; }
+    void setNextFreeIndex(Eigen::Index index) { _nextFreeIndex = index; }
 
 private:
-    unsigned _nextFreeIndex;
+    Eigen::Index _nextFreeIndex;
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/python/lsst/jointcal/astrometryTransform.cc
+++ b/python/lsst/jointcal/astrometryTransform.cc
@@ -76,9 +76,8 @@ void declareAstrometryTransformPolynomial(py::module &mod) {
 
     cls.def(py::init<const unsigned>(), "order"_a);
     cls.def("getOrder", &AstrometryTransformPolynomial::getOrder);
-    cls.def("coeff", (double (AstrometryTransformPolynomial::*)(unsigned const, unsigned const,
-                                                                unsigned const) const) &
-                             AstrometryTransformPolynomial::coeff);
+    cls.def("coeff", py::overload_cast<std::size_t, std::size_t, std::size_t>(
+                &AstrometryTransformPolynomial::coeff, py::const_));
     cls.def("determinant", &AstrometryTransformPolynomial::determinant);
     cls.def("getNpar", &AstrometryTransformPolynomial::getNpar);
     cls.def("toAstMap", &AstrometryTransformPolynomial::toAstMap);

--- a/python/lsst/jointcal/photometryMappings.cc
+++ b/python/lsst/jointcal/photometryMappings.cc
@@ -56,7 +56,7 @@ void declarePhotometryMappingBase(py::module &mod) {
     cls.def("getParameters", &PhotometryMappingBase::getParameters);
 
     cls.def("getMappingIndices", [](PhotometryMappingBase const &self) {
-        std::vector<unsigned> indices(0);
+        IndexVector indices(0);
         self.getMappingIndices(indices);
         return indices;
     });

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -282,7 +282,7 @@ void Associations::prepareFittedStars(int minMeasurements) {
 void Associations::selectFittedStars(int minMeasurements) {
     LOGLS_INFO(_log, "Fitted stars before measurement # cut: " << fittedStarList.size());
 
-    std::size_t totalMeasured = 0, validMeasured = 0;
+    int totalMeasured = 0, validMeasured = 0;
 
     // first pass: remove objects that have less than a certain number of measurements.
     for (auto const &ccdImage : ccdImageList) {

--- a/src/AstrometryTransform.cc
+++ b/src/AstrometryTransform.cc
@@ -213,21 +213,21 @@ std::unique_ptr<AstrometryTransform> AstrometryTransform::roughInverse(const Fra
 
 // not dummy : what it does is virtual because paramRef is virtual.
 void AstrometryTransform::getParams(double *params) const {
-    int npar = getNpar();
-    for (int i = 0; i < npar; ++i) params[i] = paramRef(i);
+    std::size_t npar = getNpar();
+    for (std::size_t i = 0; i < npar; ++i) params[i] = paramRef(i);
 }
 
 void AstrometryTransform::offsetParams(Eigen::VectorXd const &delta) {
-    int npar = getNpar();
-    for (int i = 0; i < npar; ++i) paramRef(i) += delta[i];
+    std::size_t npar = getNpar();
+    for (std::size_t i = 0; i < npar; ++i) paramRef(i) += delta[i];
 }
 
-double AstrometryTransform::paramRef(const int) const {
+double AstrometryTransform::paramRef(Eigen::Index const) const {
     throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                       std::string("AstrometryTransform::paramRef should never be called "));
 }
 
-double &AstrometryTransform::paramRef(const int) {
+double &AstrometryTransform::paramRef(Eigen::Index const) {
     throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                       "AstrometryTransform::paramRef should never be called ");
 }
@@ -465,7 +465,7 @@ void AstrometryTransformIdentity::read(istream &stream) {
 
 //! Default transform : identity for all orders (>=1 )
 
-AstrometryTransformPolynomial::AstrometryTransformPolynomial(const unsigned order) : _order(order) {
+AstrometryTransformPolynomial::AstrometryTransformPolynomial(std::size_t order) : _order(order) {
     _nterms = (order + 1) * (order + 2) / 2;
 
     // allocate and fill coefficients
@@ -479,8 +479,8 @@ AstrometryTransformPolynomial::AstrometryTransformPolynomial(const unsigned orde
 
 //#ifdef TO_BE_FIXED
 AstrometryTransformPolynomial::AstrometryTransformPolynomial(const AstrometryTransform *transform,
-                                                             const Frame &frame, unsigned order,
-                                                             unsigned nPoint) {
+                                                             const Frame &frame, std::size_t order,
+                                                             std::size_t nPoint) {
     StarMatchList sm;
 
     double step = std::sqrt(fabs(frame.getArea()) / double(nPoint));
@@ -502,14 +502,14 @@ AstrometryTransformPolynomial::AstrometryTransformPolynomial(const AstrometryTra
 
 AstrometryTransformPolynomial::AstrometryTransformPolynomial(
         std::shared_ptr<afw::geom::TransformPoint2ToPoint2> transform, jointcal::Frame const &domain,
-        unsigned const order, unsigned const nSteps) {
+        std::size_t order, std::size_t nSteps) {
     jointcal::StarMatchList starMatchList;
     double xStart = domain.xMin;
     double yStart = domain.yMin;
     double xStep = domain.getWidth() / (nSteps + 1);
     double yStep = domain.getHeight() / (nSteps + 1);
-    for (unsigned i = 0; i < nSteps; ++i) {
-        for (unsigned j = 0; j < nSteps; ++j) {
+    for (std::size_t i = 0; i < nSteps; ++i) {
+        for (std::size_t j = 0; j < nSteps; ++j) {
             // TODO: once DM-4044 is done, we can remove the redundancy in `Point`/`Point2D` here
             jointcal::Point in(xStart + i * xStep, yStart + j * yStep);
             afw::geom::Point2D inAfw(in.x, in.y);
@@ -526,7 +526,7 @@ AstrometryTransformPolynomial::AstrometryTransformPolynomial(
 void AstrometryTransformPolynomial::computeMonomials(double xIn, double yIn, double *monomial) const {
     /* The ordering of monomials is implemented here.
        You may not change it without updating the "mapping" routines
-      coeff(unsigned, unsigned, unsigned).
+      coeff(std::size_t, std::size_t, std::size_t).
       I (P.A.) did not find a clever way to loop over monomials.
       Improvements welcome.
       This routine is used also by the fit to fill monomials.
@@ -534,10 +534,10 @@ void AstrometryTransformPolynomial::computeMonomials(double xIn, double yIn, dou
     */
 
     double xx = 1;
-    for (unsigned ix = 0; ix <= _order; ++ix) {
+    for (std::size_t ix = 0; ix <= _order; ++ix) {
         double yy = 1;
-        unsigned k = ix * (ix + 1) / 2;
-        for (unsigned iy = 0; iy <= _order - ix; ++iy) {
+        std::size_t k = ix * (ix + 1) / 2;
+        for (std::size_t iy = 0; iy <= _order - ix; ++iy) {
             monomial[k] = xx * yy;
             yy *= yIn;
             k += ix + iy + 2;
@@ -546,9 +546,9 @@ void AstrometryTransformPolynomial::computeMonomials(double xIn, double yIn, dou
     }
 }
 
-void AstrometryTransformPolynomial::setOrder(const unsigned order) {
+void AstrometryTransformPolynomial::setOrder(std::size_t order) {
     _order = order;
-    unsigned old_nterms = _nterms;
+    std::size_t old_nterms = _nterms;
     _nterms = (_order + 1) * (_order + 2) / 2;
 
     // temporarily save coefficients
@@ -557,10 +557,10 @@ void AstrometryTransformPolynomial::setOrder(const unsigned order) {
     _coeffs.resize(2 * _nterms);
     // reassign to zero (this is necessary because ycoeffs
     // are after xcoeffs and so their meaning changes
-    for (unsigned k = 0; k < _nterms; ++k) _coeffs[k] = 0;
+    for (std::size_t k = 0; k < _nterms; ++k) _coeffs[k] = 0;
     // put back what we had before
-    unsigned kmax = min(old_nterms, _nterms);
-    for (unsigned k = 0; k < kmax; ++k) {
+    std::size_t kmax = min(old_nterms, _nterms);
+    for (std::size_t k = 0; k < kmax; ++k) {
         _coeffs[k] = old_coeffs[k];                         // x terms
         _coeffs[k + _nterms] = old_coeffs[k + old_nterms];  // y terms
     }
@@ -608,14 +608,14 @@ void AstrometryTransformPolynomial::computeDerivative(Point const &where,
 
     double xx = 1;
     double xxm1 = 1;  // xx^(ix-1)
-    for (unsigned ix = 0; ix <= _order; ++ix) {
-        unsigned k = (ix) * (ix + 1) / 2;
+    for (std::size_t ix = 0; ix <= _order; ++ix) {
+        std::size_t k = (ix) * (ix + 1) / 2;
         // iy = 0
         dermx[k] = ix * xxm1;
         dermy[k] = 0;
         k += ix + 2;
         double yym1 = 1;  // yy^(iy-1)
-        for (unsigned iy = 1; iy <= _order - ix; ++iy) {
+        for (std::size_t iy = 1; iy <= _order - ix; ++iy) {
             dermx[k] = ix * xxm1 * yym1 * yin;
             dermy[k] = iy * xx * yym1;
             yym1 *= yin;
@@ -675,8 +675,8 @@ void AstrometryTransformPolynomial::transformPosAndErrors(FatPoint const &in, Fa
 
     double xx = 1;
     double xxm1 = 1;  // xx^(ix-1)
-    for (unsigned ix = 0; ix <= _order; ++ix) {
-        unsigned k = (ix) * (ix + 1) / 2;
+    for (std::size_t ix = 0; ix <= _order; ++ix) {
+        std::size_t k = (ix) * (ix + 1) / 2;
         // iy = 0
         dermx[k] = ix * xxm1;
         dermy[k] = 0;
@@ -684,7 +684,7 @@ void AstrometryTransformPolynomial::transformPosAndErrors(FatPoint const &in, Fa
         k += ix + 2;
         double yy = yin;
         double yym1 = 1;  // yy^(iy-1)
-        for (unsigned iy = 1; iy <= _order - ix; ++iy) {
+        for (std::size_t iy = 1; iy <= _order - ix; ++iy) {
             monomials[k] = xx * yy;
             dermx[k] = ix * xxm1 * yy;
             dermy[k] = iy * xx * yym1;
@@ -735,8 +735,8 @@ void AstrometryTransformPolynomial::transformPosAndErrors(FatPoint const &in, Fa
    AstrometryTransformPolynomial::apply, AstrometryTransformPolynomial::Derivative, ... routines
    Change all or none ! */
 
-double AstrometryTransformPolynomial::coeff(const unsigned degX, const unsigned degY,
-                                            const unsigned whichCoord) const {
+double AstrometryTransformPolynomial::coeff(std::size_t degX, std::size_t degY,
+                                            std::size_t whichCoord) const {
     assert((degX + degY <= _order) && whichCoord < 2);
     /* this assertion above is enough to ensure that the index used just
        below is within bounds since the reserved length is
@@ -744,14 +744,14 @@ double AstrometryTransformPolynomial::coeff(const unsigned degX, const unsigned 
     return _coeffs[(degX + degY) * (degX + degY + 1) / 2 + degY + whichCoord * _nterms];
 }
 
-double &AstrometryTransformPolynomial::coeff(const unsigned degX, const unsigned degY,
-                                             const unsigned whichCoord) {
+double &AstrometryTransformPolynomial::coeff(std::size_t degX, std::size_t degY,
+                                             std::size_t whichCoord) {
     assert((degX + degY <= _order) && whichCoord < 2);
     return _coeffs[(degX + degY) * (degX + degY + 1) / 2 + degY + whichCoord * _nterms];
 }
 
-double AstrometryTransformPolynomial::coeffOrZero(const unsigned degX, const unsigned degY,
-                                                  const unsigned whichCoord) const {
+double AstrometryTransformPolynomial::coeffOrZero(std::size_t degX, std::size_t degY,
+                                                  std::size_t whichCoord) const {
     //  assert((degX+degY<=order) && whichCoord<2);
     assert(whichCoord < 2);
     if (degX + degY <= _order)
@@ -760,27 +760,27 @@ double AstrometryTransformPolynomial::coeffOrZero(const unsigned degX, const uns
 }
 
 /* parameter serialization for "virtual" fits */
-double AstrometryTransformPolynomial::paramRef(const int i) const {
-    assert(unsigned(i) < 2 * _nterms);
+double AstrometryTransformPolynomial::paramRef(Eigen::Index const i) const {
+    assert(i < 2 * Eigen::Index(_nterms));
     return _coeffs[i];
 }
 
-double &AstrometryTransformPolynomial::paramRef(const int i) {
-    assert(unsigned(i) < 2 * _nterms);
+double &AstrometryTransformPolynomial::paramRef(Eigen::Index const i) {
+    assert(i < 2 * Eigen::Index(_nterms));
     return _coeffs[i];
 }
 
 void AstrometryTransformPolynomial::paramDerivatives(Point const &where, double *dx, double *dy)
         const { /* first half : dxout/dpar, second half : dyout/dpar */
     computeMonomials(where.x, where.y, dx);
-    for (unsigned k = 0; k < _nterms; ++k) {
+    for (std::size_t k = 0; k < _nterms; ++k) {
         dy[_nterms + k] = dx[k];
         dx[_nterms + k] = dy[k] = 0;
     }
 }
 
 /* utility for the dump(ostream&) routine */
-static string monomialString(const unsigned powX, const unsigned powY) {
+static string monomialString(std::size_t powX, std::size_t powY) {
     stringstream ss;
     if (powX + powY) ss << "*";
     if (powX > 0) ss << "x";
@@ -793,13 +793,13 @@ static string monomialString(const unsigned powX, const unsigned powY) {
 void AstrometryTransformPolynomial::dump(ostream &stream) const {
     auto oldPrecision = stream.precision();
     stream.precision(12);
-    for (unsigned ic = 0; ic < 2; ++ic) {
+    for (std::size_t ic = 0; ic < 2; ++ic) {
         if (ic == 0)
             stream << "newx = ";
         else
             stream << "newy = ";
-        for (unsigned p = 0; p <= _order; ++p)
-            for (unsigned py = 0; py <= p; ++py) {
+        for (std::size_t p = 0; p <= _order; ++p)
+            for (std::size_t py = 0; py <= p; ++py) {
                 if (p + py != 0) stream << " + ";
                 stream << coeff(p - py, py, ic) << monomialString(p - py, py);
             }
@@ -886,8 +886,8 @@ double AstrometryTransformPolynomial::computeFit(StarMatchList const &starMatchL
 
         double bxcoeff = wxx * resx + wxy * resy;
         double bycoeff = wyy * resy + wxy * resx;
-        for (unsigned j = 0; j < _nterms; ++j) {
-            for (unsigned i = j; i < _nterms; ++i) {
+        for (std::size_t j = 0; j < _nterms; ++j) {
+            for (std::size_t i = j; i < _nterms; ++i) {
                 A(i, j) += wxx * monomials[i] * monomials[j];
                 A(i + _nterms, j + _nterms) += wyy * monomials[i] * monomials[j];
                 A(j, i + _nterms) = A(i, j + _nterms) += wxy * monomials[i] * monomials[j];
@@ -904,7 +904,7 @@ double AstrometryTransformPolynomial::computeFit(StarMatchList const &starMatchL
     }
 
     Eigen::VectorXd sol = factor.solve(B);
-    for (unsigned k = 0; k < 2 * _nterms; ++k) _coeffs[k] += sol(k);
+    for (std::size_t k = 0; k < 2 * _nterms; ++k) _coeffs[k] += sol(k);
     if (starMatchList.size() == _nterms) return 0;
     return (sumr2 - B.dot(sol));
 }
@@ -945,8 +945,8 @@ std::unique_ptr<AstrometryTransform> AstrometryTransformPolynomial::composeAndRe
 */
 
 class PolyXY {
-    unsigned order;
-    unsigned nterms;
+    std::size_t order;
+    std::size_t nterms;
     vector<long double> coeffs;
 
 public:
@@ -955,20 +955,20 @@ public:
         coeffs.insert(coeffs.begin(), nterms, 0L);  // fill & initialize to 0.
     }
 
-    unsigned getOrder() const { return order; }
+    std::size_t getOrder() const { return order; }
 
-    PolyXY(AstrometryTransformPolynomial const &transform, const unsigned whichCoord)
+    PolyXY(AstrometryTransformPolynomial const &transform, std::size_t whichCoord)
             : order(transform.getOrder()), nterms((order + 1) * (order + 2) / 2), coeffs(nterms, 0L) {
-        for (unsigned px = 0; px <= order; ++px)
-            for (unsigned py = 0; py <= order - px; ++py) coeff(px, py) = transform.coeff(px, py, whichCoord);
+        for (std::size_t px = 0; px <= order; ++px)
+            for (std::size_t py = 0; py <= order - px; ++py) coeff(px, py) = transform.coeff(px, py, whichCoord);
     }
 
-    long double coeff(const unsigned powX, const unsigned powY) const {
+    long double coeff(std::size_t powX, std::size_t powY) const {
         assert(powX + powY <= order);
         return coeffs.at((powX + powY) * (powX + powY + 1) / 2 + powY);
     }
 
-    long double &coeff(const unsigned powX, const unsigned powY) {
+    long double &coeff(std::size_t powX, std::size_t powY) {
         assert(powX + powY <= order);
         return coeffs.at((powX + powY) * (powX + powY + 1) / 2 + powY);
     }
@@ -977,53 +977,53 @@ public:
 /* =====================  PolyXY Algebra routines ================== */
 
 static void operator+=(PolyXY &left, const PolyXY &right) {
-    unsigned rdeg = right.getOrder();
+    std::size_t rdeg = right.getOrder();
     assert(left.getOrder() >= rdeg);
-    for (unsigned i = 0; i <= rdeg; ++i)
-        for (unsigned j = 0; j <= rdeg - i; ++j) left.coeff(i, j) += right.coeff(i, j);
+    for (std::size_t i = 0; i <= rdeg; ++i)
+        for (std::size_t j = 0; j <= rdeg - i; ++j) left.coeff(i, j) += right.coeff(i, j);
 }
 
 /* multiplication by a scalar */
 static PolyXY operator*(const long double &a, const PolyXY &polyXY) {
     PolyXY result(polyXY);
     // no direct access to coefficients: do it the soft way
-    unsigned order = polyXY.getOrder();
-    for (unsigned i = 0; i <= order; ++i)
-        for (unsigned j = 0; j <= order - i; ++j) result.coeff(i, j) *= a;
+    std::size_t order = polyXY.getOrder();
+    for (std::size_t i = 0; i <= order; ++i)
+        for (std::size_t j = 0; j <= order - i; ++j) result.coeff(i, j) *= a;
     return result;
 }
 
 /*! result(x,y) = p1(x,y)*p2(x,y) */
 static PolyXY product(const PolyXY &p1, const PolyXY &p2) {
-    unsigned deg1 = p1.getOrder();
-    unsigned deg2 = p2.getOrder();
+    std::size_t deg1 = p1.getOrder();
+    std::size_t deg2 = p2.getOrder();
     PolyXY result(deg1 + deg2);
-    for (unsigned i1 = 0; i1 <= deg1; ++i1)
-        for (unsigned j1 = 0; j1 <= deg1 - i1; ++j1)
-            for (unsigned i2 = 0; i2 <= deg2; ++i2)
-                for (unsigned j2 = 0; j2 <= deg2 - i2; ++j2)
+    for (std::size_t i1 = 0; i1 <= deg1; ++i1)
+        for (std::size_t j1 = 0; j1 <= deg1 - i1; ++j1)
+            for (std::size_t i2 = 0; i2 <= deg2; ++i2)
+                for (std::size_t j2 = 0; j2 <= deg2 - i2; ++j2)
                     result.coeff(i1 + i2, j1 + j2) += p1.coeff(i1, j1) * p2.coeff(i2, j2);
     return result;
 }
 
 /* powers[k](x,y) = polyXY(x,y)**k, 0 <= k <= maxP */
-static void computePowers(const PolyXY &polyXY, const unsigned maxP, vector<PolyXY> &powers) {
+static void computePowers(const PolyXY &polyXY, std::size_t maxP, vector<PolyXY> &powers) {
     powers.reserve(maxP + 1);
     powers.push_back(PolyXY(0));
     powers[0].coeff(0, 0) = 1L;
-    for (unsigned k = 1; k <= maxP; ++k) powers.push_back(product(powers[k - 1], polyXY));
+    for (std::size_t k = 1; k <= maxP; ++k) powers.push_back(product(powers[k - 1], polyXY));
 }
 
 /*! result(x,y) = polyXY(polyX(x,y),polyY(x,y)) */
 static PolyXY composition(const PolyXY &polyXY, const PolyXY &polyX, const PolyXY &polyY) {
-    unsigned pdeg = polyXY.getOrder();
+    std::size_t pdeg = polyXY.getOrder();
     PolyXY result(pdeg * max(polyX.getOrder(), polyY.getOrder()));
     vector<PolyXY> pXPowers;
     vector<PolyXY> pYPowers;
     computePowers(polyX, pdeg, pXPowers);
     computePowers(polyY, pdeg, pYPowers);
-    for (unsigned px = 0; px <= pdeg; ++px)
-        for (unsigned py = 0; py <= pdeg - px; ++py)
+    for (std::size_t px = 0; px <= pdeg; ++px)
+        for (std::size_t py = 0; py <= pdeg - px; ++py)
             result += polyXY.coeff(px, py) * product(pXPowers.at(px), pYPowers.at(py));
     return result;
 }
@@ -1046,8 +1046,8 @@ AstrometryTransformPolynomial AstrometryTransformPolynomial::operator*(
 
     // copy the results the hard way.
     AstrometryTransformPolynomial result(_order * right._order);
-    for (unsigned px = 0; px <= result._order; ++px)
-        for (unsigned py = 0; py <= result._order - px; ++py) {
+    for (std::size_t px = 0; px <= result._order; ++px)
+        for (std::size_t py = 0; py <= result._order - px; ++py) {
             result.coeff(px, py, 0) = rx.coeff(px, py);
             result.coeff(px, py, 1) = ry.coeff(px, py);
         }
@@ -1058,8 +1058,8 @@ AstrometryTransformPolynomial AstrometryTransformPolynomial::operator+(
         AstrometryTransformPolynomial const &right) const {
     if (_order >= right._order) {
         AstrometryTransformPolynomial res(*this);
-        for (unsigned i = 0; i <= right._order; ++i)
-            for (unsigned j = 0; j <= right._order - i; ++j) {
+        for (std::size_t i = 0; i <= right._order; ++i)
+            for (std::size_t j = 0; j <= right._order - i; ++j) {
                 res.coeff(i, j, 0) += right.coeff(i, j, 0);
                 res.coeff(i, j, 1) += right.coeff(i, j, 1);
             }
@@ -1071,8 +1071,8 @@ AstrometryTransformPolynomial AstrometryTransformPolynomial::operator+(
 AstrometryTransformPolynomial AstrometryTransformPolynomial::operator-(
         AstrometryTransformPolynomial const &right) const {
     AstrometryTransformPolynomial res(std::max(_order, right._order));
-    for (unsigned i = 0; i <= res._order; ++i)
-        for (unsigned j = 0; j <= res._order - i; ++j) {
+    for (std::size_t i = 0; i <= res._order; ++i)
+        for (std::size_t j = 0; j <= res._order - i; ++j) {
             res.coeff(i, j, 0) = coeffOrZero(i, j, 0) - right.coeffOrZero(i, j, 0);
             res.coeff(i, j, 1) = coeffOrZero(i, j, 1) - right.coeffOrZero(i, j, 1);
         }
@@ -1089,7 +1089,7 @@ void AstrometryTransformPolynomial::write(ostream &s) const {
     s << "order " << _order << endl;
     int oldprec = s.precision();
     s << setprecision(12);
-    for (unsigned k = 0; k < 2 * _nterms; ++k) s << _coeffs[k] << ' ';
+    for (std::size_t k = 0; k < 2 * _nterms; ++k) s << _coeffs[k] << ' ';
     s << endl;
     s << setprecision(oldprec);
 }
@@ -1107,17 +1107,17 @@ void AstrometryTransformPolynomial::read(istream &s) {
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           " AstrometryTransformPolynomial::read : expecting \"order\" and found " + order);
     setOrder(_order);
-    for (unsigned k = 0; k < 2 * _nterms; ++k) s >> _coeffs[k];
+    for (std::size_t k = 0; k < 2 * _nterms; ++k) s >> _coeffs[k];
 }
 
 ndarray::Array<double, 2, 2> AstrometryTransformPolynomial::toAstPolyMapCoefficients() const {
-    int nCoeffs = _coeffs.size();
-    ndarray::Array<double, 2, 2> result = ndarray::allocate(ndarray::makeVector(nCoeffs, 4));
+    std::size_t nCoeffs = _coeffs.size();
+    ndarray::Array<double, 2, 2> result = ndarray::allocate(ndarray::makeVector(nCoeffs, std::size_t(4)));
 
     ndarray::Size k = 0;
-    for (unsigned iCoord = 0; iCoord < 2; ++iCoord) {
-        for (unsigned p = 0; p <= _order; ++p) {
-            for (unsigned py = 0; py <= p; ++py, ++k) {
+    for (std::size_t iCoord = 0; iCoord < 2; ++iCoord) {
+        for (std::size_t p = 0; p <= _order; ++p) {
+            for (std::size_t py = 0; py <= p; ++py, ++k) {
                 result[k][0] = coeff(p - py, py, iCoord);
                 result[k][1] = iCoord + 1;
                 result[k][2] = p - py;
@@ -1132,22 +1132,22 @@ ndarray::Array<double, 2, 2> AstrometryTransformPolynomial::toAstPolyMapCoeffici
 std::shared_ptr<AstrometryTransformPolynomial> inversePolyTransform(AstrometryTransform const &forward,
                                                                     Frame const &domain,
                                                                     double const precision,
-                                                                    int const maxOrder,
-                                                                    unsigned const nSteps) {
+                                                                    std::size_t maxOrder,
+                                                                    std::size_t nSteps) {
     StarMatchList sm;
     double xStart = domain.xMin;
     double yStart = domain.yMin;
     double xStep = domain.getWidth() / (nSteps - 1);
     double yStep = domain.getHeight() / (nSteps - 1);
-    for (unsigned i = 0; i < nSteps; ++i) {
-        for (unsigned j = 0; j < nSteps; ++j) {
+    for (std::size_t i = 0; i < nSteps; ++i) {
+        for (std::size_t j = 0; j < nSteps; ++j) {
             Point in(xStart + i * xStep, yStart + j * yStep);
             Point out(forward.apply(in));
             sm.push_back(StarMatch(out, in, nullptr, nullptr));
         }
     }
-    unsigned npairs = sm.size();
-    int order;
+    std::size_t npairs = sm.size();
+    std::size_t order;
     std::shared_ptr<AstrometryTransformPolynomial> poly;
     std::shared_ptr<AstrometryTransformPolynomial> oldPoly;
     double chi2 = 0;
@@ -1279,7 +1279,7 @@ double AstrometryTransformLinearRot::fit(StarMatchList const &) {
 }
 
 double AstrometryTransformLinearShift::fit(StarMatchList const &starMatchList) {
-    int npairs = starMatchList.size();
+    std::size_t npairs = starMatchList.size();
     if (npairs < 3) {
         LOGLS_FATAL(_log, "AstrometryTransformLinearShift::fit trying to fit a linear transform with only "
                                   << npairs << " matches.");

--- a/src/ChipVisitAstrometryMapping.cc
+++ b/src/ChipVisitAstrometryMapping.cc
@@ -40,10 +40,10 @@ ChipVisitAstrometryMapping::ChipVisitAstrometryMapping(std::shared_ptr<SimpleAst
     setWhatToFit(true, true);
 }
 
-unsigned ChipVisitAstrometryMapping::getNpar() const { return _nPar1 + _nPar2; }
+std::size_t ChipVisitAstrometryMapping::getNpar() const { return _nPar1 + _nPar2; }
 
-void ChipVisitAstrometryMapping::getMappingIndices(std::vector<unsigned> &indices) const {
-    unsigned npar = getNpar();
+void ChipVisitAstrometryMapping::getMappingIndices(IndexVector &indices) const {
+    std::size_t npar = getNpar();
     if (indices.size() < npar) indices.resize(npar);
     // in case we are only fitting one of the two transforms
     if (_nPar1)
@@ -54,9 +54,9 @@ void ChipVisitAstrometryMapping::getMappingIndices(std::vector<unsigned> &indice
     }
     // if we get here we are fitting both
     // there is probably a more elegant way to feed a subpart of a std::vector
-    std::vector<unsigned> ind2(_nPar2);
+    IndexVector ind2(_nPar2);
     _m2->getMappingIndices(ind2);
-    for (unsigned k = 0; k < _nPar2; ++k) indices.at(k + _nPar1) = ind2.at(k);
+    for (Eigen::Index k = 0; k < _nPar2; ++k) indices.at(k + _nPar1) = ind2.at(k);
 }
 
 void ChipVisitAstrometryMapping::computeTransformAndDerivatives(FatPoint const &where, FatPoint &outPoint,

--- a/src/ConstrainedAstrometryModel.cc
+++ b/src/ConstrainedAstrometryModel.cc
@@ -136,8 +136,11 @@ const AstrometryMapping *ConstrainedAstrometryModel::getMapping(CcdImage const &
   whatToFit. If whatToFit contains "Distortions" and not
   Distortions<Something>, it is understood as both chips and
   visits. */
-unsigned ConstrainedAstrometryModel::assignIndices(std::string const &whatToFit, unsigned firstIndex) {
-    unsigned index = firstIndex;
+Eigen::Index ConstrainedAstrometryModel::assignIndices(
+    std::string const &whatToFit,
+    Eigen::Index firstIndex
+) {
+    Eigen::Index index = firstIndex;
     if (whatToFit.find("Distortions") == std::string::npos) {
         LOGLS_ERROR(_log, "assignIndices was called and Distortions is *not* in whatToFit");
         return 0;
@@ -216,8 +219,8 @@ const AstrometryTransform &ConstrainedAstrometryModel::getVisitTransform(VisitId
     return visitp->second->getTransform();
 }
 
-int ConstrainedAstrometryModel::getTotalParameters() const {
-    int total = 0;
+std::size_t ConstrainedAstrometryModel::getTotalParameters() const {
+    std::size_t total = 0;
     for (auto &i : _chipMap) {
         total += i.second->getNpar();
     }

--- a/src/ConstrainedPhotometryModel.cc
+++ b/src/ConstrainedPhotometryModel.cc
@@ -41,8 +41,11 @@
 namespace lsst {
 namespace jointcal {
 
-unsigned ConstrainedPhotometryModel::assignIndices(std::string const &whatToFit, unsigned firstIndex) {
-    unsigned index = firstIndex;
+Eigen::Index ConstrainedPhotometryModel::assignIndices(
+    std::string const &whatToFit,
+    Eigen::Index firstIndex
+) {
+    Eigen::Index index = firstIndex;
     if (whatToFit.find("Model") == std::string::npos) {
         LOGLS_WARN(_log, "assignIndices was called and Model is *not* in whatToFit");
         return index;
@@ -105,13 +108,13 @@ void ConstrainedPhotometryModel::freezeErrorTransform() {
 }
 
 void ConstrainedPhotometryModel::getMappingIndices(CcdImage const &ccdImage,
-                                                   std::vector<unsigned> &indices) const {
+                                                   IndexVector &indices) const {
     auto mapping = findMapping(ccdImage);
     mapping->getMappingIndices(indices);
 }
 
-int ConstrainedPhotometryModel::getTotalParameters() const {
-    int total = 0;
+std::size_t ConstrainedPhotometryModel::getTotalParameters() const {
+    std::size_t total = 0;
     for (auto &idMapping : _chipMap) {
         total += idMapping.second->getNpar();
     }
@@ -133,7 +136,8 @@ namespace {
 ndarray::Array<double, 2, 2> toChebyMapCoeffs(std::shared_ptr<PhotometryTransformChebyshev> transform) {
     auto coeffs = transform->getCoefficients();
     // 4 x nPar: ChebyMap wants rows that look like (a_ij, 1, i, j) for out += a_ij*T_i(x)*T_j(y)
-    ndarray::Array<double, 2, 2> chebyCoeffs = allocate(ndarray::makeVector(transform->getNpar(), 4));
+    ndarray::Array<double, 2, 2> chebyCoeffs = allocate(ndarray::makeVector(transform->getNpar(),
+                                                                            std::size_t(4)));
     Eigen::VectorXd::Index k = 0;
     auto order = transform->getOrder();
     for (ndarray::Size j = 0; j <= order; ++j) {

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -55,15 +55,15 @@ void PhotometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
        Ccd should match the one(s) in the list. */
     if (measuredStarList) assert(&(measuredStarList->front()->getCcdImage()) == &ccdImage);
 
-    unsigned nparModel = (_fittingModel) ? _photometryModel->getNpar(ccdImage) : 0;
-    unsigned nparFlux = (_fittingFluxes) ? 1 : 0;
-    unsigned nparTotal = nparModel + nparFlux;
-    std::vector<unsigned> indices(nparModel, -1);
+    std::size_t nparModel = (_fittingModel) ? _photometryModel->getNpar(ccdImage) : 0;
+    std::size_t nparFlux = (_fittingFluxes) ? 1 : 0;
+    std::size_t nparTotal = nparModel + nparFlux;
+    IndexVector indices(nparModel, -1);
     if (_fittingModel) _photometryModel->getMappingIndices(ccdImage, indices);
 
     Eigen::VectorXd H(nparTotal);  // derivative matrix
     // current position in the Jacobian
-    unsigned kTriplets = tripletList.getNextFreeIndex();
+    Eigen::Index kTriplets = tripletList.getNextFreeIndex();
     const MeasuredStarList &catalog = (measuredStarList) ? *measuredStarList : ccdImage.getCatalogForFit();
 
     for (auto const &measuredStar : catalog) {
@@ -76,14 +76,14 @@ void PhotometryFit::leastSquareDerivativesMeasurement(CcdImage const &ccdImage, 
 
         if (_fittingModel) {
             _photometryModel->computeParameterDerivatives(*measuredStar, ccdImage, H);
-            for (unsigned k = 0; k < indices.size(); k++) {
-                unsigned l = indices[k];
+            for (std::size_t k = 0; k < indices.size(); k++) {
+                Eigen::Index l = indices[k];
                 tripletList.addTriplet(l, kTriplets, H[k] * inverseSigma);
                 grad[l] += H[k] * W * residual;
             }
         }
         if (_fittingFluxes) {
-            unsigned index = measuredStar->getFittedStar()->getIndexInMatrix();
+            Eigen::Index index = measuredStar->getFittedStar()->getIndexInMatrix();
             // Note: H = dR/dFittedStarFlux == -1
             tripletList.addTriplet(index, kTriplets, -1.0 * inverseSigma);
             grad[index] += -1.0 * W * residual;
@@ -106,7 +106,7 @@ void PhotometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
     // Can't compute anything if there are no refStars.
     if (_associations->refStarList.size() == 0) return;
 
-    unsigned kTriplets = tripletList.getNextFreeIndex();
+    Eigen::Index kTriplets = tripletList.getNextFreeIndex();
 
     for (auto const &fittedStar : fittedStarList) {
         auto refStar = fittedStar->getRefStar();
@@ -122,7 +122,7 @@ void PhotometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
         // Residual is fittedStar - refStar for consistency with measurement terms.
         double residual = _photometryModel->computeRefResidual(*fittedStar, *refStar);
 
-        unsigned index = fittedStar->getIndexInMatrix();
+        Eigen::Index index = fittedStar->getIndexInMatrix();
         // Note: H = dR/dFittedStar == 1
         tripletList.addTriplet(index, kTriplets, 1.0 * inverseSigma);
         grad(index) += 1.0 * std::pow(inverseSigma, 2) * residual;
@@ -171,14 +171,14 @@ void PhotometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
 /*! it fills the array of indices of parameters that a Measured star
     constrains. Not really all of them if you check. */
 void PhotometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                             std::vector<unsigned> &indices) const {
+                                             IndexVector &indices) const {
     indices.clear();
     if (_fittingModel) {
         _photometryModel->getMappingIndices(measuredStar.getCcdImage(), indices);
     }
     if (_fittingFluxes) {
         std::shared_ptr<FittedStar const> const fs = measuredStar.getFittedStar();
-        unsigned fsIndex = fs->getIndexInMatrix();
+        Eigen::Index fsIndex = fs->getIndexInMatrix();
         indices.push_back(fsIndex);
     }
 }
@@ -191,7 +191,7 @@ void PhotometryFit::assignIndices(std::string const &whatToFit) {
     // When entering here, we assume that whatToFit has already been interpreted.
 
     _nParModel = (_fittingModel) ? _photometryModel->assignIndices(whatToFit, 0) : 0;
-    unsigned ipar = _nParModel;
+    std::size_t ipar = _nParModel;
 
     if (_fittingFluxes) {
         for (auto &fittedStar : _associations->fittedStarList) {
@@ -221,7 +221,7 @@ void PhotometryFit::offsetParams(Eigen::VectorXd const &delta) {
             // the parameter layout here is used also
             // - when filling the derivatives
             // - when assigning indices (assignIndices())
-            unsigned index = fittedStar->getIndexInMatrix();
+            Eigen::Index index = fittedStar->getIndexInMatrix();
             _photometryModel->offsetFittedStar(*fittedStar, delta(index));
         }
     }

--- a/src/PhotometryMapping.cc
+++ b/src/PhotometryMapping.cc
@@ -36,7 +36,7 @@ LOG_LOGGER _log = LOG_GET("jointcal.PhotometryMapping");
 namespace lsst {
 namespace jointcal {
 
-void ChipVisitPhotometryMapping::getMappingIndices(std::vector<unsigned> &indices) const {
+void ChipVisitPhotometryMapping::getMappingIndices(IndexVector &indices) const {
     if (indices.size() < getNpar()) indices.resize(getNpar());
     // If we're fitting the chip mapping, fill those indices.
     if (_nParChip > 0) {
@@ -46,10 +46,10 @@ void ChipVisitPhotometryMapping::getMappingIndices(std::vector<unsigned> &indice
     if (_nParVisit > 0) {
         // TODO DM-12169: there is probably a better way to feed a subpart of a std::vector
         // (maybe a view or iterators?)
-        std::vector<unsigned> tempIndices(_visitMapping->getNpar());
+        IndexVector tempIndices(_visitMapping->getNpar());
         _visitMapping->getMappingIndices(tempIndices);
         // We have to insert the visit indices starting after the chip indices.
-        for (unsigned k = 0; k < _visitMapping->getNpar(); ++k) {
+        for (std::size_t k = 0; k < _visitMapping->getNpar(); ++k) {
             indices.at(k + _nParChip) = tempIndices.at(k);
         }
     }

--- a/src/PhotometryTransform.cc
+++ b/src/PhotometryTransform.cc
@@ -42,9 +42,9 @@ namespace {
 // The CoeffGetter argument g is something that behaves like an array, providing access
 // to the coefficients.
 template <typename CoeffGetter>
-double evaluateFunction1d(CoeffGetter g, double x, int size) {
+double evaluateFunction1d(CoeffGetter g, double x, std::size_t size) {
     double b_kp2 = 0.0, b_kp1 = 0.0;
-    for (int k = (size - 1); k > 0; --k) {
+    for (std::size_t k = (size - 1); k > 0; --k) {
         double b_k = g[k] + 2 * x * b_kp1 - b_kp2;
         b_kp2 = b_kp1;
         b_kp1 = b_k;
@@ -58,7 +58,7 @@ double evaluateFunction1d(CoeffGetter g, double x, int size) {
 // the result of that to evaluateFunction1d with the results as the "coefficients" associated
 // with the T_j(y) functions.
 struct RecursionArrayImitator {
-    double operator[](int i) const {
+    double operator[](Eigen::Index i) const {
         return evaluateFunction1d(coefficients[i], x, coefficients.getSize<1>());
     }
 

--- a/src/SimpleAstrometryModel.cc
+++ b/src/SimpleAstrometryModel.cc
@@ -45,7 +45,7 @@ SimpleAstrometryModel::SimpleAstrometryModel(CcdImageList const &ccdImageList,
           _skyToTangentPlane(projectionHandler)
 
 {
-    unsigned count = 0;
+    std::size_t count = 0;
 
     for (auto i = ccdImageList.cbegin(); i != ccdImageList.cend(); ++i, ++count) {
         const CcdImage &im = **i;
@@ -67,7 +67,7 @@ SimpleAstrometryModel::SimpleAstrometryModel(CcdImageList const &ccdImageList,
             AstrometryTransformPolynomial pol(order);
             if (pol.getOrder() > 0)  // if not, it cannot be decreased
             {
-                while (unsigned(pol.getNpar()) > 2 * nObj) {
+                while (pol.getNpar() > 2 * nObj) {
                     LOGLS_WARN(_log, "Reducing polynomial order from "
                                              << pol.getOrder() << ", due to too few sources (" << nObj
                                              << " vs. " << pol.getNpar() << " parameters)");
@@ -98,12 +98,12 @@ const AstrometryMapping *SimpleAstrometryModel::getMapping(CcdImage const &ccdIm
     return findMapping(ccdImage);
 }
 
-unsigned SimpleAstrometryModel::assignIndices(std::string const &whatToFit, unsigned firstIndex) {
+Eigen::Index SimpleAstrometryModel::assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) {
     if (whatToFit.find("Distortions") == std::string::npos) {
         LOGLS_ERROR(_log, "AssignIndices was called and Distortions is *not* in whatToFit.");
         return 0;
     }
-    unsigned index = firstIndex;
+    Eigen::Index index = firstIndex;
     for (auto i = _myMap.begin(); i != _myMap.end(); ++i) {
         SimplePolyMapping *p = dynamic_cast<SimplePolyMapping *>(&*(i->second));
         if (!p) continue;  // it should be AstrometryTransformIdentity
@@ -124,8 +124,8 @@ void SimpleAstrometryModel::freezeErrorTransform() {
     for (auto &i : _myMap) i.second->freezeErrorTransform();
 }
 
-int SimpleAstrometryModel::getTotalParameters() const {
-    int total = 0;
+std::size_t SimpleAstrometryModel::getTotalParameters() const {
+    std::size_t total = 0;
     for (auto &i : _myMap) {
         total += i.second->getNpar();
     }

--- a/src/SimplePhotometryModel.cc
+++ b/src/SimplePhotometryModel.cc
@@ -35,8 +35,8 @@
 namespace lsst {
 namespace jointcal {
 
-unsigned SimplePhotometryModel::assignIndices(std::string const &whatToFit, unsigned firstIndex) {
-    unsigned ipar = firstIndex;
+Eigen::Index SimplePhotometryModel::assignIndices(std::string const &whatToFit, Eigen::Index firstIndex) {
+    Eigen::Index ipar = firstIndex;
     for (auto const &i : _myMap) {
         auto mapping = i.second.get();
         mapping->setIndex(ipar);
@@ -59,14 +59,14 @@ void SimplePhotometryModel::freezeErrorTransform() {
 }
 
 void SimplePhotometryModel::getMappingIndices(CcdImage const &ccdImage,
-                                              std::vector<unsigned> &indices) const {
+                                              std::vector<Eigen::Index> &indices) const {
     auto mapping = findMapping(ccdImage);
     if (indices.size() < mapping->getNpar()) indices.resize(mapping->getNpar());
     indices[0] = mapping->getIndex();
 }
 
-int SimplePhotometryModel::getTotalParameters() const {
-    int total = 0;
+std::size_t SimplePhotometryModel::getTotalParameters() const {
+    std::size_t total = 0;
     for (auto &i : _myMap) {
         total += i.second->getNpar();
     }


### PR DESCRIPTION
Extensive changes to the types used for indexing. Now using
Eigen::Index (defaults to std::ptrdiff_t) for indices and
std::size_t for counts. This requires using the cholmod_l_*
functions instead of cholmod_*. (A patch to the LSST Eigen
package handles the cholmod calls in there).

This is an effort to combat segfaults with large numbers of
HSC exposures (>~ 290).

Perhaps this is more extensive than it strictly needs to be
(e.g., polynomial orders don't need the full dynamic range of
std::size_t) but consistency helps avoid compiler warnings
and annoying casts.