### PR TITLE
DM-24278: Apply proper motion to matched sources in Jointcal

### DIFF
--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -78,12 +78,14 @@ public:
      * parallelize the creation of the ccdImages.
      *
      * @param imageList A pre-built ccdImage list.
+     * @param epoch The julian epoch year to which all proper motion corrections should be made.
      */
-    Associations(CcdImageList const &imageList)
+    Associations(CcdImageList const &imageList, double epoch = 0)
             : ccdImageList(imageList),
               _commonTangentPoint(Point(std::numeric_limits<double>::quiet_NaN(),
                                         std::numeric_limits<double>::quiet_NaN())),
-              _maxMeasuredStars(0) {}
+              _maxMeasuredStars(0),
+              _epoch(epoch) {}
 
     /// No moves or copies: jointcal only ever needs one Associations object.
     Associations(Associations const &) = delete;
@@ -107,6 +109,14 @@ public:
     Point getCommonTangentPoint() const { return _commonTangentPoint; }
 
     size_t getMaxMeasuredStars() const { return _maxMeasuredStars; }
+
+    /**
+     * Common epoch of all of the ccdImages as a Julian Epoch Year (e.g. 2000.0 for J2000).
+     */
+    ///@{
+    double getEpoch() const { return _epoch; }
+    void setEpoch(double epoch) { _epoch = epoch; }
+    ///@}
 
     /**
      * @brief      Create a ccdImage from an exposure catalog and metadata, and add it to the list.
@@ -224,12 +234,17 @@ private:
      */
     void normalizeFittedStars();
 
+    // Common tangent point on-sky of all of the ccdImages, typically determined by computeCommonTangentPoint.
     Point _commonTangentPoint;
 
     // The number of MeasuredStars at the start of fitting, before any outliers are removed.
     // This is used to reserve space in vectors for e.g. outlier removal, but is not updated during outlier
     // removal or cleanup, so should only be used as an upper bound on the number of MeasuredStars.
     size_t _maxMeasuredStars;
+
+    // Julian Epoch Year (e.g. 2000.0 for J2000)
+    // Common epoch of all of the ccdImages, typically computed externally via astropy and then set.
+    double _epoch;
 };
 
 }  // namespace jointcal

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -167,13 +167,6 @@ public:
     //! track of that.
     void deprojectFittedStars();
 
-//! Set the color field of FittedStar 's from a colored catalog.
-/* If Color is "g-i", then the color is assigned from columns "g" and "i" of the colored catalog. */
-#ifdef TODO
-    void setFittedStarColors(std::string const &dicStarListName, std::string const &color,
-                             double matchCutArcSec);
-#endif
-
     /**
      * Prepare the fittedStar list by making quality cuts and normalizing measurements.
      *

--- a/include/lsst/jointcal/Associations.h
+++ b/include/lsst/jointcal/Associations.h
@@ -99,14 +99,14 @@ public:
     void computeCommonTangentPoint();
 
     /**
-     * @brief      Sets a shared tangent point for all ccdImages.
+     * Shared tangent point for all ccdImages (decimal degrees).
      *
-     * @param      commonTangentPoint  The common tangent point of all input images (decimal degrees).
+     * Used to project sidereal coordinates related to the images onto a single plane.
      */
+    ///@{
     void setCommonTangentPoint(lsst::geom::Point2D const &commonTangentPoint);
-
-    //! can be used to project sidereal coordinates related to the image set on a plane.
     Point getCommonTangentPoint() const { return _commonTangentPoint; }
+    ///@}
 
     size_t getMaxMeasuredStars() const { return _maxMeasuredStars; }
 
@@ -228,6 +228,7 @@ private:
     void normalizeFittedStars();
 
     // Common tangent point on-sky of all of the ccdImages, typically determined by computeCommonTangentPoint.
+    // (decimal degrees)
     Point _commonTangentPoint;
 
     // The number of MeasuredStars at the start of fitting, before any outliers are removed.

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -139,11 +139,11 @@ private:
     double _referenceColor, _sigCol;  // average and r.m.s color
     double _refractionCoefficient;    // fit parameter
     Eigen::Index _refracPosInMatrix;  // where it stands
-    double _JDRef;                    // average Julian date
 
     // counts in parameter subsets.
     std::size_t _nParRefrac;
 
+    double _epoch;     // epoch to correct proper motion/parallax to (Julian Epoch year, e.g. J2000.0)
     double _posError;  // constant term on error on position (in pixel unit)
 
     void leastSquareDerivativesMeasurement(CcdImage const &ccdImage, TripletList &tripletList,
@@ -160,7 +160,7 @@ private:
     void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const override;
 
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const &sky2TP,
-                              Point const &refractionVector, double refractionCoeff, double mjd) const;
+                              Point const &refractionVector, double refractionCoeff, double deltaYears) const;
 
     /// Compute the chi2 (per star or total, depending on which Chi2Accumulator is used) from one CcdImage.
     void accumulateStatImage(CcdImage const &ccdImage, Chi2Accumulator &accum) const;

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -159,6 +159,16 @@ private:
 
     void getIndicesOfMeasuredStar(MeasuredStar const &measuredStar, IndexVector &indices) const override;
 
+    /**
+     * Transform the positions of a FittedStar into the frame of a MeasuredStar.
+     *
+     * @param fittedStar The star to transform.
+     * @param sky2TP Transformation from sky coordinates to CcdImage tangent plane.
+     * @param refractionVector On-sky vector to refraction correct position.
+     * @param refractionCoeff Amount of refraction correction to apply.
+     * @param deltaYears Difference in years between FittedStar and MeasuredStar epochs.
+     * @return Corrected position of FittedStar.
+     */
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const &sky2TP,
                               Point const &refractionVector, double refractionCoeff, double deltaYears) const;
 

