### PR TITLE
DM-22386: Look for subclasses of float and not exactly a float

### DIFF
--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -237,7 +237,7 @@ class JointcalTestBase:
         for key in result:
             if expect[key.metric] is not None:
                 value = result[key].quantity.value
-                if type(value) == float:
+                if isinstance(value, float):
                     self.assertFloatsAlmostEqual(value, expect[key.metric], msg=key.metric, rtol=1e-5)
                 else:
                     self.assertEqual(value, expect[key.metric], msg=key.metric)


### PR DESCRIPTION
In Astropy 4 the floating point scalar value from a `Quantity` is now a `numpy.float64` and not a `float`.  The test for float fails. Fix by checking `isinstance` `float`.