### PR TITLE
DM-22823: Remove accidental Doxygen comments for namespaces

### DIFF
--- a/include/lsst/jointcal/SimpleAstrometryMapping.h
+++ b/include/lsst/jointcal/SimpleAstrometryMapping.h
@@ -30,14 +30,15 @@
 #include "lsst/jointcal/AstrometryMapping.h"
 #include "lsst/jointcal/AstrometryTransform.h"
 
-//! Class for a simple mapping implementing a generic AstrometryTransform
-/*! It uses a template rather than a pointer so that the derived
-classes can use the specifics of the transform. The class
-simplePolyMapping overloads a few routines. */
-
 namespace lsst {
 namespace jointcal {
 
+/** Class for a simple mapping implementing a generic AstrometryTransform
+ *
+ * It uses a template rather than a pointer so that the derived
+ * classes can use the specifics of the transform. The class
+ * simplePolyMapping overloads a few routines.
+ */
 class SimpleAstrometryMapping : public AstrometryMapping {
 public:
     SimpleAstrometryMapping(AstrometryTransform const &astrometryTransform, bool toBeFit = true)


### PR DESCRIPTION
This PR removes or rearranges Doxygen comments that were intended to be file-level but instead described namespaces.