### PR TITLE
DM-17830: Use only stars in internal jointcal fitting

### DIFF
--- a/tests/config/cfht-flagged-config.py
+++ b/tests/config/cfht-flagged-config.py
@@ -1,0 +1,5 @@
+config.sourceSelector.name = "flagged"
+# Calib flag names changed with RFC-498 (DM-14997).  The following sets the config to use the
+# old names associated with the current data in testdata_jointcal that was processed pre-RFC-498.
+# Remove line if the data in testdata_jointcal are ever reprocessed post-RFC-498 (e.g. DM-17597)
+config.sourceSelector.active.field = "calib_psfUsed"

--- a/tests/config/config.py
+++ b/tests/config/config.py
@@ -1,2 +1,10 @@
 config.astrometryRefObjLoader.ref_dataset_name = "sdss-dr9-fink-v5b"
 config.photometryRefObjLoader.ref_dataset_name = "sdss-dr9-fink-v5b"
+# TODO DM-17597: Use the astrometrySourceSelector until we redo the refcats and metrics.
+# Once we do that, we can try using the sourceSelector defaults and recompute all
+# the metrics to match, though it may result in problems due to not having enough sources
+# because the testdata is generally fainter than the HSC/LSST data that the defaults
+# are now designed for.
+config.sourceSelector.name = "astrometry"
+config.sourceSelector["astrometry"].sourceFluxType = "Calib"
+config.sourceSelector["astrometry"].badFlags.extend(["slot_Shape_flag", "base_PixelFlags_flag_interpolated"])

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -71,8 +71,6 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         self.config.astrometryModel = "simple"
         self.config.photometryModel = "simpleFlux"
 
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
-
         # to test whether we got the expected chi2 contribution files.
         self.other_args.extend(['--config', 'writeChi2FilesInitialFinal=True'])
 
@@ -115,7 +113,6 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "constrained"
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -161,7 +158,6 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.photometryModel = "constrainedFlux"
         self.config.doAstrometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_astrometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -211,11 +207,9 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
     def test_jointcalTask_2_visits_constrainedPhotometry_flagged(self):
         """Test the use of the FlaggedSourceSelector."""
         pa1, metrics = self.setup_jointcalTask_2_visits_constrainedPhotometry()
-        self.config.sourceSelector.name = "flagged"
-        # Calib flag names changed with RFC-498 (DM-14997).  The following sets the config to use the
-        # old names associated with the current data in testdata_jointcal that was processed pre-RFC-498.
-        # Remove line if the data in testdata_jointcal are ever reprocessed post-RFC-498.
-        self.config.sourceSelector.active.field = "calib_psfUsed"
+        test_config = os.path.join(lsst.utils.getPackageDir('jointcal'),
+                                   'tests/config/cfht-flagged-config.py')
+        self.configfiles.append(test_config)
         # Reduce warnings due to flaggedSourceSelector having fewer sources than astrometrySourceSelector.
         self.config.minMeasuredStarsPerCcd = 30
         self.config.minRefStarsPerCcd = 20

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -75,7 +75,6 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "simple"
         self.config.photometryModel = "simpleFlux"
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
 
         # See Readme for an explanation of these empirical values.
         # NOTE: the photometry and astrometry refstars numbers are different
@@ -108,7 +107,6 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "constrained"
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -159,7 +157,6 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
         """
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.photometryModel = "constrainedFlux"
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.config.doAstrometry = False
         self.jointcalStatistics.do_astrometry = False
 

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -71,7 +71,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "simple"
         self.config.photometryModel = "simpleFlux"
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
 
         # See Readme for an explanation of these empirical values.
         dist_rms_relative = 17e-3*u.arcsecond
@@ -101,7 +100,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "simple"
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -124,7 +122,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.photometryModel = "simpleFlux"
         self.config.doAstrometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_astrometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -191,7 +188,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config = lsst.jointcal.jointcal.JointcalConfig()
         self.config.astrometryModel = "simple"
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         data_refs = self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute,
@@ -206,7 +202,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config.astrometryModel = "simple"
         self.config.photometryModel = "simpleFlux"
         # use the a.net refcat for photometry, gaia for astrometry
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         test_config = os.path.join(lsst.utils.getPackageDir('jointcal'), 'tests/config/hsc-gaia-config.py')
         self.configfiles.append(test_config)
         dist_rms_relative = 17e-3*u.arcsecond
@@ -243,7 +238,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config.astrometryModel = "simple"
         self.config.matchCut = 10.0  # TODO: once DM-6885 is fixed, we need to put `*lsst.afw.geom.arcseconds`
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -265,7 +259,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config.astrometryModel = "simple"
         self.config.minMeasurements = 2
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.
@@ -289,7 +282,6 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
         self.config.minMeasurements = 3
         self.config.astrometryModel = "simple"
         self.config.doPhotometry = False
-        self.config.sourceSelector['astrometry'].badFlags.append("base_PixelFlags_flag_interpolated")
         self.jointcalStatistics.do_photometry = False
 
         # See Readme for an explanation of these empirical values.


### PR DESCRIPTION
and limit to isolated stars with SNR > 10.
This config shows improvement in the photometric repeatability
and match to the reference catalog.
* Revert to astrometry source selector in unit tests
  that check equality in metrics when jointcal run on testdata.
* Remove some now-redundant config overrides in those
  affected unit tests.