### PR TITLE
DM-30534: Turn off config parameter from obs_subaru for tests

### DIFF
--- a/tests/config/hsc-config.py
+++ b/tests/config/hsc-config.py
@@ -1,2 +1,3 @@
 # no colorterms in tests unless specifically requested (this overrides the default HSC config)
 config.applyColorTerms = False
+config.astrometryOutlierRelativeTolerance = 0.0


### PR DESCRIPTION
The default value of the astrometryOutlierRelativeTolerance config
parameter has been changed in obs_subaru, so the expected values of chi2
and ndof change in some tests.