### PR TITLE
DM-27083: Improve jointcal outlier rejection

### DIFF
--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -74,6 +74,9 @@ public:
      * @param[in]  whatToFit  See child method assignIndices for valid string values.
      * @param[in]  nSigmaCut  How many sigma to reject outliers at. Outlier
      *                        rejection ignored for nSigmaCut=0.
+     * @param[in]  sigmaRelativeTolerance  Percentage change in the chi2 cut for outliers tolerated for
+     *                                     termination. If value is zero, minimization iterations will
+     *                                     continue until there are no outliers.
      * @param[in]  doRankUpdate  Use CholmodSimplicialLDLT2.update() to do a fast rank update after outlier
      *                           removal; otherwise do a slower full recomputation of the matrix.
      *                           Only matters if nSigmaCut != 0.
@@ -102,9 +105,9 @@ public:
      *         the second run with the same "whatToFit" will produce no change in
      *         the fitted parameters, if the calculations and indices are defined correctly.
      */
-    MinimizeResult minimize(std::string const &whatToFit, double const nSigmaCut = 0,
-                            bool const doRankUpdate = true, bool const doLineSearch = false,
-                            std::string const &dumpMatrixFile = "");
+    MinimizeResult minimize(std::string const &whatToFit, double const nSigmaCut = 0, 
+                            double sigmaRelativeTolerance = 0, bool const doRankUpdate = true,
+                            bool const doLineSearch = false, std::string const &dumpMatrixFile = "");
 
     /**
      * Returns the chi2 for the current state.
@@ -179,11 +182,12 @@ protected:
      * @param[in]  nSigmaCut   Number of sigma to select on.
      * @param[out] msOutliers  list of MeasuredStar outliers to populate
      * @param[out] fsOutliers  list of FittedStar outliers to populate
+     * @param[out] cut  value of chi2 that defines which objects are outliers
      *
      * @return     Total number of outliers that were removed.
      */
     std::size_t findOutliers(double nSigmaCut, MeasuredStarList &msOutliers,
-                             FittedStarList &fsOutliers) const;
+                             FittedStarList &fsOutliers, double &cut) const;
 
     /**
      * Contributions to derivatives from (presumably) outlier terms. No

--- a/python/lsst/jointcal/fitter.cc
+++ b/python/lsst/jointcal/fitter.cc
@@ -42,8 +42,9 @@ namespace {
 void declareFitterBase(py::module &mod) {
     py::class_<FitterBase, std::shared_ptr<FitterBase>> cls(mod, "FitterBase");
 
-    cls.def("minimize", &FitterBase::minimize, "whatToFit"_a, "nSigRejCut"_a = 0, "doRankUpdate"_a = true,
-            "doLineSearch"_a = false, "dumpMatrixFile"_a = "");
+    cls.def("minimize", &FitterBase::minimize, "whatToFit"_a, "nSigRejCut"_a = 0,
+            "sigmaRelativeTolerance"_a = 0, "doRankUpdate"_a = true, "doLineSearch"_a = false,
+            "dumpMatrixFile"_a = "");
     cls.def("computeChi2", &FitterBase::computeChi2);
     cls.def("saveChi2Contributions", &FitterBase::saveChi2Contributions);
 }

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -176,6 +176,18 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 
+    def test_jointcalTask_2_visits_constrainedAstrometry_astrometryOutlierRelativeTolerance(self):
+        """Test that astrometryOutlierRelativeTolerance changes the fit. Setting
+        1% for the astrometryOutlierRelativeTolerance will result in higher chi2
+        and ndof.
+        """
+        dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
+        self.config.astrometryOutlierRelativeTolerance = 0.01
+        metrics['astrometry_final_chi2'] = 1427.11
+        metrics['astrometry_final_ndof'] = 1990
+
+        self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
+
     def test_jointcalTask_2_visits_constrainedAstrometry_astrometryReferenceUncertainty_smaller(self):
         """Test with a smaller fake reference uncertainty: chi2 will be higher."""
         dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()


### PR DESCRIPTION
Truncate iterations of outlier rejection when the outlier cut criterion
changes by less than the allowed tolerance, given by the jointcal.py
config parameter `astrometryOutlierRelativeTolerance`. This happens when
removing additional outliers stops significantly changing the model and
hence the chi2 distribution. The default behavior is unchanged: when
`astrometryOutlierRelativeTolerance`=0 iterations of outlier rejection
continue until there are no more outliers.