--- a/include/lsst/jointcal/AstrometryFit.h
+++ b/include/lsst/jointcal/AstrometryFit.h
@@ -91,7 +91,7 @@ public:
      * Set parameters to fit and assign indices in the big matrix.
      *
      * @param[in]  whatToFit   Valid strings: zero or more of "Distortions", "Positions",
-     *                         "Refrac", "PM" which define which parameter set
+     *                         "PM" which define which parameter set
      *                         is going to be variable when computing
      *                         derivatives (leastSquareDerivatives) and minimizing
      *                         (minimize()). whatToFit="Positions Distortions"
@@ -134,14 +134,8 @@ protected:
     void saveChi2RefContributions(std::string const &filename) const override;
 
 private:
-    bool _fittingDistortions, _fittingPos, _fittingRefrac, _fittingPM;
+    bool _fittingDistortions, _fittingPos, _fittingPM;
     std::shared_ptr<AstrometryModel> _astrometryModel;
-    double _referenceColor, _sigCol;  // average and r.m.s color
-    double _refractionCoefficient;    // fit parameter
-    Eigen::Index _refracPosInMatrix;  // where it stands
-
-    // counts in parameter subsets.
-    std::size_t _nParRefrac;
 
     double _epoch;     // epoch to correct proper motion/parallax to (Julian Epoch year, e.g. J2000.0)
     double _posError;  // constant term on error on position (in pixel unit)
@@ -164,13 +158,11 @@ private:
      *
      * @param fittedStar The star to transform.
      * @param sky2TP Transformation from sky coordinates to CcdImage tangent plane.
-     * @param refractionVector On-sky vector to refraction correct position.
-     * @param refractionCoeff Amount of refraction correction to apply.
      * @param deltaYears Difference in years between FittedStar and MeasuredStar epochs.
      * @return Corrected position of FittedStar.
      */
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const &sky2TP,
-                              Point const &refractionVector, double refractionCoeff, double deltaYears) const;
+                              double deltaYears) const;
 
     /// Compute the chi2 (per star or total, depending on which Chi2Accumulator is used) from one CcdImage.
     void accumulateStatImage(CcdImage const &ccdImage, Chi2Accumulator &accum) const;

--- a/include/lsst/jointcal/BaseStar.h
+++ b/include/lsst/jointcal/BaseStar.h
@@ -26,6 +26,7 @@
 #define LSST_JOINTCAL_BASE_STAR_H
 
 #include <iostream>
+#include <iomanip>
 #include <cstdio>
 #include <string>
 #include <sstream>

--- a/include/lsst/jointcal/CcdImage.h
+++ b/include/lsst/jointcal/CcdImage.h
@@ -154,8 +154,7 @@ public:
     //!  Airmass
     double getAirMass() const { return _airMass; }
 
-    //! Julian Date
-    double getMjd() const { return _mjd; }
+    double getEpoch() const { return _epoch; }
 
     //! Return the exposure's photometric calibration
     std::shared_ptr<afw::image::PhotoCalib> getPhotoCalib() const { return _photoCalib; }
@@ -216,7 +215,7 @@ private:
 
     lsst::geom::SpherePoint _boresightRaDec;
     double _airMass;  // airmass value.
-    double _mjd;      // modified julian date
+    double _epoch;    // julian epoch year (e.g. 2000.0 for J2000)
     std::shared_ptr<afw::image::PhotoCalib> _photoCalib;
     std::shared_ptr<afw::cameraGeom::Detector> _detector;
     // refraction

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -29,6 +29,7 @@
 #include <fstream>
 
 #include "Eigen/Core"
+#include "lsst/jointcal/ProperMotion.h"
 #include "lsst/jointcal/BaseStar.h"
 #include "lsst/jointcal/StarList.h"
 
@@ -39,26 +40,14 @@ class MeasuredStar;
 class RefStar;
 class AstrometryTransform;
 
-/*! \file */
-
-//! objects whose position is going to be fitted. Coordinates in Common Tangent Plane.
-
-struct PmBlock {
-    // proper motion in x and y. Units depend on how you fit them
-    double pmx, pmy;
-    double epmx, epmy, epmxy;
-    double color;  // OK it is unrelated, but associated in practice
-    bool mightMove;
-
-    PmBlock() : pmx(0), pmy(0), epmx(0), epmy(0), epmxy(0), color(0), mightMove(false){};
-};
-
 /**
- * The objects which have been measured several times.
+ * FittedStars are objects whose position or flux is going to be fitted, and which come from the association
+ * of multiple MeasuredStars.
  *
+ * x/y Coordinates are in the Common Tangent Plane (degrees).
  * MeasuredStars from different CcdImages that represent the same on-sky object all point to one FittedStar.
  */
