### PR TITLE
DM-30777: removed unused include of lsst/afw/image/Utils.h

### DIFF
--- a/tests/test_wcs.cc
+++ b/tests/test_wcs.cc
@@ -35,7 +35,6 @@
 #include "lsst/geom/Angle.h"
 #include "lsst/geom/Point.h"
 #include "lsst/afw/geom/SkyWcs.h"
-#include "lsst/afw/image/Utils.h"
 #include "lsst/afw/image/Image.h"
 #include "lsst/afw/fits.h"
 #include "lsst/daf/base.h"


### PR DESCRIPTION
Remove include "lsst/afw/image/Utils.h which is not really used in afw and neither in jointcal