### PR TITLE
DM-27177: Remove lsst.afw.image.Filter

### DIFF
--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -1024,7 +1024,7 @@ class JointcalTask(pipeBase.PipelineTask, pipeBase.CmdLineTask):
                                  photoCalib=butler.get('calexp_photoCalib', dataId=dataId),
                                  wcs=butler.get('calexp_wcs', dataId=dataId),
                                  bbox=butler.get('calexp_bbox', dataId=dataId),
-                                 filter=butler.get('calexp_filterLabel', dataId=dataId))
+                                 filter=butler.get('calexp_filter', dataId=dataId))
 
     def loadData(self, dataRefs, associations, jointcalControl):
         """Read the data that jointcal needs to run. (Gen2 version)"""

--- a/python/lsst/jointcal/testUtils.py
+++ b/python/lsst/jointcal/testUtils.py
@@ -178,7 +178,7 @@ def createFakeCcdImage(butler, visit, num, fluxFieldName,
     visitInfo = fakeVisitInfo if fakeVisitInfo is not None else butler.get('calexp.visitInfo', dataId=dataId)
     bbox = butler.get('calexp.bbox', dataId=dataId)
     detector = butler.get('calexp.detector', dataId=dataId)
-    filt = butler.get("calexp.filterLabel", dataId=dataId).bandLabel
+    filt = butler.get("calexp.filter", dataId=dataId).bandLabel
     photoCalib = lsst.afw.image.PhotoCalib(photoCalibMean, photoCalibErr)
 
     catalog = createFakeCatalog(num, bbox, fluxFieldName, skyWcs=skyWcs)

--- a/python/lsst/jointcal/testUtils.py
+++ b/python/lsst/jointcal/testUtils.py
@@ -178,7 +178,7 @@ def createFakeCcdImage(butler, visit, num, fluxFieldName,
     visitInfo = fakeVisitInfo if fakeVisitInfo is not None else butler.get('calexp.visitInfo', dataId=dataId)
     bbox = butler.get('calexp.bbox', dataId=dataId)
     detector = butler.get('calexp.detector', dataId=dataId)
-    filt = butler.get("calexp.filter", dataId=dataId).getName()
+    filt = butler.get("calexp.filterLabel", dataId=dataId).bandLabel
     photoCalib = lsst.afw.image.PhotoCalib(photoCalibMean, photoCalibErr)
 
     catalog = createFakeCatalog(num, bbox, fluxFieldName, skyWcs=skyWcs)

--- a/tests/jointcalTestBase.py
+++ b/tests/jointcalTestBase.py
@@ -168,10 +168,6 @@ class JointcalTestBase:
 
         self.outputDataId = outputDataId
 
-        # Ensure that the filter list is reset for each test so that we avoid
-        # confusion or contamination from other instruments.
-        lsst.obs.base.FilterDefinitionCollection.reset()
-
         self.set_output_dir()
 
     def tearDown(self):

--- a/tests/test_astrometryModel.py
+++ b/tests/test_astrometryModel.py
@@ -133,7 +133,7 @@ class AstrometryModelTestBase:
             ccdId = detector.getId()
             wcs = butler.get('calexp.wcs', dataId=dataId)
             bbox = butler.get('calexp.bbox', dataId=dataId)
-            filt = butler.get('calexp.filterLabel', dataId=dataId)
+            filt = butler.get('calexp.filter', dataId=dataId)
             filterName = filt.physicalLabel
             photoCalib = lsst.afw.image.PhotoCalib(100.0, 1.0)
 

--- a/tests/test_astrometryModel.py
+++ b/tests/test_astrometryModel.py
@@ -35,7 +35,6 @@ import lsst.afw.cameraGeom
 import lsst.afw.geom
 import lsst.afw.table
 import lsst.afw.image
-import lsst.afw.image.utils
 import lsst.geom
 import lsst.log
 
@@ -103,10 +102,6 @@ class AstrometryModelTestBase:
         config = lsst.jointcal.JointcalConfig()
         config.load(os.path.join(os.path.dirname(__file__), "config/config.py"))
         sourceSelector = config.sourceSelector.target(config=config.sourceSelector['science'])
-
-        # Ensure that the filter list is reset for each test so that we avoid
-        # confusion or contamination each time we create a cfht camera below.
-        lsst.afw.image.utils.resetFilters()
 
         # jointcal's cfht test data has 6 ccds and 2 visits.
         self.visits = [849375, 850587]

--- a/tests/test_ccdImage.py
+++ b/tests/test_ccdImage.py
@@ -34,9 +34,6 @@ class CcdImageTestCase(lsst.utils.tests.TestCase):
     def setUp(self):
         self.nStars1 = 4
         self.nStars2 = 100
-        # Ensure that the filter list is reset for each test so that we avoid
-        # confusion or contamination each time we create a cfht camera below.
-        lsst.obs.base.FilterDefinitionCollection.reset()
         struct = testUtils.createTwoFakeCcdImages(num1=self.nStars1, num2=self.nStars2)
         self.ccdImage1 = struct.ccdImageList[0]
         self.ccdImage2 = struct.ccdImageList[1]

--- a/tests/test_jointcal.py
+++ b/tests/test_jointcal.py
@@ -133,10 +133,6 @@ class TestJointcalVisitCatalog(lsst.utils.tests.TestCase):
 
 class JointcalTestBase:
     def setUp(self):
-        # Ensure that the filter list is reset for each test so that we avoid
-        # confusion or contamination each time we create a cfht camera below.
-        lsst.obs.base.FilterDefinitionCollection.reset()
-
         struct = lsst.jointcal.testUtils.createTwoFakeCcdImages(100, 100)
         self.ccdImageList = struct.ccdImageList
         # so that countStars() returns nonzero results

--- a/tests/test_photometryModel.py
+++ b/tests/test_photometryModel.py
@@ -47,10 +47,6 @@ class PhotometryModelTestBase:
     unittest to use the test_* methods in this class.
     """
     def setUp(self):
-        # Ensure that the filter list is reset for each test so that we avoid
-        # confusion or contamination each time we create a cfht camera below.
-        lsst.obs.base.FilterDefinitionCollection.reset()
-
         struct = lsst.jointcal.testUtils.createTwoFakeCcdImages(100, 100)
         self.ccdImageList = struct.ccdImageList
         self.camera = struct.camera


### PR DESCRIPTION
This PR removes remaining use of the obsolete `afw.image.Filter`, then replaces the deprecated `filterLabel` component with a new `filter` component backed by `afw.image.FilterLabel`.