-class FittedStar : public BaseStar, public PmBlock {
+class FittedStar : public BaseStar {
 public:
     FittedStar() : BaseStar(), _indexInMatrix(-1), _measurementCount(0), _refStar(nullptr) {}
 
@@ -110,6 +99,8 @@ public:
 
     //! Get the astrometric reference star associated with this star.
     const RefStar* getRefStar() const { return _refStar; };
+
+    double color;  // TODO: remove this holdover from PmBlock class
 
 private:
     Eigen::Index _indexInMatrix;

--- a/include/lsst/jointcal/FittedStar.h
+++ b/include/lsst/jointcal/FittedStar.h
@@ -100,8 +100,6 @@ public:
     //! Get the astrometric reference star associated with this star.
     const RefStar* getRefStar() const { return _refStar; };
 
-    double color;  // TODO: remove this holdover from PmBlock class
-
 private:
     Eigen::Index _indexInMatrix;
     int _measurementCount;

--- a/include/lsst/jointcal/MeasuredStar.h
+++ b/include/lsst/jointcal/MeasuredStar.h
@@ -41,8 +41,13 @@ double instMagFromInstFlux(double instFlux) { return -2.5 * std::log10(instFlux)
 
 class CcdImage;
 
-//! objects measured on actual images. Coordinates and uncertainties are expressed in pixel image frame. Flux
-//! expressed in ADU/s.
+/**
+ * Sources measured on images.
+ *
+ * x/y positions and uncertainties (from BaseStar) are in pixels in the image frame.
+ * instFlux[Err] are in counts.
+ * flux[Err] (from BaseStar) are nJy.
+ */
 class MeasuredStar : public BaseStar {
 public:
     MeasuredStar()

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -109,11 +109,6 @@ private:
     /// Compute the derivatives of the reference terms
     void leastSquareDerivativesReference(FittedStarList const &fittedStarList, TripletList &tripletList,
                                          Eigen::VectorXd &grad) const override;
-
-#ifdef STORAGE
-    Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const *sky2TP,
-                              Point const &refractionVector, double refractionCoeff, double deltaYears) const;
-#endif
 };
 }  // namespace jointcal
 }  // namespace lsst

--- a/include/lsst/jointcal/PhotometryFit.h
+++ b/include/lsst/jointcal/PhotometryFit.h
@@ -112,7 +112,7 @@ private:
 
 #ifdef STORAGE
     Point transformFittedStar(FittedStar const &fittedStar, AstrometryTransform const *sky2TP,
-                              Point const &refractionVector, double refractionCoeff, double mjd) const;
+                              Point const &refractionVector, double refractionCoeff, double deltaYears) const;
 #endif
 };
 }  // namespace jointcal

--- a/include/lsst/jointcal/ProperMotion.h
+++ b/include/lsst/jointcal/ProperMotion.h
@@ -1,0 +1,83 @@
+// -*- LSST-C++ -*-
+/*
+ * This file is part of jointcal.
+ *
+ * Developed for the LSST Data Management System.
+ * This product includes software developed by the LSST Project
+ * (https://www.lsst.org).
+ * See the COPYRIGHT file at the top-level directory of this distribution
+ * for details of code ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef LSST_JOINTCAL_PROPER_MOTION_H
+#define LSST_JOINTCAL_PROPER_MOTION_H
+
+#include <iostream>
+#include <memory>
+#include <math.h>  // atan2
+
+namespace lsst {
+namespace jointcal {
+
+class Point;
+
+/**
+ * Proper motion data for a reference star or fitted star.
+ *
+ * Whether to just use these values or fit them is determined by the RefStar and FittedStar they belong to.
+ *
+ * Units are radians/year
+ * Note: RA proper motion is `pm_ra*cos(dec)`
+ */
+class ProperMotion {
+public:
+    ProperMotion(double ra, double dec, double raErr, double decErr, double raDecCov = 0)
+            : _ra(ra), _dec(dec), _raErr(raErr), _decErr(decErr), _raDecCov(raDecCov) {
+        _offsetBearing = atan2(dec, ra);
+    };
+
+    ProperMotion(ProperMotion const &) = default;
+    ProperMotion(ProperMotion &&) = default;
+    ProperMotion &operator=(ProperMotion const &) = default;
+    ProperMotion &operator=(ProperMotion &&) = default;
+    ~ProperMotion() = default;
+
+    /**
+     * Apply proper motion correction to the input star, returning a star with PM-corrected coordinates.
+     *
+     * NOTE: This method does not apply to the coordinate errors (Point does not include uncertainty).
+     *
+     * @param star The star to correct for this proper motion.
+     * @param timeDeltaYears The difference in time from the correction epoch to correct for, in years.
+     *
+     * @return The star with corrected coordinates.
+     */
+    Point apply(Point star, double timeDeltaYears) const;
+
+    friend std::ostream &operator<<(std::ostream &stream, ProperMotion const &pm);
+
+private:
+    // Proper motion in ra and dec. Units are radians/year
+    double _ra, _dec;
+    double _raErr, _decErr, _raDecCov;
+
+    // Cache the bearing along-which to offset.
+    double _offsetBearing;
+};
+}  // namespace jointcal
+}  // namespace lsst
+
+#endif  // LSST_JOINTCAL_PROPER_MOTION_H

