### PR TITLE
DM-35697: Use lsst.utils.timer.profile rather than deprecated pipe_base version

### DIFF
--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -778,7 +778,7 @@ class JointcalTask(pipeBase.PipelineTask):
         oldWcsList = []
         filters = []
         load_cat_profile_file = 'jointcal_load_data.prof' if self.config.detailedProfile else ''
-        with pipeBase.cmdLineTask.profile(load_cat_profile_file):
+        with lsst.utils.timer.profile(load_cat_profile_file):
             table = make_schema_table()  # every detector catalog has the same layout
             # No guarantee that the input is in the same order of visits, so we have to map one of them.
             catalogMap = {ref.dataId['visit']: i for i, ref in enumerate(inputSourceTableVisit)}
@@ -1054,7 +1054,7 @@ class JointcalTask(pipeBase.PipelineTask):
 
         fit_profile_file = 'jointcal_fit_%s.prof'%name if self.config.detailedProfile else ''
         dataName = "{}_{}".format(tract, defaultFilter.physicalLabel)
-        with pipeBase.cmdLineTask.profile(fit_profile_file):
+        with lsst.utils.timer.profile(fit_profile_file):
             result = fit_function(associations, dataName)
         # TODO DM-12446: turn this into a "butler save" somehow.
         # Save reference and measurement chi2 contributions for this data


### PR DESCRIPTION
Required lsst/utils#131