### PR TITLE
DM-32601-docfix: fix pipelines build

### DIFF
--- a/doc/lsst.jointcal/index.rst
+++ b/doc/lsst.jointcal/index.rst
@@ -25,3 +25,5 @@ Python API reference
 
 .. automodapi:: lsst.jointcal
    :no-main-docstr:
+.. automodapi:: lsst.jointcal.cameraGeometry
+   :no-main-docstr:

--- a/doc/lsst.jointcal/index.rst
+++ b/doc/lsst.jointcal/index.rst
@@ -25,7 +25,3 @@ Python API reference
 
 .. automodapi:: lsst.jointcal
    :no-main-docstr:
-.. automodapi:: lsst.jointcal.dataIds
-   :no-main-docstr:
-.. automodapi:: lsst.jointcal.utils
-   :no-main-docstr:

--- a/python/lsst/jointcal/cameraGeometry.py
+++ b/python/lsst/jointcal/cameraGeometry.py
@@ -77,12 +77,11 @@ class CameraModel:
         """Calculate the afw cameraGeom distortion model to be included in an
         on-disk camera model.
 
-
         PLACEHOLDER: This may be as simple as running `computePixelScale` and
         then doing a numpy polynomial fit to it for the cameraGeom input.
         However, we need to check details of how that distortion model is
-        stored in a Camera.
-            e.g.: np.polyfit(self.fieldAngle, self.radialScale, poly_degree))
+        stored in a Camera. e.g.:
+        np.polyfit(self.fieldAngle, self.radialScale, poly_degree)
         """
         raise NotImplementedError("not yet!")
 


### PR DESCRIPTION
DM-32601 broke the pipelines build by not removing jointcal.utils from the automodapi block in index.rst.

This branch also adds an automodapi that was missed when a new module was added.