--- a/include/lsst/jointcal/RefStar.h
+++ b/include/lsst/jointcal/RefStar.h
@@ -34,8 +34,13 @@
 namespace lsst {
 namespace jointcal {
 
-//! Objects used as position anchors, typically USNO stars. Coordinate system defined by user. The Common
-//! Tangent Plane seems a good idea.
+/**
+ * Objects used as position/flux anchors (e.g. Gaia DR2 stars). Coordinate system should match that of the
+ * fittedStars these are associated with; typically the common tangent plane.
+ *
+ * RefStars should ahve their proper motion and parallax corrections pre-applied, so that they are at
+ * the same epoch as is stored in Associations.
+ */
 class RefStar : public BaseStar {
 public:
     RefStar(double xx, double yy, double flux, double fluxErr) : BaseStar(xx, yy, flux, fluxErr) {}
@@ -48,8 +53,6 @@ public:
 };
 
 /****** RefStarList ***********/
-
-class Frame;
 
 // typedef StarList<RefStar> RefStarList;
 class RefStarList : public StarList<RefStar> {};

--- a/python/lsst/jointcal/associations.cc
+++ b/python/lsst/jointcal/associations.cc
@@ -39,7 +39,7 @@ namespace {
 void declareAssociations(py::module &mod) {
     py::class_<Associations, std::shared_ptr<Associations>> cls(mod, "Associations");
     cls.def(py::init<>());
-    cls.def(py::init<CcdImageList const &>(), "imageList"_a);
+    cls.def(py::init<CcdImageList const &, double>(), "imageList"_a, "epoch"_a = 0);
 
     // NOTE: these could go away if the lists they wrap can be accessed directly.
     cls.def("refStarListSize", &Associations::refStarListSize);
@@ -66,6 +66,9 @@ void declareAssociations(py::module &mod) {
     cls.def("getCommonTangentPoint", &Associations::getCommonTangentPoint);
     cls.def("setCommonTangentPoint", &Associations::setCommonTangentPoint);
     cls.def("computeCommonTangentPoint", &Associations::computeCommonTangentPoint);
+
+    cls.def("getEpoch", &Associations::getEpoch);
+    cls.def("setEpoch", &Associations::setEpoch);
 }
 
 PYBIND11_MODULE(associations, mod) {

--- a/python/lsst/jointcal/ccdImage.cc
+++ b/python/lsst/jointcal/ccdImage.cc
@@ -56,8 +56,8 @@ void declareCcdImage(py::module &mod) {
     cls.def("getCcdId", &CcdImage::getCcdId);
     cls.def_property_readonly("ccdId", &CcdImage::getCcdId);
 
-    cls.def("getMjd", &CcdImage::getMjd);
-    cls.def_property_readonly("mjd", &CcdImage::getMjd);
+    cls.def("getEpoch", &CcdImage::getEpoch);
+    cls.def_property_readonly("epoch", &CcdImage::getEpoch);
 
     cls.def("getImageFrame", &CcdImage::getImageFrame, py::return_value_policy::reference_internal);
     cls.def_property_readonly("imageFrame", &CcdImage::getImageFrame,

--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -497,7 +497,7 @@ class JointcalConfig(pipeBase.PipelineTaskConfig,
         dtype=bool,
         doc=("Write .csv files containing the contributions to chi2 for the initialization and final fit. "
              "Output files will be written to `config.debugOutputPath` and will "
-             "be of the form `astrometry_[initial|final]_chi2-TRACT-FILTER1."),
+             "be of the form `astrometry_[initial|final]_chi2-TRACT-FILTER."),
         default=False
     )
     writeChi2FilesOuterLoop = pexConfig.Field(

--- a/python/lsst/jointcal/star.cc
+++ b/python/lsst/jointcal/star.cc
@@ -66,13 +66,11 @@ void declareBaseStar(py::module &mod) {
     cls.def(py::init<double, double, double, double>(), "x"_a, "y"_a, "flux"_a, "fluxErr"_a);
 
     // these three are actually declared in FatPoint, but we didn't want that in Python.
-    // NOTE: see DM-9814 about the necessity of the pointer cast below.
     // readwrite so that we can set them in unittests.
-    cls.def_readwrite("vx", (double BaseStar::*)&BaseStar::vx);
-    cls.def_readwrite("vy", (double BaseStar::*)&BaseStar::vy);
-    cls.def_readwrite("vxy", (double BaseStar::*)&BaseStar::vxy);
+    cls.def_readwrite("vx", &BaseStar::vx);
+    cls.def_readwrite("vy", &BaseStar::vy);
+    cls.def_readwrite("vxy", &BaseStar::vxy);
 
-    // cls.def("getFlux", &BaseStar::getFlux);
     cls.def_property_readonly("flux", (double (BaseStar::*)() const) & BaseStar::getFlux);
     cls.def_property_readonly("fluxErr", (double (BaseStar::*)() const) & BaseStar::getFluxErr);
     cls.def_property_readonly("mag", (double (BaseStar::*)() const) & BaseStar::getMag);

--- a/src/AstrometryFit.cc
+++ b/src/AstrometryFit.cc
@@ -280,7 +280,7 @@ void AstrometryFit::leastSquareDerivativesReference(FittedStarList const &fitted
     TanRaDecToPixel proj(AstrometryTransformLinear(), Point(0., 0.));
     for (auto const &i : fittedStarList) {
         const FittedStar &fs = *i;
-        const RefStar *rs = fs.getRefStar();
+        auto rs = fs.getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.
@@ -405,7 +405,7 @@ void AstrometryFit::accumulateStatRefStars(Chi2Accumulator &accum) const {
     FittedStarList &fittedStarList = _associations->fittedStarList;
     TanRaDecToPixel proj(AstrometryTransformLinear(), Point(0., 0.));
     for (auto const &fs : fittedStarList) {
-        const RefStar *rs = fs->getRefStar();
+        auto rs = fs->getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(*fs);
         // fs projects to (0,0), no need to compute its transform.
@@ -636,7 +636,7 @@ void AstrometryFit::saveChi2RefContributions(std::string const &filename) const 
     TanRaDecToPixel proj(AstrometryTransformLinear(), Point(0., 0.));
     for (auto const &i : fittedStarList) {
         const FittedStar &fs = *i;
-        const RefStar *rs = fs.getRefStar();
+        auto rs = fs.getRefStar();
         if (rs == nullptr) continue;
         proj.setTangentPoint(fs);
         // fs projects to (0,0), no need to compute its transform.

--- a/src/CcdImage.cc
+++ b/src/CcdImage.cc
@@ -128,7 +128,7 @@ CcdImage::CcdImage(afw::table::SourceCatalog &catalog, std::shared_ptr<lsst::afw
 
     _boresightRaDec = visitInfo->getBoresightRaDec();
     _airMass = visitInfo->getBoresightAirmass();
-    _mjd = visitInfo->getDate().get(lsst::daf::base::DateTime::MJD);
+    _epoch = visitInfo->getDate().get(lsst::daf::base::DateTime::EPOCH);
     double latitude = visitInfo->getObservatory().getLatitude();
     _lstObs = visitInfo->getEra();
     _hourAngle = visitInfo->getBoresightHourAngle();

--- a/src/FittedStar.cc
+++ b/src/FittedStar.cc
@@ -46,10 +46,10 @@ FittedStar::FittedStar(const MeasuredStar &measuredStar)
 void FittedStar::setRefStar(const RefStar *refStar) {
     if ((_refStar != nullptr) && (refStar != nullptr)) {
         // TODO: should we raise an Exception in this case?
-        LOGLS_WARN(_log,
-                   "FittedStar: " << *this << " is already matched to another RefStar. Clean up your lists.");
-        LOGLS_WARN(_log, "old refStar: " << *_refStar);
-        LOGLS_WARN(_log, "new refStar: " << *refStar);
+        LOGLS_ERROR(_log, "FittedStar: " << *this
+                                         << " is already matched to another RefStar. Clean up your lists.");
+        LOGLS_ERROR(_log, "old refStar: " << *_refStar);
+        LOGLS_ERROR(_log, "new refStar: " << *refStar);
     } else
         _refStar = refStar;
 }

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -236,7 +236,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
     ofile << "inputFlux" << separator << "inputFluxErr" << separator;
     ofile << "transformedFlux" << separator << "transformedFluxErr" << separator;
     ofile << "fittedFlux" << separator;
-    ofile << "epoch" << separator << "color" << separator;
+    ofile << "epoch" << separator;
     ofile << "fsindex" << separator;
     ofile << "ra" << separator << "dec" << separator;
     ofile << "chi2" << separator << "nm" << separator;
@@ -249,7 +249,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
     ofile << "measured flux (nJy)" << separator << "measured flux error" << separator;
     ofile << separator << separator;
     ofile << "fitted flux (nJy)" << separator;
-    ofile << "Julian Epoch Year of the measurement" << separator << "currently unused" << separator;
+    ofile << "Julian Epoch Year of the measurement" << separator;
     ofile << "unique index of the fittedStar" << separator;
     ofile << "on-sky position of fitted star" << separator << separator;
     ofile << "contribution to Chi2 (1 dof)" << separator << "number of measurements of this FittedStar"
@@ -277,7 +277,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
             ofile << measuredStar->getInstFlux() << separator << instFluxErr << separator;
             ofile << measuredStar->getFlux() << separator << measuredStar->getFluxErr() << separator;
             ofile << flux << separator << fluxErr << separator << fittedStar->getFlux() << separator;
-            ofile << ccdImage->getEpoch() << separator << fittedStar->color << separator;
+            ofile << ccdImage->getEpoch() << separator;
             ofile << fittedStar->getIndexInMatrix() << separator;
             ofile << fittedStar->x << separator << fittedStar->y << separator;
             ofile << chi2Val << separator << fittedStar->getMeasurementCount() << separator;
@@ -291,13 +291,13 @@ void PhotometryFit::saveChi2RefContributions(std::string const &filename) const 
     std::string separator = "\t";
 
     ofile << "#ra" << separator << "dec " << separator;
-    ofile << "mag" << separator << "color" << separator;
+    ofile << "mag" << separator;
     ofile << "refFlux" << separator << "refFluxErr" << separator;
     ofile << "fittedFlux" << separator << "fittedFluxErr" << separator;
     ofile << "fsindex" << separator << "chi2" << separator << "nm" << std::endl;
 
     ofile << "#coordinates of fittedStar" << separator << separator;
-    ofile << "magnitude" << separator << "currently unused" << separator;
+    ofile << "magnitude" << separator;
     ofile << "refStar flux (nJy)" << separator << "refStar fluxErr" << separator;
     ofile << "fittedStar flux (nJy)" << separator << "fittedStar fluxErr" << separator;
     ofile << "unique index of the fittedStar" << separator << "refStar contribution to Chi2 (1 dof)"
@@ -313,7 +313,7 @@ void PhotometryFit::saveChi2RefContributions(std::string const &filename) const 
 
         ofile << std::setprecision(9);
         ofile << fittedStar->x << separator << fittedStar->y << separator;
-        ofile << fittedStar->getMag() << separator << fittedStar->color << separator;
+        ofile << fittedStar->getMag() << separator;
         ofile << refStar->getFlux() << separator << refStar->getFluxErr() << separator;
         ofile << fittedStar->getFlux() << separator << fittedStar->getFluxErr() << separator;
         ofile << fittedStar->getIndexInMatrix() << separator << chi2 << separator

--- a/src/PhotometryFit.cc
+++ b/src/PhotometryFit.cc
@@ -236,7 +236,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
     ofile << "inputFlux" << separator << "inputFluxErr" << separator;
     ofile << "transformedFlux" << separator << "transformedFluxErr" << separator;
     ofile << "fittedFlux" << separator;
-    ofile << "mjd" << separator << "color" << separator;
+    ofile << "epoch" << separator << "color" << separator;
     ofile << "fsindex" << separator;
     ofile << "ra" << separator << "dec" << separator;
     ofile << "chi2" << separator << "nm" << separator;
@@ -249,7 +249,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
     ofile << "measured flux (nJy)" << separator << "measured flux error" << separator;
     ofile << separator << separator;
     ofile << "fitted flux (nJy)" << separator;
-    ofile << "modified Julian date of the measurement" << separator << "currently unused" << separator;
+    ofile << "Julian Epoch Year of the measurement" << separator << "currently unused" << separator;
     ofile << "unique index of the fittedStar" << separator;
     ofile << "on-sky position of fitted star" << separator << separator;
     ofile << "contribution to Chi2 (1 dof)" << separator << "number of measurements of this FittedStar"
@@ -265,7 +265,6 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
             double instFluxErr = _photometryModel->tweakFluxError(*measuredStar);
             double flux = _photometryModel->transform(*ccdImage, *measuredStar);
             double fluxErr = _photometryModel->transformError(*ccdImage, *measuredStar);
-            double jd = ccdImage->getMjd();
             std::shared_ptr<FittedStar const> const fittedStar = measuredStar->getFittedStar();
             double residual = _photometryModel->computeResidual(*ccdImage, *measuredStar);
             double chi2Val = std::pow(residual / fluxErr, 2);
@@ -278,7 +277,7 @@ void PhotometryFit::saveChi2MeasContributions(std::string const &filename) const
             ofile << measuredStar->getInstFlux() << separator << instFluxErr << separator;
             ofile << measuredStar->getFlux() << separator << measuredStar->getFluxErr() << separator;
             ofile << flux << separator << fluxErr << separator << fittedStar->getFlux() << separator;
-            ofile << jd << separator << fittedStar->color << separator;
+            ofile << ccdImage->getEpoch() << separator << fittedStar->color << separator;
             ofile << fittedStar->getIndexInMatrix() << separator;
             ofile << fittedStar->x << separator << fittedStar->y << separator;
             ofile << chi2Val << separator << fittedStar->getMeasurementCount() << separator;

--- a/tests/test_jointcal.py
+++ b/tests/test_jointcal.py
@@ -26,6 +26,7 @@ from unittest import mock
 
 import numpy as np
 import pyarrow.parquet
+import astropy.time
 
 import lsst.log
 import lsst.utils
@@ -447,10 +448,10 @@ class TestComputeBoundingCircle(lsst.utils.tests.TestCase):
 
         # Put the visit boresights at the WCS origin, for consistency
         visitInfo1 = lsst.afw.image.VisitInfo(exposureId=30577512,
-                                              date=DateTime(65321.1),
+                                              date=DateTime(date=65321.1),
                                               boresightRaDec=wcs1.getSkyOrigin())
         visitInfo2 = lsst.afw.image.VisitInfo(exposureId=30621144,
-                                              date=DateTime(65322.1),
+                                              date=DateTime(date=65322.1),
                                               boresightRaDec=wcs1.getSkyOrigin())
 
         struct = lsst.jointcal.testUtils.createTwoFakeCcdImages(fakeWcses=[wcs1, wcs2],
@@ -460,22 +461,22 @@ class TestComputeBoundingCircle(lsst.utils.tests.TestCase):
 
 
 class TestJointcalComputePMDate(JointcalTestBase, lsst.utils.tests.TestCase):
-    """Tests of jointcal._compute_proper_motion_epoch()"""
+    """Tests of jointcal._compute_proper_motion_epoch(), using fake dates."""
     def test_compute_proper_motion_epoch(self):
-        mjds = np.array((65432.1, 66666, 65555, 64322.2))
+        mjds = np.array((65432.1, 66666.0, 55555.0, 44322.2))
 
         wcs1, wcs2 = make_fake_wcs()
         visitInfo1 = lsst.afw.image.VisitInfo(exposureId=30577512,
-                                              date=DateTime(mjds[0]),
+                                              date=DateTime(date=mjds[0]),
                                               boresightRaDec=wcs1.getSkyOrigin())
         visitInfo2 = lsst.afw.image.VisitInfo(exposureId=30621144,
-                                              date=DateTime(mjds[1]),
+                                              date=DateTime(date=mjds[1]),
                                               boresightRaDec=wcs2.getSkyOrigin())
         visitInfo3 = lsst.afw.image.VisitInfo(exposureId=30577513,
-                                              date=DateTime(mjds[2]),
+                                              date=DateTime(date=mjds[2]),
                                               boresightRaDec=wcs1.getSkyOrigin())
         visitInfo4 = lsst.afw.image.VisitInfo(exposureId=30621145,
-                                              date=DateTime(mjds[3]),
+                                              date=DateTime(date=mjds[3]),
                                               boresightRaDec=wcs2.getSkyOrigin())
 
         struct1 = lsst.jointcal.testUtils.createTwoFakeCcdImages(fakeWcses=[wcs1, wcs2],
@@ -490,7 +491,7 @@ class TestJointcalComputePMDate(JointcalTestBase, lsst.utils.tests.TestCase):
 
         jointcal = lsst.jointcal.JointcalTask(config=self.config, butler=self.butler)
         result = jointcal._compute_proper_motion_epoch(ccdImageList)
-        self.assertEqual(result.mjd, mjds.mean())
+        self.assertEqual(result.jyear, (astropy.time.Time(mjds, format="mjd", scale="tai").jyear).mean())
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_jointcal_cfht.py
+++ b/tests/test_jointcal_cfht.py
@@ -99,8 +99,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
                        'selected_photometry_fittedStars': 2232,
                        'selected_astrometry_ccdImages': 12,
                        'selected_photometry_ccdImages': 12,
-                       'astrometry_final_chi2': 1159.736,
-                       'astrometry_final_ndof': 1872,
+                       'astrometry_final_chi2': 1145.457,
+                       'astrometry_final_ndof': 1868,
                        'photometry_final_chi2': 11624.3,
                        'photometry_final_ndof': 2778
                        }
@@ -137,8 +137,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
                    'associated_astrometry_fittedStars': 2272,
                    'selected_astrometry_fittedStars': 1229,
                    'selected_astrometry_ccdImages': 12,
-                   'astrometry_final_chi2': 1144.88,
-                   'astrometry_final_ndof': 1918,
+                   'astrometry_final_chi2': 1100.75,
+                   'astrometry_final_ndof': 1910,
                    }
 
         return dist_rms_relative, metrics
@@ -158,7 +158,7 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """Demonstrate that skipping the rank update doesn't substantially affect astrometry.
         """
         relative_error, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
-        metrics['astrometry_final_chi2'] = 1069.348
+        metrics['astrometry_final_chi2'] = 1069.538
         metrics['astrometry_final_ndof'] = 1644
 
         self.config.astrometryDoRankUpdate = False
@@ -171,8 +171,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """
         dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
         self.config.outlierRejectSigma = 4
-        metrics['astrometry_final_chi2'] = 772.409
-        metrics['astrometry_final_ndof'] = 1744
+        metrics['astrometry_final_chi2'] = 800.919
+        metrics['astrometry_final_ndof'] = 1796
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 
@@ -183,8 +183,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         """
         dist_rms_relative, metrics = self.setup_jointcalTask_2_visits_constrainedAstrometry()
         self.config.astrometryOutlierRelativeTolerance = 0.01
-        metrics['astrometry_final_chi2'] = 1400.84
-        metrics['astrometry_final_ndof'] = 1986
+        metrics['astrometry_final_chi2'] = 1393.40
+        metrics['astrometry_final_ndof'] = 1982
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 
@@ -194,8 +194,8 @@ class JointcalTestCFHT(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestC
         test_config = os.path.join(lsst.utils.getPackageDir('jointcal'),
                                    'tests/config/astrometryReferenceErr-config.py')
         self.configfiles.append(test_config)
-        metrics['astrometry_final_chi2'] = 1275.70
-        metrics['astrometry_final_ndof'] = 2062
+        metrics['astrometry_final_chi2'] = 1303.55
+        metrics['astrometry_final_ndof'] = 2068
 
         self._testJointcalTask(2, dist_rms_relative, self.dist_rms_absolute, None, metrics=metrics)
 

--- a/tests/test_jointcal_decam.py
+++ b/tests/test_jointcal_decam.py
@@ -96,7 +96,7 @@ class JointcalTestDECAM(jointcalTestBase.JointcalTestBase, lsst.utils.tests.Test
                    'selected_photometry_fittedStars': 4637,
                    'selected_astrometry_ccdImages': 15,
                    'selected_photometry_ccdImages': 15,
-                   'astrometry_final_chi2': 2899.14,
+                   'astrometry_final_chi2': 2899.20,
                    'astrometry_final_ndof': 896,
                    'photometry_final_chi2': 16529,
                    'photometry_final_ndof': 3634,

--- a/tests/test_jointcal_hsc.py
+++ b/tests/test_jointcal_hsc.py
@@ -148,8 +148,8 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
                    'associated_astrometry_fittedStars': 5860,
                    'selected_astrometry_fittedStars': 3568,
                    'selected_astrometry_ccdImages': 30,
-                   'astrometry_final_chi2': 10218.518,
-                   'astrometry_final_ndof': 18574,
+                   'astrometry_final_chi2': 10225.31,
+                   'astrometry_final_ndof': 18576,
                    }
         self._testJointcalTask(10, dist_rms_relative, dist_rms_absolute, pa1, metrics=metrics)
 
@@ -299,7 +299,7 @@ class JointcalTestHSC(jointcalTestBase.JointcalTestBase, lsst.utils.tests.TestCa
                    'associated_astrometry_fittedStars': 3199,
                    'selected_astrometry_fittedStars': 432,
                    'selected_astrometry_ccdImages': 9,
-                   'astrometry_final_chi2': 567.443,
+                   'astrometry_final_chi2': 567.433,
                    'astrometry_final_ndof': 1286,
                    }
         pa1 = None

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -1,0 +1,145 @@
+# This file is part of jointcal.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import warnings
+
+import numpy as np
+import astropy.units as u
+import astropy.time
+from astropy.coordinates import SkyCoord
+
+import unittest
+import lsst.utils.tests
+
+import lsst.jointcal.star
+
+
+class TestProperMotion(lsst.utils.tests.TestCase):
+    """Tests of applying proper motion correction to stars."""
+    def setUp(self):
+        # These tests use times that are outside what ERFA considers "reasonable";
+        # ignore any warnings it emits about times and distances.
+        warnings.filterwarnings("ignore", module="erfa")
+        self.ra = 300 * u.degree
+        self.dec = 80 * u.degree
+        self.pm_ra = 1000 * u.mas / u.yr  # ra*cos(dec)
+        self.pm_dec = 2000 * u.mas / u.yr
+        flux = 10  # need something for the constructor, but value is irrelevant here
+        # 100 year baseline
+        self.baseline_epoch = astropy.time.Time("2000-01-01 00:00:05", scale="tai")
+        self.observed_epoch = astropy.time.Time("2100-01-01 00:00:05", scale="tai")
+        self.dt = (self.observed_epoch.tai - self.baseline_epoch.tai).to(astropy.units.yr)
+        self.coord = SkyCoord(self.ra, self.dec, frame="icrs",
+                              pm_ra_cosdec=self.pm_ra, pm_dec=self.pm_dec,
+                              obstime=self.observed_epoch)
+        self.star = lsst.jointcal.star.BaseStar(self.ra.value, self.dec.value,
+                                                flux, flux*0.001)
+        self.refStar = lsst.jointcal.star.RefStar(self.ra.value, self.dec.value,
+                                                  flux, flux*0.001)
+        self.star.vx = self.ra.to_value(u.degree) * 0.01
+        self.star.vy = self.dec.to_value(u.degree) * 0.01
+        self.properMotion = lsst.jointcal.star.ProperMotion(self.pm_ra.to_value(u.radian/u.yr),
+                                                            self.pm_dec.to_value(u.radian/u.yr),
+                                                            self.pm_ra.to_value(u.radian/u.yr)*0.01,
+                                                            self.pm_dec.to_value(u.radian/u.yr)*0.01)
+
+        # Test points on the whole sphere, all with the same large proper motion value.
+        np.random.seed(100)
+        n = 100
+        ras = np.random.random(n)*360 * u.degree
+        # uniformly distributed in declination
+        decs = np.arccos(np.random.random(n)*2 - 1) * u.degree
+        pm_ra = np.ones(n) * 300 * u.mas / u.yr
+        pm_dec = np.ones(n) * 400 * u.mas / u.yr
+        self.coords = SkyCoord(ras, decs, frame="icrs", pm_ra_cosdec=pm_ra, pm_dec=pm_dec,
+                               obstime=self.observed_epoch)
+
+    def test_apply_no_proper_motion(self):
+        """If refCat as no ProperMotion set, applyProperMotion() should change
+        nothing.
+        """
+        result = self.refStar.applyProperMotion(self.star, self.dt.value)
+        self.assertEqual(result.x, self.star.x)
+        self.assertEqual(result.y, self.star.y)
+        # TODO? astropy SkyCoord does not include coordinate errors, or error propogation.
+        # How do I test it?
+        # self.assertEqual(result.vx, self.star.vx)
+        # self.assertEqual(result.vy, self.star.vy)
+
+    def test_apply_one(self):
+        """Test apply on a single coordinate (useful for debugging).
+        """
+        expect = self.coord.apply_space_motion(dt=self.dt)
+
+        self.refStar.setProperMotion(self.properMotion)
+        result = self.refStar.applyProperMotion(self.star, self.dt.value)
+        # original star should not be changed:
+        self.assertEqual(self.ra.to_value(u.degree), self.star.x)
+        self.assertEqual(self.dec.to_value(u.degree), self.star.y)
+        self.assertEqual(self.ra.to_value(u.degree)*0.01, self.star.vx)
+        self.assertEqual(self.dec.to_value(u.degree)*0.01, self.star.vy)
+
+        # 1e-9 deg == 3.6 microarcsec; that's pretty good accuracy over a 100 year baseline.
+        self.assertFloatsAlmostEqual(result.x, expect.ra.to_value(u.degree), rtol=1e-9)
+        self.assertFloatsAlmostEqual(result.y, expect.dec.to_value(u.degree), rtol=1e-9)
+        # TODO? astropy SkyCoord does not include coordinate errors, or error propogation.
+        # How do I test it?
+        # self.assertEqual(result.vx, expect.vx)
+        # self.assertEqual(result.vy, expect.vy)
+
+    def test_apply_many(self):
+        """Test apply over a range of points on the sphere.
+        """
+        expect = self.coords.apply_space_motion(dt=self.dt)
+
+        ras = np.zeros(len(expect))
+        decs = np.zeros(len(expect))
+        for i, x in enumerate(self.coords):
+            self.coords
+            star = lsst.jointcal.star.BaseStar(x.ra.value, x.dec.value,
+                                               100, 100*0.001)
+            refStar = lsst.jointcal.star.RefStar(x.ra.value, x.dec.value,
+                                                 100, 100*0.001)
+            star.vx = x.ra.to_value(u.degree) * 0.01
+            star.vy = x.dec.to_value(u.degree) * 0.01
+            properMotion = lsst.jointcal.star.ProperMotion(x.pm_ra_cosdec.to_value(u.radian/u.yr),
+                                                           x.pm_dec.to_value(u.radian/u.yr),
+                                                           x.pm_ra_cosdec.to_value(u.radian/u.yr)*0.01,
+                                                           x.pm_dec.to_value(u.radian/u.yr)*0.01)
+            refStar.setProperMotion(properMotion)
+            result = refStar.applyProperMotion(star, self.dt.value)
+            ras[i] = result.x
+            decs[i] = result.y
+        self.assertFloatsAlmostEqual(ras, expect.ra.to_value(u.degree), rtol=1e-7)
+        self.assertFloatsAlmostEqual(decs, expect.dec.to_value(u.degree), rtol=6e-7)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
As implemented on this ticket, the new PM corrections do not include PM uncertainty which will be done on DM-30383.