### PR TITLE
DM-32487: Adjust flags and tests to support osx-arm64

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -1,7 +1,15 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts, targets, env
+import os
 
-for flag in ("-fexceptions", "-DNSUPERNODAL", "-DNPARTITION"):
+
+flags = ["-fexceptions", "-DNSUPERNODAL", "-DNPARTITION"]
+
+uname = os.uname()
+if uname.sysname == 'Darwin' and uname.machine == 'arm64':
+    flags.append('-faligned-allocation')
+
+for flag in flags:
     env["CFLAGS"].append(flag)
     env["CXXFLAGS"].append(flag)
 

--- a/tests/test_star.py
+++ b/tests/test_star.py
@@ -97,9 +97,12 @@ class TestProperMotion(lsst.utils.tests.TestCase):
         self.assertEqual(self.ra.to_value(u.degree)*0.01, self.star.vx)
         self.assertEqual(self.dec.to_value(u.degree)*0.01, self.star.vy)
 
-        # 1e-9 deg == 3.6 microarcsec; that's pretty good accuracy over a 100 year baseline.
-        self.assertFloatsAlmostEqual(result.x, expect.ra.to_value(u.degree), rtol=1e-9)
-        self.assertFloatsAlmostEqual(result.y, expect.dec.to_value(u.degree), rtol=1e-9)
+        # 5e-8 deg == 180 microarcsec over a 100 year baseline.
+        # The precision here is driven by differences in astropy coord.apply_space_motion()
+        # for different architectures; the computation of refStar.applyProperMotion does
+        # not depend on architecture to full double precision.
+        self.assertFloatsAlmostEqual(result.x, expect.ra.to_value(u.degree), rtol=5e-8)
+        self.assertFloatsAlmostEqual(result.y, expect.dec.to_value(u.degree), rtol=5e-8)
         # TODO? astropy SkyCoord does not include coordinate errors, or error propogation.
         # How do I test it?
         # self.assertEqual(result.vx, expect.vx)


### PR DESCRIPTION
Note that the astropy vs Rubin proper motion comparison test needed to be relaxed because the astropy value (used as a comparison) is varies depending on architecture.