### PR TITLE
DM-30254: Fix jointcal crash when doing outlier rejection on only the model

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -119,9 +119,8 @@ public:
      * @param[in]  control    The JointcalControl object
      */
     void createCcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw::geom::SkyWcs> wcs,
-                        std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo,
-                        lsst::geom::Box2I const &bbox, std::string const &filter,
-                        std::shared_ptr<afw::image::PhotoCalib> photoCalib,
+                        std::shared_ptr<lsst::afw::image::VisitInfo> visitInfo, lsst::geom::Box2I const &bbox,
+                        std::string const &filter, std::shared_ptr<afw::image::PhotoCalib> photoCalib,
                         std::shared_ptr<afw::cameraGeom::Detector> detector, int visit, int ccd,
                         lsst::jointcal::JointcalControl const &control);
 

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -167,6 +167,16 @@ public:
      */
     void prepareFittedStars(int minMeasurements);
 
+    /**
+     * Remove FittedStars that have no measured stars; this can happen after outlier rejection.
+     *
+     * Use this to perform e.g. position minimization with outlier rejection after model minimization has
+     * removed measuredStar outliers, to prevent the matrix from becoming non-positive definite.
+     * Once this has been called, prepareFittedStars() has to be called again if the full
+     * measuredStar->FittedStar relationship needs to be reconstructed.
+     */
+    void cleanFittedStars();
+
     CcdImageList const &getCcdImageList() const { return ccdImageList; }
 
     //! Number of different bands in the input image list. Not implemented so far

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -68,7 +68,8 @@ public:
      */
     Associations()
             : _commonTangentPoint(Point(std::numeric_limits<double>::quiet_NaN(),
-                                        std::numeric_limits<double>::quiet_NaN())) {}
+                                        std::numeric_limits<double>::quiet_NaN())),
+              _maxMeasuredStars(0) {}
 
     /**
      * Create an Associations object from a pre-built list of ccdImages.
@@ -81,7 +82,8 @@ public:
     Associations(CcdImageList const &imageList)
             : ccdImageList(imageList),
               _commonTangentPoint(Point(std::numeric_limits<double>::quiet_NaN(),
-                                        std::numeric_limits<double>::quiet_NaN())) {}
+                                        std::numeric_limits<double>::quiet_NaN())),
+              _maxMeasuredStars(0) {}
 
     /// No moves or copies: jointcal only ever needs one Associations object.
     Associations(Associations const &) = delete;
@@ -103,6 +105,8 @@ public:
 
     //! can be used to project sidereal coordinates related to the image set on a plane.
     Point getCommonTangentPoint() const { return _commonTangentPoint; }
+
+    size_t getMaxMeasuredStars() const { return _maxMeasuredStars; }
 
     /**
      * @brief      Create a ccdImage from an exposure catalog and metadata, and add it to the list.
@@ -218,9 +222,14 @@ private:
      * Only call after selectFittedStars() has been called: it assumes that each measuredStar points to a
      * fittedStar, and that the measurementCount for each fittedStar is correct.
      */
-    void normalizeFittedStars() const;
+    void normalizeFittedStars();
 
     Point _commonTangentPoint;
+
+    // The number of MeasuredStars at the start of fitting, before any outliers are removed.
+    // This is used to reserve space in vectors for e.g. outlier removal, but is not updated during outlier
+    // removal or cleanup, so should only be used as an upper bound on the number of MeasuredStars.
+    size_t _maxMeasuredStars;
 };
 
 }  // namespace jointcal

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -159,8 +159,7 @@ private:
 
     void accumulateStatRefStars(Chi2Accumulator &accum) const override;
 
-    void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                  IndexVector &indices) const override;
+    void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const override;
 
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const &sky2TP,
                               Point const &refractionVector, double refractionCoeff, double mjd) const;

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -142,8 +142,6 @@ private:
     double _JDRef;                    // average Julian date
 
     // counts in parameter subsets.
-    std::size_t _nParDistortions;
-    std::size_t _nParPositions;
     std::size_t _nParRefrac;
 
     double _posError;  // constant term on error on position (in pixel unit)

