### PR TITLE
DM-40322: Implement hook to define spatial bounds for prerequisites.

### DIFF
--- a/python/lsst/jointcal/jointcal.py
+++ b/python/lsst/jointcal/jointcal.py
@@ -274,6 +274,9 @@ class JointcalTaskConnections(pipeBase.PipelineTaskConnections,
                 if "metricvalue_jointcal_photometry" in key:
                     self.outputs.remove(key)
 
+    def getSpatialBoundsConnections(self):
+        return ("inputVisitSummary",)
+
 
 class JointcalConfig(pipeBase.PipelineTaskConfig,
                      pipelineConnections=JointcalTaskConnections):


### PR DESCRIPTION
After this is fully implemented in QG generation (DM-38498) this will allow us to remove the lookupFunction for reference catalog inputs.