### PR TITLE
DM-23835 - Remove third parties from code (use conda third-parties)

### DIFF
--- a/ups/jointcal.table
+++ b/ups/jointcal.table
@@ -1,4 +1,5 @@
 setupRequired(sconsUtils)
+setupRequired(eigen)
 setupRequired(afw)
 setupRequired(daf_persistence)
 setupRequired(obs_base)

--- a/ups/jointcal.table
+++ b/ups/jointcal.table
@@ -1,8 +1,4 @@
-setupRequired(scons)
 setupRequired(sconsUtils)
-setupRequired(pybind11)
-setupRequired(eigen)
-setupRequired(boost)
 setupRequired(afw)
 setupRequired(daf_persistence)
 setupRequired(obs_base)


### PR DESCRIPTION
This is a special case.

We keep `eigen` for jointcal specifically because eigen in conda-forge does not have long support for the cholmod code.