--- a/include/lsst/jointcal/BaseStar.h
+++ b/include/lsst/jointcal/BaseStar.h
@@ -80,7 +80,8 @@ public:
     }
 
     virtual void print(std::ostream &out) const {
-        out << "x: " << x << " y: " << y << " flux: " << _flux << " fluxErr: " << _fluxErr;
+        FatPoint::print(out);
+        out << " flux: " << std::setprecision(9) << _flux << " fluxErr: " << _fluxErr;
     }
 
     BaseStar &operator=(Point const &point) {

--- a/include/lsst/jointcal/FatPoint.h
+++ b/include/lsst/jointcal/FatPoint.h
@@ -48,7 +48,7 @@ public:
 
     void print(std::ostream& s = std::cout) const {
         Point::print(s);
-        s << " vxx,vyy,vxy " << vx << ' ' << vy << ' ' << vxy;
+        s << std::setprecision(8) << " vxx,vyy,vxy " << vx << ',' << vy << ',' << vxy;
     }
 };
 }  // namespace jointcal

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -203,8 +203,7 @@ protected:
     void removeRefOutliers(FittedStarList &outliers);
 
     /// Set the indices of a measured star from the full matrix, for outlier removal.
-    virtual void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                          IndexVector &indices) const = 0;
+    virtual void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const = 0;
 
     /// Compute the chi2 (per star or total, depending on which Chi2Accumulator is used) for measurements.
     virtual void accumulateStatImageList(CcdImageList const &ccdImageList, Chi2Accumulator &accum) const = 0;

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -53,7 +53,7 @@ enum class MinimizeResult {
 class FitterBase {
 public:
     explicit FitterBase(std::shared_ptr<Associations> associations)
-            : _associations(associations), _whatToFit(""), _lastNTrip(0), _nParTot(0) {}
+            : _associations(associations), _whatToFit(""), _lastNTrip(0), _nTotal(0) {}
 
     /// No copy or move: there is only ever one fitter of a given type.
     FitterBase(FitterBase const &) = delete;
@@ -157,7 +157,7 @@ protected:
     std::string _whatToFit;
 
     Eigen::Index _lastNTrip;  // last triplet count, used to speed up allocation
-    Eigen::Index _nParTot;
+    Eigen::Index _nTotal;     // Total number of parameters being fit.
 
     // lsst.logging instance, to be created by subclass so that messages have consistent name while fitting.
     LOG_LOGGER _log;

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -53,7 +53,7 @@ enum class MinimizeResult {
 class FitterBase {
 public:
     explicit FitterBase(std::shared_ptr<Associations> associations)
-            : _associations(associations), _whatToFit(""), _lastNTrip(0), _nParTot(0), _nMeasuredStars(0) {}
+            : _associations(associations), _whatToFit(""), _lastNTrip(0), _nParTot(0) {}
 
     /// No copy or move: there is only ever one fitter of a given type.
     FitterBase(FitterBase const &) = delete;
@@ -158,7 +158,6 @@ protected:
 
     Eigen::Index _lastNTrip;  // last triplet count, used to speed up allocation
     Eigen::Index _nParTot;
-    Eigen::Index _nMeasuredStars;
 
     // lsst.logging instance, to be created by subclass so that messages have consistent name while fitting.
     LOG_LOGGER _log;

--- a/include/lsst/jointcal/FitterBase.h
+++ b/include/lsst/jointcal/FitterBase.h
@@ -53,7 +53,12 @@ enum class MinimizeResult {
 class FitterBase {
 public:
     explicit FitterBase(std::shared_ptr<Associations> associations)
-            : _associations(associations), _whatToFit(""), _lastNTrip(0), _nTotal(0) {}
+            : _associations(associations),
+              _whatToFit(""),
+              _lastNTrip(0),
+              _nTotal(0),
+              _nModelParams(0),
+              _nStarParams(0) {}
 
     /// No copy or move: there is only ever one fitter of a given type.
     FitterBase(FitterBase const &) = delete;
@@ -156,8 +161,10 @@ protected:
     std::shared_ptr<Associations> _associations;
     std::string _whatToFit;
 
-    Eigen::Index _lastNTrip;  // last triplet count, used to speed up allocation
-    Eigen::Index _nTotal;     // Total number of parameters being fit.
+    Eigen::Index _lastNTrip;     // last triplet count, used to speed up allocation
+    Eigen::Index _nTotal;        // Total number of parameters being fit.
+    Eigen::Index _nModelParams;  // Number of model parameters that are being fit.
+    Eigen::Index _nStarParams;   // Number of star positions/fluxes that are being fit.
 
     // lsst.logging instance, to be created by subclass so that messages have consistent name while fitting.
     LOG_LOGGER _log;

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -106,8 +106,7 @@ private:
 
     void accumulateStatRefStars(Chi2Accumulator &accum) const override;
 
-    void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                  IndexVector &indices) const override;
+    void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const override;
 
     void leastSquareDerivativesMeasurement(CcdImage const &ccdImage, TripletList &tripletList,
                                            Eigen::VectorXd &grad,

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -55,9 +55,7 @@ public:
             : FitterBase(associations),
               _fittingModel(false),
               _fittingFluxes(false),
-              _photometryModel(photometryModel),
-              _nParModel(0),
-              _nParFluxes(0) {
+              _photometryModel(photometryModel) {
         _log = LOG_GET("jointcal.PhotometryFit");
     }
 
@@ -97,10 +95,6 @@ protected:
 private:
     bool _fittingModel, _fittingFluxes;
     std::shared_ptr<PhotometryModel> _photometryModel;
-
-    // counts in parameter subsets.
-    std::size_t _nParModel;
-    std::size_t _nParFluxes;
 
     void accumulateStatImageList(CcdImageList const &ccdImageList, Chi2Accumulator &accum) const override;
 

--- a/include/lsst/jointcal/Point.h
+++ b/include/lsst/jointcal/Point.h
@@ -25,6 +25,7 @@
 #ifndef LSST_JOINTCAL_POINT_H
 #define LSST_JOINTCAL_POINT_H
 #include <iostream>
+#include <iomanip>
 #include <cmath>
 
 namespace lsst {
@@ -62,10 +63,10 @@ public:
     //! Difference
     Point operator-(const Point& Right) const { return Point(x - Right.x, y - Right.y); }
 
-    //! utility
-    virtual void print(std::ostream& s = std::cout) const { s << "x: " << x << " y: " << y; }
+    virtual void print(std::ostream& s = std::cout) const {
+        s << std::setprecision(15) << "x: " << x << " y: " << y;
+    }
 
-    //! -
     friend std::ostream& operator<<(std::ostream& stream, const Point& point) {
         point.print(stream);
         return stream;

--- a/python/lsst/jointcal/associations.cc
+++ b/python/lsst/jointcal/associations.cc
@@ -55,6 +55,7 @@ void declareAssociations(py::module &mod) {
     cls.def("createCcdImage", &Associations::createCcdImage);
     cls.def("addCcdImage", &Associations::addCcdImage);
     cls.def("prepareFittedStars", &Associations::prepareFittedStars);
+    cls.def("cleanFittedStars", &Associations::cleanFittedStars);
 
     cls.def("getCcdImageList", &Associations::getCcdImageList, py::return_value_policy::reference_internal);
     cls.def_property_readonly("ccdImageList", &Associations::getCcdImageList,

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -451,7 +451,7 @@ class JointcalConfig(pipeBase.PipelineTaskConfig,
         default=20,
     )
     maxAstrometrySteps = pexConfig.Field(
-        doc="Maximum number of minimize iterations to take when fitting photometry.",
+        doc="Maximum number of minimize iterations to take when fitting astrometry.",
         dtype=int,
         default=20,
     )

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -344,7 +344,7 @@ void Associations::selectFittedStars(int minMeasurements) {
     LOGLS_INFO(_log, "Total, valid number of Measured stars: " << totalMeasured << ", " << validMeasured);
 }
 
-void Associations::normalizeFittedStars() const {
+void Associations::normalizeFittedStars() {
     // Clear positions in order to take the average of the measuredStars.
     for (auto &fittedStar : fittedStarList) {
         fittedStar->x = 0.0;
@@ -370,8 +370,10 @@ void Associations::normalizeFittedStars() const {
         }
     }
 
+    _maxMeasuredStars = 0;
     for (auto &fi : fittedStarList) {
         auto measurementCount = fi->getMeasurementCount();
+        _maxMeasuredStars += measurementCount;
         fi->x /= measurementCount;
         fi->y /= measurementCount;
         fi->getFlux() /= measurementCount;

--- a/src/Associations.cc
+++ b/src/Associations.cc
@@ -379,6 +379,25 @@ void Associations::normalizeFittedStars() const {
     }
 }
 
+void Associations::cleanFittedStars() {
+    auto iter = fittedStarList.begin();
+    auto end = fittedStarList.end();
+    size_t count = 0;
+    while (iter != end) {
+        auto fittedStar = *iter;
+        if (fittedStar->getMeasurementCount() == 0) {
+            LOGLS_TRACE(_log, "Deleting FittedStar (has no measuredStars): " << *fittedStar);
+            iter = fittedStarList.erase(iter);
+            count++;
+        } else {
+            ++iter;
+        }
+    }
+    if (count > 0) {
+        LOGLS_INFO(_log, "Removed " << count << " fittedStars that had no associated measuredStar.");
+    }
+}
+
 void Associations::assignMags() {
     for (auto const &ccdImage : ccdImageList) {
         MeasuredStarList &catalog = ccdImage->getCatalogForFit();

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -482,11 +482,11 @@ void AstrometryFit::assignIndices(std::string const &whatToFit) {
         _refracPosInMatrix = ipar;
         ipar += _nParRefrac;
     }
-    _nParTot = ipar;
+    _nTotal = ipar;
 }
 
 void AstrometryFit::offsetParams(Eigen::VectorXd const &delta) {
-    if (delta.size() != _nParTot)
+    if (delta.size() != _nTotal)
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "AstrometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");
@@ -528,13 +528,13 @@ void AstrometryFit::checkStuff() {
     for (unsigned k = 0; k < sizeof(what2fit) / sizeof(what2fit[0]); ++k) {
         assignIndices(what2fit[k]);
         TripletList tripletList(10000);
-        Eigen::VectorXd grad(_nParTot);
+        Eigen::VectorXd grad(_nTotal);
         grad.setZero();
         leastSquareDerivatives(tripletList, grad);
-        SparseMatrixD jacobian(_nParTot, tripletList.getNextFreeIndex());
+        SparseMatrixD jacobian(_nTotal, tripletList.getNextFreeIndex());
         jacobian.setFromTriplets(tripletList.begin(), tripletList.end());
         SparseMatrixD hessian = jacobian * jacobian.transpose();
-        LOGLS_DEBUG(_log, "npar : " << _nParTot << ' ' << _nParDistortions);
+        LOGLS_DEBUG(_log, "npar : " << _nTotal << ' ' << _nParDistortions);
     }
 }
 

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -428,8 +428,7 @@ void AstrometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
 //! this routine is to be used only in the framework of outlier removal
 /*! it fills the array of indices of parameters that a Measured star
     constrains. Not really all of them if you check. */
-void AstrometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                             IndexVector &indices) const {
+void AstrometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const {
     if (_fittingDistortions) {
         const AstrometryMapping *mapping = _astrometryModel->getMapping(measuredStar.getCcdImage());
         mapping->getMappingIndices(indices);

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -53,7 +53,7 @@ std::size_t FitterBase::findOutliers(double nSigmaCut, MeasuredStarList &msOutli
                                      FittedStarList &fsOutliers, double &cut) const {
     // collect chi2 contributions
     Chi2List chi2List;
-    chi2List.reserve(_associations->refStarList.size());  // TODO: do we need to reserve anything?
+    chi2List.reserve(_associations->getMaxMeasuredStars() + _associations->refStarList.size());
     // contributions from measurement terms:
     accumulateStatImageList(_associations->ccdImageList, chi2List);
     // and from reference terms

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -300,6 +300,10 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
         }
     }
 
+    if (totalMeasOutliers + totalRefOutliers > 0) {
+        _associations->cleanFittedStars();
+    }
+
     // only print the outlier summary if outlier rejection was turned on.
     if (nSigmaCut != 0) {
         LOGLS_INFO(_log, "Number of outliers (Measured + Reference = Total): "

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -53,7 +53,7 @@ std::size_t FitterBase::findOutliers(double nSigmaCut, MeasuredStarList &msOutli
                                      FittedStarList &fsOutliers, double &cut) const {
     // collect chi2 contributions
     Chi2List chi2List;
-    chi2List.reserve(_nMeasuredStars + _associations->refStarList.size());
+    chi2List.reserve(_associations->refStarList.size());  // TODO: do we need to reserve anything?
     // contributions from measurement terms:
     accumulateStatImageList(_associations->ccdImageList, chi2List);
     // and from reference terms

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -45,7 +45,7 @@ Chi2Statistic FitterBase::computeChi2() const {
     accumulateStatRefStars(chi2);
     // chi2.ndof contains the number of squares.
     // So subtract the number of parameters.
-    chi2.ndof -= _nParTot;
+    chi2.ndof -= _nTotal;
     return chi2;
 }
 
@@ -74,7 +74,7 @@ std::size_t FitterBase::findOutliers(double nSigmaCut, MeasuredStarList &msOutli
        of what we are touching using an integer vector. This is the
        trick that Marc Betoule came up to for outlier removals in "star
        flats" fits. */
-    Eigen::VectorXi affectedParams(_nParTot);
+    Eigen::VectorXi affectedParams(_nTotal);
     affectedParams.setZero();
 
     std::size_t nOutliers = 0;  // returned to the caller
@@ -178,7 +178,7 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
     // TODO : write a guesser for the number of triplets
     std::size_t nTrip = (_lastNTrip) ? _lastNTrip : 1e6;
     TripletList tripletList(nTrip);
-    Eigen::VectorXd grad(_nParTot);
+    Eigen::VectorXd grad(_nTotal);
     grad.setZero();
     double scale = 1.0;
 
@@ -188,7 +188,7 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
 
     LOGLS_DEBUG(_log, "End of triplet filling, ntrip = " << tripletList.size());
 
-    SparseMatrixD hessian = createHessian(_nParTot, tripletList);
+    SparseMatrixD hessian = createHessian(_nTotal, tripletList);
     tripletList.clear();  // we don't need it any more after we have the hessian.
 
     LOGLS_DEBUG(_log, "Starting factorization, hessian: dim="
@@ -263,7 +263,7 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
         removeRefOutliers(fsOutliers);
         if (doRankUpdate) {
             // convert triplet list to eigen internal format
-            SparseMatrixD H(_nParTot, outlierTriplets.getNextFreeIndex());
+            SparseMatrixD H(_nTotal, outlierTriplets.getNextFreeIndex());
             H.setFromTriplets(outlierTriplets.begin(), outlierTriplets.end());
             chol.update(H, false /* means downdate */);
             // The contribution of outliers to the gradient is the opposite
@@ -278,7 +278,7 @@ MinimizeResult FitterBase::minimize(std::string const &whatToFit, double nSigmaC
             _lastNTrip = nextTripletList.size();
             LOGLS_DEBUG(_log, "Triplets recomputed, ntrip = " << nextTripletList.size());
 
-            hessian = createHessian(_nParTot, nextTripletList);
+            hessian = createHessian(_nTotal, nextTripletList);
             nextTripletList.clear();  // we don't need it any more after we have the hessian.
 
             LOGLS_DEBUG(_log,

--- a/src/FitterBase.cc
+++ b/src/FitterBase.cc
@@ -91,7 +91,14 @@ std::size_t FitterBase::findOutliers(double nSigmaCut, MeasuredStarList &msOutli
             // it is a reference outlier
             fittedStar = std::dynamic_pointer_cast<FittedStar>(chi2->star);
             if (fittedStar->getMeasurementCount() == 0) {
-                LOGLS_WARN(_log, "FittedStar with no measuredStars found as an outlier: " << *fittedStar);
+                LOGLS_WARN(_log, "FittedStar with no measuredStars found as an outlier: "
+                                         << *fittedStar << " chi2: " << chi2->chi2);
+                continue;
+            }
+            if (_nStarParams == 0) {
+                LOGLS_TRACE(_log,
+                            "RefStar is outlier but not removed when not fitting FittedStar-RefStar values: "
+                                    << *(fittedStar->getRefStar()) << " chi2: " << chi2->chi2);
                 continue;
             }
             // NOTE: Stars contribute twice to astrometry (x,y), but once to photometry (flux),

--- a/src/Histo2d.cc
+++ b/src/Histo2d.cc
@@ -36,7 +36,7 @@ LOG_LOGGER _log = LOG_GET("jointcal.Histo2d");
 namespace lsst {
 namespace jointcal {
 
-Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float mmaxy) : data(nnx*nny,0.) {
+Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float mmaxy) : data(nnx * nny, 0.) {
     nx = nnx;
     ny = nny;
     minx = mminx;
@@ -56,13 +56,13 @@ Histo2d::Histo2d(int nnx, float mminx, float mmaxx, int nny, float mminy, float 
 }
 
 Histo2d::Histo2d(const Histo2d &other) {
-    data=other.data;
-    nx=other.nx; 
-    ny=other.ny;
-    minx=other.minx;
-    miny=other.miny;
-    scalex=other.scalex;
-    scaley=other.scaley;
+    data = other.data;
+    nx = other.nx;
+    ny = other.ny;
+    minx = other.minx;
+    miny = other.miny;
+    scalex = other.scalex;
+    scaley = other.scaley;
 }
 
 bool Histo2d::indices(double x, double y, int &ix, int &iy) const {
@@ -81,7 +81,7 @@ double Histo2d::maxBin(double &x, double &y) const {
     int imax = 0;
     float valmax = -1e30;
 
-    for (std::size_t i=0;i < data.size(); i++) {
+    for (std::size_t i = 0; i < data.size(); i++) {
         if (data[i] > valmax) {
             valmax = data[i];
             imax = i;

--- a/src/Histo4d.cc
+++ b/src/Histo4d.cc
@@ -40,7 +40,8 @@ namespace jointcal {
 
 SparseHisto4d::SparseHisto4d(const int n1, double min1, double max1, const int n2, double min2, double max2,
                              const int n3, double min3, double max3, const int n4, double min4, double max4,
-                             const int nEntries) : _data(nEntries,0) {
+                             const int nEntries)
+        : _data(nEntries, 0) {
     double indexMax = n1 * n2 * n3 * n4;
     if (indexMax > double(INT_MAX))
         LOGLS_WARN(_log, "Cannot hold a 4D histo with more than " << INT_MAX << " values.");

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -203,13 +203,13 @@ void PhotometryFit::assignIndices(std::string const &whatToFit) {
         }
     }
     _nParFluxes = ipar - _nParModel;
-    _nParTot = ipar;
+    _nTotal = ipar;
     LOGLS_DEBUG(_log,
-                "nParameters total: " << _nParTot << " model: " << _nParModel << " fluxes: " << _nParFluxes);
+                "nParameters total: " << _nTotal << " model: " << _nParModel << " fluxes: " << _nParFluxes);
 }
 
 void PhotometryFit::offsetParams(Eigen::VectorXd const &delta) {
-    if (delta.size() != _nParTot)
+    if (delta.size() != _nTotal)
         throw LSST_EXCEPT(pex::exceptions::InvalidParameterError,
                           "PhotometryFit::offsetParams : the provided vector length is not compatible with "
                           "the current whatToFit setting");

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -170,8 +170,7 @@ void PhotometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
 //! this routine is to be used only in the framework of outlier removal
 /*! it fills the array of indices of parameters that a Measured star
     constrains. Not really all of them if you check. */
-void PhotometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar,
-                                             IndexVector &indices) const {
+void PhotometryFit::getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const {
     indices.clear();
     if (_fittingModel) {
         _photometryModel->getMappingIndices(measuredStar.getCcdImage(), indices);

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -189,8 +189,8 @@ void PhotometryFit::assignIndices(std::string const &whatToFit) {
     _fittingFluxes = (_whatToFit.find("Fluxes") != std::string::npos);
     // When entering here, we assume that whatToFit has already been interpreted.
 
-    _nParModel = (_fittingModel) ? _photometryModel->assignIndices(whatToFit, 0) : 0;
-    std::size_t ipar = _nParModel;
+    _nModelParams = (_fittingModel) ? _photometryModel->assignIndices(whatToFit, 0) : 0;
+    std::size_t ipar = _nModelParams;
 
     if (_fittingFluxes) {
         for (auto &fittedStar : _associations->fittedStarList) {
@@ -202,10 +202,10 @@ void PhotometryFit::assignIndices(std::string const &whatToFit) {
             ipar += 1;
         }
     }
-    _nParFluxes = ipar - _nParModel;
+    _nStarParams = ipar - _nModelParams;
     _nTotal = ipar;
-    LOGLS_DEBUG(_log,
-                "nParameters total: " << _nTotal << " model: " << _nParModel << " fluxes: " << _nParFluxes);
+    LOGLS_DEBUG(_log, "nParameters total: " << _nTotal << " model: " << _nModelParams
+                                            << " fluxes: " << _nStarParams);
 }
 
 void PhotometryFit::offsetParams(Eigen::VectorXd const &delta) {

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -137,8 +137,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
                    'associated_astrometry_fittedStars': 2272,
                    'selected_astrometry_fittedStars': 1229,
                    'selected_astrometry_ccdImages': 12,
-                   'astrometry_final_chi2': 1124.0575,
-                   'astrometry_final_ndof': 1912,
+                   'astrometry_final_chi2': 1144.88,
+                   'astrometry_final_ndof': 1918,
                    }
 
         return dist_rms_relative, metrics
@@ -159,7 +159,7 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """
         relative_error, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
         metrics['astrometry_final_chi2'] = 1069.348
-        metrics['astrometry_final_ndof'] = 1900
+        metrics['astrometry_final_ndof'] = 1644
 
         self.config.astrometryDoRankUpdate = False
 
@@ -171,8 +171,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """
         dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
         self.config.outlierRejectSigma = 4
-        metrics['astrometry_final_chi2'] = 757.027
-        metrics['astrometry_final_ndof'] = 1732
+        metrics['astrometry_final_chi2'] = 772.409
+        metrics['astrometry_final_ndof'] = 1744
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 
@@ -183,8 +183,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """
         dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
         self.config.astrometryOutlierRelativeTolerance = 0.01
-        metrics['astrometry_final_chi2'] = 1427.11
-        metrics['astrometry_final_ndof'] = 1990
+        metrics['astrometry_final_chi2'] = 1400.84
+        metrics['astrometry_final_ndof'] = 1986
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 
@@ -252,7 +252,7 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         # The constrainedPhotometry model is not purely linear, so a small
         # change in final chi2 is possible.
         metrics['photometry_final_chi2'] = 11396.27
-        metrics['photometry_final_ndof'] = 2716
+        metrics['photometry_final_ndof'] = 2695
 
         self._testJointcalTask(2, None, None, pa1, metrics=metrics)
 
@@ -268,7 +268,7 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         # lines in the DEBUG log for values that are not ~1 for proof).
         pa1 = 0.14
         metrics['photometry_final_chi2'] = 10500.4
-        metrics['photometry_final_ndof'] = 2714
+        metrics['photometry_final_ndof'] = 2712
 
         self._testJointcalTask(2, None, None, pa1, metrics=metrics)
 

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -96,8 +96,8 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
                    'selected_photometry_fittedStars': 4637,
                    'selected_astrometry_ccdImages': 15,
                    'selected_photometry_ccdImages': 15,
-                   'astrometry_final_chi2': 2803.108,
-                   'astrometry_final_ndof': 890,
+                   'astrometry_final_chi2': 2899.14,
+                   'astrometry_final_ndof': 896,
                    'photometry_final_chi2': 16529,
                    'photometry_final_ndof': 3634,
                    }

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -253,8 +253,8 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
                    'associated_astrometry_fittedStars': 2070,
                    'selected_astrometry_fittedStars': 1042,
                    'selected_astrometry_ccdImages': 6,
-                   'astrometry_final_chi2': 800.346,
-                   'astrometry_final_ndof': 1864,
+                   'astrometry_final_chi2': 819.608,
+                   'astrometry_final_ndof': 1872,
                    }
         pa1 = None
         self._testJointcalTask(2, self.dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)


### PR DESCRIPTION
The new code here is not exercised by any existing tests, and it's not something I can readily mock up with a new test. It does allow us to try out an alternate fitting approach in DM-30252, and I hope that ticket produces a test case that uses this code.